### PR TITLE
Correct ecosystem name in UI for Go (golang).

### DIFF
--- a/internal/server/dashboard.go
+++ b/internal/server/dashboard.go
@@ -118,7 +118,7 @@ func supportedEcosystems() []string {
 		"npm",
 		"cargo",
 		"gem",
-		"go",
+		"golang",
 		"hex",
 		"pub",
 		"pypi",


### PR DESCRIPTION
With this change, viewing package lists in the UI will actually display Golang packages :-)