### PR TITLE
Use cosign v4 bundle format for release signing

### DIFF
--- a/.goreleaser.yaml
+++ b/.goreleaser.yaml
@@ -36,11 +36,10 @@ checksum:
 
 signs:
   - cmd: cosign
-    certificate: "${artifact}.pem"
+    signature: "${artifact}.cosign.bundle"
     args:
       - sign-blob
-      - "--output-certificate=${certificate}"
-      - "--output-signature=${signature}"
+      - "--bundle=${signature}"
       - "${artifact}"
       - "--yes"
     artifacts: checksum


### PR DESCRIPTION
cosign v4 defaults to the new sigstore bundle format and ignores `--output-signature` / `--output-certificate`, which makes `sign-blob` fail with `create bundle file: open : no such file or directory` because no `--bundle` path is given. This switches to `--bundle=${signature}` and emits a single `checksums.txt.cosign.bundle` instead of separate `.sig` and `.pem` files. Same fix already verified on `git-pkgs/pom` v0.1.2.