### PR TITLE
Sort the ecosystems list for presentation in the UI

### DIFF
--- a/internal/server/dashboard.go
+++ b/internal/server/dashboard.go
@@ -114,22 +114,25 @@ type PackagesListPageData struct {
 }
 
 func supportedEcosystems() []string {
+	// this list should be kept sorted in lexicographic order so
+	// that the 'select' list in the UI will be in the expected
+	// order
 	return []string{
-		"npm",
 		"cargo",
-		"gem",
-		"golang",
-		"hex",
-		"pub",
-		"pypi",
-		"maven",
-		"nuget",
 		"composer",
 		"conan",
 		"conda",
 		"cran",
-		"oci",
 		"deb",
+		"gem",
+		"golang",
+		"hex",
+		"maven",
+		"npm",
+		"nuget",
+		"oci",
+		"pub",
+		"pypi",
 		"rpm",
 	}
 }


### PR DESCRIPTION
In the page footer and the 'select' list on the packages page, the list of ecosystems should be sorted in a predictable order.