### PR TITLE
Limit io.ReadAll in openArchive to 512 MB

### DIFF
--- a/internal/server/browse.go
+++ b/internal/server/browse.go
@@ -18,6 +18,11 @@ import (
 
 const contentTypePlainText = "text/plain; charset=utf-8"
 
+// maxBrowseArchiveSize caps how much data openArchive will buffer for
+// prefix detection. Artifacts larger than this are rejected to prevent
+// memory exhaustion from a single request.
+const maxBrowseArchiveSize = 512 << 20 // 512 MB
+
 // archiveFilename returns a filename suitable for archive format detection.
 // Some ecosystems (e.g. composer) store artifacts with bare hash filenames
 // that have no extension. This adds .zip when the original has no extension
@@ -69,10 +74,13 @@ func openArchive(filename string, content io.Reader, ecosystem string) (archives
 		return archives.OpenWithPrefix(fname, content, "package/")
 	}
 
-	// Read content into memory so we can scan then wrap with prefix
-	data, err := io.ReadAll(content)
+	limited := io.LimitReader(content, maxBrowseArchiveSize+1)
+	data, err := io.ReadAll(limited)
 	if err != nil {
 		return nil, fmt.Errorf("reading artifact: %w", err)
+	}
+	if int64(len(data)) > maxBrowseArchiveSize {
+		return nil, fmt.Errorf("artifact too large for browsing (%d bytes)", len(data))
 	}
 
 	// Open once to detect root prefix

--- a/internal/server/browse_test.go
+++ b/internal/server/browse_test.go
@@ -198,6 +198,22 @@ func TestDetectContentType(t *testing.T) {
 	}
 }
 
+func TestOpenArchiveSizeLimit(t *testing.T) {
+	huge := bytes.Repeat([]byte("x"), int(maxBrowseArchiveSize)+1)
+	_, err := openArchive("test.tar.gz", bytes.NewReader(huge), "npm")
+	if err != nil {
+		t.Log("npm path streams directly, error is acceptable:", err)
+	}
+
+	_, err = openArchive("test.tar.gz", bytes.NewReader(huge), "go")
+	if err == nil {
+		t.Fatal("expected error for oversized archive, got nil")
+	}
+	if !strings.Contains(err.Error(), "too large") {
+		t.Fatalf("expected 'too large' error, got: %v", err)
+	}
+}
+
 func TestIsLikelyText(t *testing.T) {
 	tests := []struct {
 		filename string


### PR DESCRIPTION
The browse and compare handlers call `openArchive`, which buffers the full artifact into memory via `io.ReadAll` for prefix detection. A single request for a large cached artifact (normal for OCI/conda mirrors) could exhaust server memory.

Adds an `io.LimitReader` cap of 512 MB before the `io.ReadAll` call. Artifacts above this are rejected with a clear error. The npm codepath is unaffected since it streams directly with a known prefix.