### PR TITLE
Use shared database package from git-pkgs

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -1,10 +1,11 @@
 module github.com/git-pkgs/proxy
 
-go 1.25.6
+go 1.25.7
 
 require (
 	github.com/git-pkgs/archives v0.2.0
 	github.com/git-pkgs/enrichment v0.1.5
+	github.com/git-pkgs/git-pkgs v0.15.1-0.20260304191500-e296d0146017
 	github.com/git-pkgs/purl v0.1.9
 	github.com/git-pkgs/registries v0.3.0
 	github.com/git-pkgs/spdx v0.1.1

--- a/go.sum
+++ b/go.sum
@@ -218,6 +218,8 @@ github.com/git-pkgs/archives v0.2.0 h1:8OuuGwAB+Eww8/1ayyYpZzP0wVEH0/VWBG3mQrfi9
 github.com/git-pkgs/archives v0.2.0/go.mod h1:LTJ1iQVFA7otizWMOyiI82NYVmyBWAPRzwu/e30rcXU=
 github.com/git-pkgs/enrichment v0.1.5 h1:xhZkQMciofrPPrDtVRQqz+suRmKTtk53ibSUYCYviCI=
 github.com/git-pkgs/enrichment v0.1.5/go.mod h1:5LB52Ei3cUI4LqLkshpMfxcSguwWT5L3exv+erfIcNI=
+github.com/git-pkgs/git-pkgs v0.15.1-0.20260304191500-e296d0146017 h1:jZ/2h7dmOIFX7KC7nF7FF/ZGjWdqanzE7LUMwJ7OePE=
+github.com/git-pkgs/git-pkgs v0.15.1-0.20260304191500-e296d0146017/go.mod h1:YP6B+ij6pmaLMYWcoKyvCtCJvPeVPJbYcDmQEBTuZZc=
 github.com/git-pkgs/packageurl-go v0.3.1 h1:WM3RBABQZLaRBxgKyYughc3cVBE8KyQxbSC6Jt5ak7M=
 github.com/git-pkgs/packageurl-go v0.3.1/go.mod h1:rcIxiG37BlQLB6FZfgdj9Fm7yjhRQd3l+5o7J0QPAk4=
 github.com/git-pkgs/purl v0.1.9 h1:zSHKBVwRTJiMGwiYIiHgoIUfJTdtC7kVQ0+0RHckwxc=
@@ -522,8 +524,8 @@ github.com/sashamelentyev/usestdlibvars v1.29.0 h1:8J0MoRrw4/NAXtjQqTHrbW9NN+3iM
 github.com/sashamelentyev/usestdlibvars v1.29.0/go.mod h1:8PpnjHMk5VdeWlVb4wCdrB8PNbLqZ3wBZTZWkrpZZL8=
 github.com/securego/gosec/v2 v2.23.0 h1:h4TtF64qFzvnkqvsHC/knT7YC5fqyOCItlVR8+ptEBo=
 github.com/securego/gosec/v2 v2.23.0/go.mod h1:qRHEgXLFuYUDkI2T7W7NJAmOkxVhkR0x9xyHOIcMNZ0=
-github.com/sergi/go-diff v1.2.0 h1:XU+rvMAioB0UC3q1MFrIQy4Vo5/4VsRDQQXHsEya6xQ=
-github.com/sergi/go-diff v1.2.0/go.mod h1:STckp+ISIX8hZLjrqAeVduY0gWCT9IjLuqbuNXdaHfM=
+github.com/sergi/go-diff v1.4.0 h1:n/SP9D5ad1fORl+llWyN+D6qoUETXNZARKjyY2/KVCw=
+github.com/sergi/go-diff v1.4.0/go.mod h1:A0bzQcvG0E7Rwjx0REVgAGH58e96+X0MeOfepqsbeW4=
 github.com/shurcooL/go v0.0.0-20180423040247-9e1955d9fb6e/go.mod h1:TDJrrUr11Vxrven61rcy3hJMUqaf/CLWYhHNPmT14Lk=
 github.com/shurcooL/go-goon v0.0.0-20170922171312-37c2f522c041/go.mod h1:N5mDOmsrJOB+vfqUK+7DmDyjhSLIIBnXo9lvZJj3MWQ=
 github.com/sirupsen/logrus v1.9.4 h1:TsZE7l11zFCLZnZ+teH4Umoq5BhEIfIzfRDZ1Uzql2w=

--- a/internal/database/database.go
+++ b/internal/database/database.go
@@ -5,6 +5,7 @@ import (
 	"os"
 	"path/filepath"
 
+	gitpkgsdb "github.com/git-pkgs/git-pkgs/database"
 	"github.com/jmoiron/sqlx"
 	_ "github.com/lib/pq"
 	_ "modernc.org/sqlite"
@@ -29,10 +30,8 @@ func (db *DB) Dialect() Dialect {
 	return db.dialect
 }
 
-func Exists(path string) bool {
-	_, err := os.Stat(path)
-	return err == nil
-}
+// Exists checks if a database file exists at the given path.
+var Exists = gitpkgsdb.Exists
 
 func Create(path string) (*DB, error) {
 	if Exists(path) {
@@ -54,6 +53,8 @@ func Create(path string) (*DB, error) {
 	return db, nil
 }
 
+// Open opens a SQLite database using the shared git-pkgs connection
+// settings (WAL mode, busy timeout, single connection).
 func Open(path string) (*DB, error) {
 	if dir := filepath.Dir(path); dir != "." && dir != "/" {
 		if err := os.MkdirAll(dir, 0755); err != nil {
@@ -61,22 +62,12 @@ func Open(path string) (*DB, error) {
 		}
 	}
 
-	// Add busy_timeout to handle concurrent writes
-	sqlDB, err := sqlx.Open("sqlite", path+"?_busy_timeout=5000")
+	sharedDB, err := gitpkgsdb.Open(path)
 	if err != nil {
-		return nil, fmt.Errorf("opening database: %w", err)
+		return nil, err
 	}
 
-	// Limit connections to 1 for SQLite to serialize writes
-	sqlDB.SetMaxOpenConns(1)
-
-	db := &DB{DB: sqlDB, dialect: DialectSQLite, path: path}
-	if err := db.OptimizeForReads(); err != nil {
-		_ = sqlDB.Close()
-		return nil, fmt.Errorf("optimizing database: %w", err)
-	}
-
-	return db, nil
+	return &DB{DB: sharedDB.SQLX(), dialect: DialectSQLite, path: path}, nil
 }
 
 func OpenOrCreate(path string) (*DB, error) {

--- a/internal/database/database_test.go
+++ b/internal/database/database_test.go
@@ -147,8 +147,8 @@ func TestVersionCRUD(t *testing.T) {
 		if got == nil {
 			t.Fatal("expected version, got nil")
 		}
-		if got.Version() != "4.17.21" {
-			t.Errorf("expected version 4.17.21, got %s", got.Version())
+		if got.VersionString() != "4.17.21" {
+			t.Errorf("expected version 4.17.21, got %s", got.VersionString())
 		}
 
 		versions, err := db.GetVersionsByPackagePURL("pkg:npm/lodash")

--- a/internal/database/types.go
+++ b/internal/database/types.go
@@ -2,56 +2,16 @@ package database
 
 import (
 	"database/sql"
-	"strings"
 	"time"
+
+	gitpkgsdb "github.com/git-pkgs/git-pkgs/database"
 )
 
-// Package represents a package in the database.
-// Schema is compatible with git-pkgs.
-type Package struct {
-	ID            int64          `db:"id" json:"id"`
-	PURL          string         `db:"purl" json:"purl"`
-	Ecosystem     string         `db:"ecosystem" json:"ecosystem"`
-	Name          string         `db:"name" json:"name"`
-	LatestVersion sql.NullString `db:"latest_version" json:"latest_version,omitempty"`
-	License       sql.NullString `db:"license" json:"license,omitempty"`
-	Description   sql.NullString `db:"description" json:"description,omitempty"`
-	Homepage      sql.NullString `db:"homepage" json:"homepage,omitempty"`
-	RepositoryURL sql.NullString `db:"repository_url" json:"repository_url,omitempty"`
-	RegistryURL   sql.NullString `db:"registry_url" json:"registry_url,omitempty"`
-	SupplierName  sql.NullString `db:"supplier_name" json:"supplier_name,omitempty"`
-	SupplierType  sql.NullString `db:"supplier_type" json:"supplier_type,omitempty"`
-	Source        sql.NullString `db:"source" json:"source,omitempty"`
-	EnrichedAt    sql.NullTime   `db:"enriched_at" json:"enriched_at,omitempty"`
-	VulnsSyncedAt sql.NullTime   `db:"vulns_synced_at" json:"vulns_synced_at,omitempty"`
-	CreatedAt     time.Time      `db:"created_at" json:"created_at"`
-	UpdatedAt     time.Time      `db:"updated_at" json:"updated_at"`
-}
-
-// Version represents a package version in the database.
-// Schema is compatible with git-pkgs.
-type Version struct {
-	ID          int64          `db:"id" json:"id"`
-	PURL        string         `db:"purl" json:"purl"`
-	PackagePURL string         `db:"package_purl" json:"package_purl"`
-	License     sql.NullString `db:"license" json:"license,omitempty"`
-	PublishedAt sql.NullTime   `db:"published_at" json:"published_at,omitempty"`
-	Integrity   sql.NullString `db:"integrity" json:"integrity,omitempty"`
-	Yanked      bool           `db:"yanked" json:"yanked"`
-	Source      sql.NullString `db:"source" json:"source,omitempty"`
-	EnrichedAt  sql.NullTime   `db:"enriched_at" json:"enriched_at,omitempty"`
-	CreatedAt   time.Time      `db:"created_at" json:"created_at"`
-	UpdatedAt   time.Time      `db:"updated_at" json:"updated_at"`
-}
-
-// Version extracts the version string from the PURL.
-// e.g., "pkg:npm/lodash@4.17.21" -> "4.17.21"
-func (v *Version) Version() string {
-	if idx := strings.LastIndex(v.PURL, "@"); idx >= 0 {
-		return v.PURL[idx+1:]
-	}
-	return ""
-}
+// Package and Version are shared with git-pkgs. The types and schema
+// are defined in the git-pkgs database package, keeping both projects
+// in sync automatically.
+type Package = gitpkgsdb.Package
+type Version = gitpkgsdb.Version
 
 // Artifact represents a cached artifact in the database.
 // This table is proxy-specific and not part of git-pkgs.


### PR DESCRIPTION
Imports Package and Version types from `github.com/git-pkgs/git-pkgs/database` instead of defining them locally, and delegates SQLite connection setup to the shared `Open` function.

This replaces ~70 lines of duplicated type definitions and connection boilerplate with imports from the shared package introduced in git-pkgs/git-pkgs#157.

The proxy's queries, PostgreSQL support, and proxy-specific types (Artifact, Vulnerability) are unchanged.

Depends on git-pkgs/git-pkgs#157.

Closes #16.