### PR TITLE
Add cooldown support for NuGet

### DIFF
--- a/README.md
+++ b/README.md
@@ -34,7 +34,7 @@ Currently works with npm, PyPI, pub.dev, Composer, and Cargo, which all include 
 | pub.dev | Dart | Yes | ✓ |
 | PyPI | Python | Yes | ✓ |
 | Maven | Java | | ✓ |
-| NuGet | .NET | | ✓ |
+| NuGet | .NET | Yes | ✓ |
 | Composer | PHP | Yes | ✓ |
 | Conan | C/C++ | | ✓ |
 | Conda | Python/R | | ✓ |

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -209,7 +209,7 @@ Durations support days (`7d`), hours (`48h`), and minutes (`30m`). Set to `0` to
 
 Resolution order: package override, then ecosystem override, then global default. This lets you set a conservative default while exempting trusted packages.
 
-Currently supported for npm, PyPI, pub.dev, and Composer. These ecosystems include publish timestamps in their metadata. Other ecosystems (Go, Cargo, RubyGems) would require extra API calls and are not yet supported.
+Currently supported for npm, PyPI, pub.dev, Composer, Cargo, and NuGet. These ecosystems include publish timestamps in their metadata.
 
 ## Docker
 

--- a/internal/handler/nuget.go
+++ b/internal/handler/nuget.go
@@ -6,6 +6,9 @@ import (
 	"io"
 	"net/http"
 	"strings"
+	"time"
+
+	"github.com/git-pkgs/purl"
 )
 
 const (
@@ -40,7 +43,7 @@ func (h *NuGetHandler) Routes() http.Handler {
 	mux.HandleFunc("GET /v3-flatcontainer/{id}/index.json", h.proxyUpstream)
 
 	// Registration (package metadata) - use prefix matching since {version}.json isn't allowed
-	mux.HandleFunc("GET /v3/registration5-gz-semver2/", h.proxyUpstream)
+	mux.HandleFunc("GET /v3/registration5-gz-semver2/", h.handleRegistration)
 
 	// Search
 	mux.HandleFunc("GET /query", h.proxyUpstream)
@@ -165,6 +168,140 @@ func (h *NuGetHandler) rewriteNuGetURL(origURL string) string {
 	}
 
 	return origURL
+}
+
+// handleRegistration proxies NuGet registration pages, applying cooldown filtering.
+func (h *NuGetHandler) handleRegistration(w http.ResponseWriter, r *http.Request) {
+	if h.proxy.Cooldown == nil || !h.proxy.Cooldown.Enabled() {
+		h.proxyUpstream(w, r)
+		return
+	}
+
+	upstreamURL := h.buildUpstreamURL(r)
+
+	h.proxy.Logger.Debug("fetching registration for cooldown filtering", "url", upstreamURL)
+
+	req, err := http.NewRequestWithContext(r.Context(), http.MethodGet, upstreamURL, nil)
+	if err != nil {
+		http.Error(w, "failed to create request", http.StatusInternalServerError)
+		return
+	}
+	req.Header.Set("Accept-Encoding", "gzip")
+
+	resp, err := h.proxy.HTTPClient.Do(req)
+	if err != nil {
+		h.proxy.Logger.Error("upstream request failed", "error", err)
+		http.Error(w, "upstream request failed", http.StatusBadGateway)
+		return
+	}
+	defer func() { _ = resp.Body.Close() }()
+
+	if resp.StatusCode != http.StatusOK {
+		for k, vv := range resp.Header {
+			for _, v := range vv {
+				w.Header().Add(k, v)
+			}
+		}
+		w.WriteHeader(resp.StatusCode)
+		_, _ = io.Copy(w, resp.Body)
+		return
+	}
+
+	body, err := ReadMetadata(resp.Body)
+	if err != nil {
+		http.Error(w, "failed to read response", http.StatusInternalServerError)
+		return
+	}
+
+	filtered, err := h.applyCooldownFiltering(body)
+	if err != nil {
+		h.proxy.Logger.Warn("failed to filter registration, proxying original", "error", err)
+		w.Header().Set("Content-Type", "application/json")
+		_, _ = w.Write(body)
+		return
+	}
+
+	w.Header().Set("Content-Type", "application/json")
+	_, _ = w.Write(filtered)
+}
+
+// applyCooldownFiltering filters versions from NuGet registration pages
+// that are too recently published.
+func (h *NuGetHandler) applyCooldownFiltering(body []byte) ([]byte, error) {
+	if h.proxy.Cooldown == nil || !h.proxy.Cooldown.Enabled() {
+		return body, nil
+	}
+
+	var registration map[string]any
+	if err := json.Unmarshal(body, &registration); err != nil {
+		return nil, err
+	}
+
+	pages, ok := registration["items"].([]any)
+	if !ok {
+		return body, nil
+	}
+
+	for _, page := range pages {
+		pageMap, ok := page.(map[string]any)
+		if !ok {
+			continue
+		}
+
+		items, ok := pageMap["items"].([]any)
+		if !ok {
+			continue
+		}
+
+		filtered := items[:0]
+		for _, item := range items {
+			itemMap, ok := item.(map[string]any)
+			if !ok {
+				continue
+			}
+
+			catalogEntry, ok := itemMap["catalogEntry"].(map[string]any)
+			if !ok {
+				filtered = append(filtered, item)
+				continue
+			}
+
+			version, _ := catalogEntry["version"].(string)
+			id, _ := catalogEntry["id"].(string)
+			publishedStr, _ := catalogEntry["published"].(string)
+
+			if publishedStr == "" {
+				filtered = append(filtered, item)
+				continue
+			}
+
+			publishedAt, err := time.Parse(time.RFC3339, publishedStr)
+			if err != nil {
+				// NuGet uses a slightly non-standard format, try parsing with fractional seconds
+				publishedAt, err = time.Parse("2006-01-02T15:04:05.999-07:00", publishedStr)
+				if err != nil {
+					filtered = append(filtered, item)
+					continue
+				}
+			}
+
+			packagePURL := purl.MakePURLString("nuget", strings.ToLower(id), "")
+
+			if !h.proxy.Cooldown.IsAllowed("nuget", packagePURL, publishedAt) {
+				h.proxy.Logger.Info("cooldown: filtering nuget version",
+					"package", id, "version", version,
+					"published", publishedStr)
+				continue
+			}
+
+			filtered = append(filtered, item)
+		}
+
+		pageMap["items"] = filtered
+		pageMap["count"] = len(filtered)
+	}
+
+	return json.Marshal(registration)
 }
 
 // handleDownload serves a package file, fetching and caching from upstream if needed.

--- a/internal/handler/nuget_test.go
+++ b/internal/handler/nuget_test.go
@@ -8,6 +8,9 @@ import (
 	"net/http/httptest"
 	"strings"
 	"testing"
+	"time"
+
+	"github.com/git-pkgs/proxy/internal/cooldown"
 )
 
 func nugetTestProxy() *Proxy {
@@ -766,5 +769,335 @@ func TestNuGetBuildUpstreamURLRegularPath(t *testing.T) {
 	want := "https://api.nuget.org/v3/registration5-gz-semver2/newtonsoft.json/index.json"
 	if got != want {
 		t.Errorf("buildUpstreamURL for registration = %q, want %q", got, want)
+	}
+}
+
+func TestNuGetCooldownFiltering(t *testing.T) {
+	now := time.Now()
+	oldTime := now.Add(-7 * 24 * time.Hour).Format(time.RFC3339)
+	recentTime := now.Add(-1 * time.Hour).Format(time.RFC3339)
+
+	registration := map[string]any{
+		"items": []any{
+			map[string]any{
+				"count": 2,
+				"items": []any{
+					map[string]any{
+						"catalogEntry": map[string]any{
+							"id":        "TestPackage",
+							"version":   "1.0.0",
+							"published": oldTime,
+						},
+					},
+					map[string]any{
+						"catalogEntry": map[string]any{
+							"id":        "TestPackage",
+							"version":   "2.0.0",
+							"published": recentTime,
+						},
+					},
+				},
+			},
+		},
+	}
+
+	body, err := json.Marshal(registration)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	proxy := testProxy()
+	proxy.Cooldown = &cooldown.Config{
+		Default: "3d",
+	}
+
+	h := &NuGetHandler{
+		proxy:    proxy,
+		proxyURL: "http://localhost:8080",
+	}
+
+	filtered, err := h.applyCooldownFiltering(body)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	var result map[string]any
+	if err := json.Unmarshal(filtered, &result); err != nil {
+		t.Fatal(err)
+	}
+
+	pages := result["items"].([]any)
+	page := pages[0].(map[string]any)
+	items := page["items"].([]any)
+
+	if len(items) != 1 {
+		t.Fatalf("expected 1 item after filtering, got %d", len(items))
+	}
+
+	entry := items[0].(map[string]any)["catalogEntry"].(map[string]any)
+	if entry["version"] != testVersion100 {
+		t.Errorf("expected version 1.0.0 to survive, got %s", entry["version"])
+	}
+
+	count := page["count"]
+	if count != float64(1) {
+		t.Errorf("expected page count to be 1, got %v", count)
+	}
+}
+
+func TestNuGetCooldownFilteringWithPackageOverride(t *testing.T) {
+	now := time.Now()
+	recentTime := now.Add(-2 * time.Hour).Format(time.RFC3339)
+
+	registration := map[string]any{
+		"items": []any{
+			map[string]any{
+				"count": 1,
+				"items": []any{
+					map[string]any{
+						"catalogEntry": map[string]any{
+							"id":        "SpecialPackage",
+							"version":   "1.0.0",
+							"published": recentTime,
+						},
+					},
+				},
+			},
+		},
+	}
+
+	body, err := json.Marshal(registration)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	proxy := testProxy()
+	proxy.Cooldown = &cooldown.Config{
+		Default:  "3d",
+		Packages: map[string]string{"pkg:nuget/specialpackage": "1h"},
+	}
+
+	h := &NuGetHandler{
+		proxy:    proxy,
+		proxyURL: "http://localhost:8080",
+	}
+
+	filtered, err := h.applyCooldownFiltering(body)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	var result map[string]any
+	if err := json.Unmarshal(filtered, &result); err != nil {
+		t.Fatal(err)
+	}
+
+	pages := result["items"].([]any)
+	page := pages[0].(map[string]any)
+	items := page["items"].([]any)
+
+	if len(items) != 1 {
+		t.Fatalf("expected 1 item (package override allows it), got %d", len(items))
+	}
+}
+
+func TestNuGetCooldownNoCooldownConfig(t *testing.T) {
+	registration := map[string]any{
+		"items": []any{
+			map[string]any{
+				"count": 1,
+				"items": []any{
+					map[string]any{
+						"catalogEntry": map[string]any{
+							"id":        "Test",
+							"version":   "1.0.0",
+							"published": time.Now().Format(time.RFC3339),
+						},
+					},
+				},
+			},
+		},
+	}
+
+	body, err := json.Marshal(registration)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	// No cooldown - applyCooldownFiltering still works, just doesn't filter
+	h := &NuGetHandler{
+		proxy:    testProxy(),
+		proxyURL: "http://localhost:8080",
+	}
+
+	filtered, err := h.applyCooldownFiltering(body)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	var result map[string]any
+	if err := json.Unmarshal(filtered, &result); err != nil {
+		t.Fatal(err)
+	}
+
+	pages := result["items"].([]any)
+	page := pages[0].(map[string]any)
+	items := page["items"].([]any)
+
+	// Without cooldown config on the handler, applyCooldownFiltering
+	// is called but proxy.Cooldown is nil, so IsAllowed is never called
+	// Actually, applyCooldownFiltering always runs the filter logic -
+	// but the caller (handleRegistration) short-circuits when cooldown is disabled.
+	// The function itself should still work fine with a nil Cooldown.
+	if len(items) != 1 {
+		t.Fatalf("expected 1 item, got %d", len(items))
+	}
+}
+
+func TestNuGetCooldownFilteringNuGetTimestamp(t *testing.T) {
+	// NuGet uses timestamps like "2024-09-07T01:37:52.233+00:00" which
+	// have fractional seconds - verify these parse correctly
+	now := time.Now()
+	oldTime := now.Add(-7 * 24 * time.Hour).Format("2006-01-02T15:04:05.000-07:00")
+
+	registration := map[string]any{
+		"items": []any{
+			map[string]any{
+				"count": 1,
+				"items": []any{
+					map[string]any{
+						"catalogEntry": map[string]any{
+							"id":        "Test",
+							"version":   "1.0.0",
+							"published": oldTime,
+						},
+					},
+				},
+			},
+		},
+	}
+
+	body, err := json.Marshal(registration)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	proxy := testProxy()
+	proxy.Cooldown = &cooldown.Config{
+		Default: "3d",
+	}
+
+	h := &NuGetHandler{
+		proxy:    proxy,
+		proxyURL: "http://localhost:8080",
+	}
+
+	filtered, err := h.applyCooldownFiltering(body)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	var result map[string]any
+	if err := json.Unmarshal(filtered, &result); err != nil {
+		t.Fatal(err)
+	}
+
+	pages := result["items"].([]any)
+	page := pages[0].(map[string]any)
+	items := page["items"].([]any)
+
+	if len(items) != 1 {
+		t.Fatalf("expected 1 item (old enough to pass cooldown), got %d", len(items))
+	}
+}
+
+func TestNuGetHandleRegistrationWithCooldown(t *testing.T) {
+	now := time.Now()
+	oldTime := now.Add(-7 * 24 * time.Hour).Format(time.RFC3339)
+	recentTime := now.Add(-1 * time.Hour).Format(time.RFC3339)
+
+	registrationJSON, _ := json.Marshal(map[string]any{
+		"items": []any{
+			map[string]any{
+				"count": 2,
+				"items": []any{
+					map[string]any{
+						"catalogEntry": map[string]any{
+							"id":        "TestPkg",
+							"version":   "1.0.0",
+							"published": oldTime,
+						},
+					},
+					map[string]any{
+						"catalogEntry": map[string]any{
+							"id":        "TestPkg",
+							"version":   "2.0.0",
+							"published": recentTime,
+						},
+					},
+				},
+			},
+		},
+	})
+
+	upstream := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		_, _ = w.Write(registrationJSON)
+	}))
+	defer upstream.Close()
+
+	proxy := testProxy()
+	proxy.Cooldown = &cooldown.Config{
+		Default: "3d",
+	}
+
+	h := &NuGetHandler{
+		proxy:       proxy,
+		upstreamURL: upstream.URL,
+		proxyURL:    "http://proxy.local",
+	}
+
+	req := httptest.NewRequest(http.MethodGet, "/v3/registration5-gz-semver2/testpkg/index.json", nil)
+	w := httptest.NewRecorder()
+	h.handleRegistration(w, req)
+
+	if w.Code != http.StatusOK {
+		t.Fatalf("status = %d, want %d", w.Code, http.StatusOK)
+	}
+
+	var result map[string]any
+	if err := json.Unmarshal(w.Body.Bytes(), &result); err != nil {
+		t.Fatal(err)
+	}
+
+	pages := result["items"].([]any)
+	page := pages[0].(map[string]any)
+	items := page["items"].([]any)
+
+	if len(items) != 1 {
+		t.Fatalf("expected 1 item after cooldown filtering, got %d", len(items))
+	}
+}
+
+func TestNuGetHandleRegistrationWithoutCooldown(t *testing.T) {
+	upstream := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		_, _ = w.Write([]byte(`{"items":[]}`))
+	}))
+	defer upstream.Close()
+
+	h := &NuGetHandler{
+		proxy:       nugetTestProxy(), // no cooldown configured
+		upstreamURL: upstream.URL,
+		proxyURL:    "http://proxy.local",
+	}
+
+	req := httptest.NewRequest(http.MethodGet, "/v3/registration5-gz-semver2/testpkg/index.json", nil)
+	w := httptest.NewRecorder()
+	h.handleRegistration(w, req)
+
+	// Without cooldown, should proxy directly
+	if w.Code != http.StatusOK {
+		t.Fatalf("status = %d, want %d", w.Code, http.StatusOK)
 	}
 }


### PR DESCRIPTION
Filter versions from NuGet registration pages (`/v3/registration5-gz-semver2/`) based on the `catalogEntry.published` timestamp. When cooldown is disabled, registration requests are proxied directly without parsing.

Handles both RFC3339 and NuGet's fractional-second timestamp format (e.g. `2024-09-07T01:37:52.233+00:00`).

Package-level overrides use lowercase NuGet PURLs (e.g. `pkg:nuget/newtonsoft.json`).