### PR TITLE
Fix cross-device link error when running in Docker with volumes

### DIFF
--- a/internal/server/server_test.go
+++ b/internal/server/server_test.go
@@ -894,10 +894,10 @@ func TestNewServer_StorageConnectivityCheck(t *testing.T) {
 	// On Windows, OpenBucket normalises to file:///C:/path; on Unix the
 	// absolute path already starts with /, so file:// + /path == file:///path.
 	wantPrefix := "file://"
-	wantSuffix := filepath.ToSlash(storagePath)
+	wantPath := filepath.ToSlash(storagePath)
 	got := srv.storage.URL()
-	if !strings.HasPrefix(got, wantPrefix) || !strings.HasSuffix(got, wantSuffix) {
-		t.Errorf("expected storage URL ending with %s, got %s", wantSuffix, got)
+	if !strings.HasPrefix(got, wantPrefix) || !strings.Contains(got, wantPath) {
+		t.Errorf("expected storage URL containing %s, got %s", wantPath, got)
 	}
 
 	_ = srv.db.Close()

--- a/internal/storage/blob.go
+++ b/internal/storage/blob.go
@@ -70,6 +70,12 @@ func OpenBucket(ctx context.Context, urlStr string) (*Blob, error) {
 		} else {
 			urlStr = "file://" + urlPath
 		}
+
+		// Create temp files next to the final path instead of in os.TempDir.
+		// This avoids "invalid cross-device link" errors from os.Rename when
+		// the bucket directory and os.TempDir are on different filesystems
+		// (e.g. Docker volume mounts).
+		urlStr += "?no_tmp_dir=true"
 	}
 
 	bucket, err := blob.OpenBucket(ctx, urlStr)

--- a/internal/storage/blob_test.go
+++ b/internal/storage/blob_test.go
@@ -217,6 +217,44 @@ func TestBlobOverwrite(t *testing.T) {
 	}
 }
 
+func TestOpenBucketSetsNoTmpDir(t *testing.T) {
+	dir := t.TempDir()
+	ctx := context.Background()
+
+	b, err := OpenBucket(ctx, fileURLFromPath(dir))
+	if err != nil {
+		t.Fatalf("OpenBucket failed: %v", err)
+	}
+	defer func() { _ = b.Close() }()
+
+	// fileblob uses os.TempDir() by default for temp files, then os.Rename to
+	// the final path. This fails with "invalid cross-device link" when the bucket
+	// dir and os.TempDir() are on different filesystems (e.g. Docker volumes).
+	// OpenBucket must set no_tmp_dir=true so temp files are created next to the
+	// final path instead.
+	if !strings.Contains(b.URL(), "no_tmp_dir=true") {
+		t.Errorf("URL should contain no_tmp_dir=true to avoid cross-device rename errors, got %q", b.URL())
+	}
+
+	// Verify Store still works with the parameter set
+	content := "cross-device test"
+	_, _, err = b.Store(ctx, "test/cross-device.txt", strings.NewReader(content))
+	if err != nil {
+		t.Fatalf("Store failed with no_tmp_dir=true: %v", err)
+	}
+
+	r, err := b.Open(ctx, "test/cross-device.txt")
+	if err != nil {
+		t.Fatalf("Open failed: %v", err)
+	}
+	defer func() { _ = r.Close() }()
+
+	data, _ := io.ReadAll(r)
+	if string(data) != content {
+		t.Errorf("content = %q, want %q", string(data), content)
+	}
+}
+
 func createTestBlob(t *testing.T) *Blob {
 	t.Helper()
 	dir := t.TempDir()


### PR DESCRIPTION
`fileblob` creates temp files in `os.TempDir()` (`/tmp`) by default, then uses `os.Rename` to move them to the final path. When the storage directory is on a different filesystem (e.g. a Docker volume mount at `/data`), the rename fails with "invalid cross-device link".

Sets `no_tmp_dir=true` on `file://` bucket URLs so fileblob creates temp files next to the final destination instead. This is the [documented solution](https://pkg.go.dev/gocloud.dev/blob/fileblob#hdr-URLs) from fileblob.

Verified end-to-end with `docker compose up` — the exact request from #65 (`/composer/files/friendsofphp/php-cs-fixer/v3.94.2/...`) now returns 200 with a volume mount.

Fixes #65