### PR TITLE
Sign release checksums with cosign keyless

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -7,6 +7,7 @@ on:
 
 permissions:
   contents: write
+  id-token: write
 
 jobs:
   release:
@@ -17,6 +18,8 @@ jobs:
         with:
           fetch-depth: 0
           persist-credentials: false
+
+      - uses: sigstore/cosign-installer@cad07c2e89fa2edd6e2d7bab4c1aa38e53f76003 # v4.1.1
 
       - name: Set up Go
         uses: actions/setup-go@4a3601121dd01d1626a1e23e37211e3254c1c06c # v6.4.0

--- a/.goreleaser.yaml
+++ b/.goreleaser.yaml
@@ -34,6 +34,18 @@ archives:
 checksum:
   name_template: "checksums.txt"
 
+signs:
+  - cmd: cosign
+    certificate: "${artifact}.pem"
+    args:
+      - sign-blob
+      - "--output-certificate=${certificate}"
+      - "--output-signature=${signature}"
+      - "${artifact}"
+      - "--yes"
+    artifacts: checksum
+    output: true
+
 snapshot:
   version_template: "{{ incpatch .Version }}-next"
 


### PR DESCRIPTION
Adds sigstore keyless signing to the release pipeline, matching git-pkgs/git-pkgs@0a82984.

The workflow gets `id-token: write` permission so cosign can exchange the GitHub OIDC token with Fulcio for a short-lived signing cert. No keys to manage. Releases will publish `checksums.txt.sig` and `checksums.txt.pem` alongside the binaries.

Bumped cosign-installer to v4.1.1 (the git-pkgs commit used v3.10.0).

Verify with:
```
cosign verify-blob \
  --certificate checksums.txt.pem \
  --signature checksums.txt.sig \
  --certificate-identity-regexp 'https://github.com/git-pkgs/proxy/.github/workflows/release.yml@refs/tags/v.*' \
  --certificate-oidc-issuer https://token.actions.githubusercontent.com \
  checksums.txt
```