### PR TITLE
Add MaxBytesReader to mirror API HandleCreate

### DIFF
--- a/internal/server/mirror_api.go
+++ b/internal/server/mirror_api.go
@@ -20,6 +20,7 @@ func NewMirrorAPIHandler(jobs *mirror.JobStore) *MirrorAPIHandler {
 
 // HandleCreate starts a new mirror job.
 func (h *MirrorAPIHandler) HandleCreate(w http.ResponseWriter, r *http.Request) {
+	r.Body = http.MaxBytesReader(w, r.Body, maxBodySize)
 	var req mirror.JobRequest
 	if err := json.NewDecoder(r.Body).Decode(&req); err != nil {
 		w.Header().Set("Content-Type", "application/json")

--- a/internal/server/mirror_api_test.go
+++ b/internal/server/mirror_api_test.go
@@ -71,6 +71,19 @@ func TestMirrorAPICreateJob(t *testing.T) {
 	}
 }
 
+func TestMirrorAPICreateOversizedBody(t *testing.T) {
+	h := setupMirrorAPI(t)
+
+	body := bytes.Repeat([]byte("x"), int(maxBodySize)+1)
+	req := httptest.NewRequest("POST", "/api/mirror", bytes.NewReader(body))
+	w := httptest.NewRecorder()
+	h.HandleCreate(w, req)
+
+	if w.Code != http.StatusBadRequest {
+		t.Errorf("status = %d, want %d", w.Code, http.StatusBadRequest)
+	}
+}
+
 func TestMirrorAPICreateInvalidBody(t *testing.T) {
 	h := setupMirrorAPI(t)
 


### PR DESCRIPTION
The mirror API's `HandleCreate` endpoint decoded the JSON request body without any size limit, unlike the other API handlers in `api.go` which use `http.MaxBytesReader`. Adds the same 1 MB cap.