### PR TITLE
Validate package paths before database lookups

### DIFF
--- a/internal/server/api.go
+++ b/internal/server/api.go
@@ -140,6 +140,10 @@ type BulkResponse struct {
 func (h *APIHandler) HandlePackagePath(w http.ResponseWriter, r *http.Request) {
 	ecosystem := chi.URLParam(r, "ecosystem")
 	wildcard := chi.URLParam(r, "*")
+	if err := validatePackagePath(wildcard); err != nil {
+		http.Error(w, err.Error(), http.StatusBadRequest)
+		return
+	}
 	segments := splitWildcardPath(wildcard)
 
 	if ecosystem == "" || len(segments) == 0 {
@@ -274,6 +278,10 @@ func (h *APIHandler) getVersion(w http.ResponseWriter, r *http.Request, ecosyste
 func (h *APIHandler) HandleVulnsPath(w http.ResponseWriter, r *http.Request) {
 	ecosystem := chi.URLParam(r, "ecosystem")
 	wildcard := chi.URLParam(r, "*")
+	if err := validatePackagePath(wildcard); err != nil {
+		http.Error(w, err.Error(), http.StatusBadRequest)
+		return
+	}
 	segments := splitWildcardPath(wildcard)
 
 	if ecosystem == "" || len(segments) == 0 {

--- a/internal/server/api_test.go
+++ b/internal/server/api_test.go
@@ -9,6 +9,7 @@ import (
 	"net/http/httptest"
 	"os"
 	"path/filepath"
+	"strings"
 	"testing"
 
 	"github.com/git-pkgs/proxy/internal/database"
@@ -45,6 +46,35 @@ func TestHandlePackagePath_MissingParams(t *testing.T) {
 
 	if w.Code != http.StatusBadRequest && w.Code != http.StatusNotFound {
 		t.Errorf("expected status 400 or 404, got %d", w.Code)
+	}
+}
+
+func TestHandlePackagePath_InvalidName(t *testing.T) {
+	logger := slog.New(slog.NewTextHandler(os.Stdout, nil))
+	svc := enrichment.New(logger)
+	h := NewAPIHandler(svc, nil)
+
+	r := chi.NewRouter()
+	r.Get("/api/package/{ecosystem}/*", h.HandlePackagePath)
+
+	tests := []struct {
+		name string
+		path string
+	}{
+		{"null byte", "/api/package/npm/lodash%00"},
+		{"too long", "/api/package/npm/" + strings.Repeat("a", maxPackagePathLen+1)},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			req := httptest.NewRequest("GET", tt.path, nil)
+			w := httptest.NewRecorder()
+			r.ServeHTTP(w, req)
+
+			if w.Code != http.StatusBadRequest {
+				t.Errorf("expected status 400, got %d", w.Code)
+			}
+		})
 	}
 }
 

--- a/internal/server/browse.go
+++ b/internal/server/browse.go
@@ -133,6 +133,10 @@ type BrowseFileInfo struct {
 func (s *Server) handleBrowsePath(w http.ResponseWriter, r *http.Request) {
 	ecosystem := chi.URLParam(r, "ecosystem")
 	wildcard := chi.URLParam(r, "*")
+	if err := validatePackagePath(wildcard); err != nil {
+		http.Error(w, err.Error(), http.StatusBadRequest)
+		return
+	}
 	segments := splitWildcardPath(wildcard)
 
 	if ecosystem == "" || len(segments) < 2 {
@@ -185,6 +189,10 @@ func (s *Server) handleBrowsePath(w http.ResponseWriter, r *http.Request) {
 func (s *Server) handleComparePath(w http.ResponseWriter, r *http.Request) {
 	ecosystem := chi.URLParam(r, "ecosystem")
 	wildcard := chi.URLParam(r, "*")
+	if err := validatePackagePath(wildcard); err != nil {
+		http.Error(w, err.Error(), http.StatusBadRequest)
+		return
+	}
 	segments := splitWildcardPath(wildcard)
 
 	if ecosystem == "" || len(segments) < 3 {

--- a/internal/server/resolve.go
+++ b/internal/server/resolve.go
@@ -1,10 +1,38 @@
 package server
 
 import (
+	"fmt"
 	"strings"
+	"unicode"
 
 	"github.com/git-pkgs/proxy/internal/database"
 )
+
+// maxPackagePathLen bounds the wildcard portion of package routes (name plus
+// version and any suffix). npm caps names at 214 and Maven coordinates can be
+// longer, so 512 leaves room without admitting pathological inputs.
+const maxPackagePathLen = 512
+
+// validatePackagePath rejects wildcard package paths that cannot be valid in
+// any supported ecosystem. It is a coarse filter applied before database or
+// enrichment lookups; ecosystem-specific name rules are layered on top.
+func validatePackagePath(path string) error {
+	if path == "" {
+		return fmt.Errorf("package name required")
+	}
+	if len(path) > maxPackagePathLen {
+		return fmt.Errorf("package path exceeds %d bytes", maxPackagePathLen)
+	}
+	for _, r := range path {
+		if r == 0 {
+			return fmt.Errorf("package path contains null byte")
+		}
+		if unicode.IsControl(r) {
+			return fmt.Errorf("package path contains control character %#U", r)
+		}
+	}
+	return nil
+}
 
 // resolvePackageName determines the package name from a wildcard path by
 // checking the database. This handles namespaced packages like Composer's

--- a/internal/server/resolve_test.go
+++ b/internal/server/resolve_test.go
@@ -3,6 +3,7 @@ package server
 import (
 	"os"
 	"path/filepath"
+	"strings"
 	"testing"
 
 	"github.com/git-pkgs/proxy/internal/database"
@@ -116,5 +117,38 @@ func TestSplitWildcardPath(t *testing.T) {
 				t.Errorf("splitWildcardPath(%q)[%d] = %q, want %q", tt.input, i, got[i], tt.want[i])
 			}
 		}
+	}
+}
+
+func TestValidatePackagePath(t *testing.T) {
+	tests := []struct {
+		name    string
+		path    string
+		wantErr bool
+	}{
+		{"simple", "lodash", false},
+		{"with version", "lodash/4.17.21", false},
+		{"npm scoped", "@babel/core/7.0.0", false},
+		{"composer namespaced", "symfony/console/6.0.0", false},
+		{"maven coordinates", "org.apache.commons/commons-lang3/3.12.0", false},
+		{"unicode", "café/1.0.0", false},
+		{"empty", "", true},
+		{"null byte", "lodash\x00/4.17.21", true},
+		{"null byte suffix", "lodash\x00", true},
+		{"newline", "lodash\n4.17.21", true},
+		{"carriage return", "lodash\r", true},
+		{"escape", "lodash\x1b[31m", true},
+		{"delete", "lodash\x7f", true},
+		{"too long", strings.Repeat("a", maxPackagePathLen+1), true},
+		{"at limit", strings.Repeat("a", maxPackagePathLen), false},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			err := validatePackagePath(tt.path)
+			if (err != nil) != tt.wantErr {
+				t.Errorf("validatePackagePath(%q) error = %v, wantErr %v", tt.path, err, tt.wantErr)
+			}
+		})
 	}
 }

--- a/internal/server/server.go
+++ b/internal/server/server.go
@@ -615,6 +615,10 @@ func (s *Server) handlePackagesList(w http.ResponseWriter, r *http.Request) {
 func (s *Server) handlePackagePath(w http.ResponseWriter, r *http.Request) {
 	ecosystem := chi.URLParam(r, "ecosystem")
 	wildcard := chi.URLParam(r, "*")
+	if err := validatePackagePath(wildcard); err != nil {
+		http.Error(w, err.Error(), http.StatusBadRequest)
+		return
+	}
 	segments := splitWildcardPath(wildcard)
 
 	if ecosystem == "" || len(segments) == 0 {


### PR DESCRIPTION
The wildcard package routes only checked for an empty path before handing user input to `GetPackageByEcosystemName` and the enrichment service. A `%00` or a multi-kilobyte name would flow straight through to the DB query.

Adds `validatePackagePath` in `resolve.go` as a coarse first filter: reject null bytes, other control characters, and paths over 512 bytes. Wired into all five chi wildcard entry points (`handlePackagePath`, `HandlePackagePath`, `HandleVulnsPath`, `handleBrowsePath`, `handleComparePath`) immediately after the wildcard is read, so bad input gets a 400 before any lookup.

The 512-byte cap is generous enough for Maven coordinates plus version plus suffix while still bounding the worst case. Ecosystem-specific name format rules (npm scoped name shape, Composer vendor/name, etc.) can layer on top of this in a follow-up.

Unit tests cover the validator directly and `TestHandlePackagePath_InvalidName` confirms `%00` and overlong paths get a 400 through the actual chi router.

Fixes #75