### PR TITLE
Check for path traversal after URL decoding

### DIFF
--- a/internal/handler/handler.go
+++ b/internal/handler/handler.go
@@ -24,9 +24,21 @@ import (
 )
 
 // containsPathTraversal returns true if the path contains ".." segments
-// that could be used to escape the intended directory.
+// that could be used to escape the intended directory. It checks the path
+// as given and after URL-decoding, and treats backslashes as separators.
 func containsPathTraversal(path string) bool {
-	for _, segment := range strings.Split(path, "/") {
+	if hasDotDotSegment(path) {
+		return true
+	}
+	if decoded, err := url.PathUnescape(path); err == nil && decoded != path {
+		return hasDotDotSegment(decoded)
+	}
+	return false
+}
+
+func hasDotDotSegment(path string) bool {
+	path = strings.ReplaceAll(path, "\\", "/")
+	for segment := range strings.SplitSeq(path, "/") {
 		if segment == ".." {
 			return true
 		}

--- a/internal/handler/path_traversal_test.go
+++ b/internal/handler/path_traversal_test.go
@@ -14,6 +14,15 @@ func TestContainsPathTraversal(t *testing.T) {
 		{"pool/main/../../../etc/shadow", true},
 		{"pool/..hidden/file", false}, // ".." as a segment, not "..hidden"
 		{"", false},
+		{"%2e%2e/etc/passwd", true},
+		{"%2e%2e%2fetc%2fpasswd", true},
+		{"pool/%2e%2e/%2e%2e/etc/shadow", true},
+		{"%2E%2E%2Fetc", true},
+		{`..\\etc\\passwd`, true},
+		{`pool\\..\\..\\etc`, true},
+		{"%2e%2e%5cetc%5cpasswd", true},
+		{"pool/%2e%2ehidden/file", false},
+		{"pool/%zz/bad-encoding", false},
 	}
 
 	for _, tt := range tests {


### PR DESCRIPTION
`containsPathTraversal` only checked literal `..` segments split on `/`. Encoded forms like `%2e%2e%2f` or backslash separators would pass straight through if a caller handed it a raw path or a Windows-style one.

The helper now runs `url.PathUnescape` and normalises `\` to `/` before checking segments. In practice chi hands us `r.URL.Path` which Go already decodes, so the encoded case is mostly belt-and-braces for `FetchOrCacheMetadata` cache keys and any future non-router callers, layered on top of the storage guard from #106.

Added table tests covering `%2e%2e/`, `%2e%2e%2f`, `%2E%2E%2F`, `%2e%2e%5c`, `..\\`, and a malformed-encoding case to confirm it fails open to the raw check rather than erroring.

Fixes #74