### PR TITLE
Structured JSON error responses for API endpoints

### DIFF
--- a/docs/swagger/docs.go
+++ b/docs/swagger/docs.go
@@ -64,13 +64,13 @@ const docTemplate = `{
                     "404": {
                         "description": "Not Found",
                         "schema": {
-                            "type": "string"
+                            "$ref": "#/definitions/server.ErrorResponse"
                         }
                     },
                     "500": {
                         "description": "Internal Server Error",
                         "schema": {
-                            "type": "string"
+                            "$ref": "#/definitions/server.ErrorResponse"
                         }
                     }
                 }
@@ -126,19 +126,19 @@ const docTemplate = `{
                     "400": {
                         "description": "Bad Request",
                         "schema": {
-                            "type": "string"
+                            "$ref": "#/definitions/server.ErrorResponse"
                         }
                     },
                     "404": {
                         "description": "Not Found",
                         "schema": {
-                            "type": "string"
+                            "$ref": "#/definitions/server.ErrorResponse"
                         }
                     },
                     "500": {
                         "description": "Internal Server Error",
                         "schema": {
-                            "type": "string"
+                            "$ref": "#/definitions/server.ErrorResponse"
                         }
                     }
                 }
@@ -177,13 +177,13 @@ const docTemplate = `{
                     "400": {
                         "description": "Bad Request",
                         "schema": {
-                            "type": "string"
+                            "$ref": "#/definitions/server.ErrorResponse"
                         }
                     },
                     "500": {
                         "description": "Internal Server Error",
                         "schema": {
-                            "type": "string"
+                            "$ref": "#/definitions/server.ErrorResponse"
                         }
                     }
                 }
@@ -240,13 +240,13 @@ const docTemplate = `{
                     "404": {
                         "description": "Not Found",
                         "schema": {
-                            "type": "string"
+                            "$ref": "#/definitions/server.ErrorResponse"
                         }
                     },
                     "500": {
                         "description": "Internal Server Error",
                         "schema": {
-                            "type": "string"
+                            "$ref": "#/definitions/server.ErrorResponse"
                         }
                     }
                 }
@@ -285,13 +285,13 @@ const docTemplate = `{
                     "400": {
                         "description": "Bad Request",
                         "schema": {
-                            "type": "string"
+                            "$ref": "#/definitions/server.ErrorResponse"
                         }
                     },
                     "500": {
                         "description": "Internal Server Error",
                         "schema": {
-                            "type": "string"
+                            "$ref": "#/definitions/server.ErrorResponse"
                         }
                     }
                 }
@@ -338,13 +338,13 @@ const docTemplate = `{
                     "400": {
                         "description": "Bad Request",
                         "schema": {
-                            "type": "string"
+                            "$ref": "#/definitions/server.ErrorResponse"
                         }
                     },
                     "500": {
                         "description": "Internal Server Error",
                         "schema": {
-                            "type": "string"
+                            "$ref": "#/definitions/server.ErrorResponse"
                         }
                     }
                 }
@@ -384,13 +384,13 @@ const docTemplate = `{
                     "400": {
                         "description": "Bad Request",
                         "schema": {
-                            "type": "string"
+                            "$ref": "#/definitions/server.ErrorResponse"
                         }
                     },
                     "500": {
                         "description": "Internal Server Error",
                         "schema": {
-                            "type": "string"
+                            "$ref": "#/definitions/server.ErrorResponse"
                         }
                     }
                 }
@@ -440,7 +440,7 @@ const docTemplate = `{
                     "500": {
                         "description": "Internal Server Error",
                         "schema": {
-                            "type": "string"
+                            "$ref": "#/definitions/server.ErrorResponse"
                         }
                     }
                 }
@@ -501,6 +501,17 @@ const docTemplate = `{
                     "additionalProperties": {
                         "$ref": "#/definitions/server.PackageResponse"
                     }
+                }
+            }
+        },
+        "server.ErrorResponse": {
+            "type": "object",
+            "properties": {
+                "code": {
+                    "type": "string"
+                },
+                "message": {
+                    "type": "string"
                 }
             }
         },

--- a/docs/swagger/swagger.json
+++ b/docs/swagger/swagger.json
@@ -57,13 +57,13 @@
                     "404": {
                         "description": "Not Found",
                         "schema": {
-                            "type": "string"
+                            "$ref": "#/definitions/server.ErrorResponse"
                         }
                     },
                     "500": {
                         "description": "Internal Server Error",
                         "schema": {
-                            "type": "string"
+                            "$ref": "#/definitions/server.ErrorResponse"
                         }
                     }
                 }
@@ -119,19 +119,19 @@
                     "400": {
                         "description": "Bad Request",
                         "schema": {
-                            "type": "string"
+                            "$ref": "#/definitions/server.ErrorResponse"
                         }
                     },
                     "404": {
                         "description": "Not Found",
                         "schema": {
-                            "type": "string"
+                            "$ref": "#/definitions/server.ErrorResponse"
                         }
                     },
                     "500": {
                         "description": "Internal Server Error",
                         "schema": {
-                            "type": "string"
+                            "$ref": "#/definitions/server.ErrorResponse"
                         }
                     }
                 }
@@ -170,13 +170,13 @@
                     "400": {
                         "description": "Bad Request",
                         "schema": {
-                            "type": "string"
+                            "$ref": "#/definitions/server.ErrorResponse"
                         }
                     },
                     "500": {
                         "description": "Internal Server Error",
                         "schema": {
-                            "type": "string"
+                            "$ref": "#/definitions/server.ErrorResponse"
                         }
                     }
                 }
@@ -233,13 +233,13 @@
                     "404": {
                         "description": "Not Found",
                         "schema": {
-                            "type": "string"
+                            "$ref": "#/definitions/server.ErrorResponse"
                         }
                     },
                     "500": {
                         "description": "Internal Server Error",
                         "schema": {
-                            "type": "string"
+                            "$ref": "#/definitions/server.ErrorResponse"
                         }
                     }
                 }
@@ -278,13 +278,13 @@
                     "400": {
                         "description": "Bad Request",
                         "schema": {
-                            "type": "string"
+                            "$ref": "#/definitions/server.ErrorResponse"
                         }
                     },
                     "500": {
                         "description": "Internal Server Error",
                         "schema": {
-                            "type": "string"
+                            "$ref": "#/definitions/server.ErrorResponse"
                         }
                     }
                 }
@@ -331,13 +331,13 @@
                     "400": {
                         "description": "Bad Request",
                         "schema": {
-                            "type": "string"
+                            "$ref": "#/definitions/server.ErrorResponse"
                         }
                     },
                     "500": {
                         "description": "Internal Server Error",
                         "schema": {
-                            "type": "string"
+                            "$ref": "#/definitions/server.ErrorResponse"
                         }
                     }
                 }
@@ -377,13 +377,13 @@
                     "400": {
                         "description": "Bad Request",
                         "schema": {
-                            "type": "string"
+                            "$ref": "#/definitions/server.ErrorResponse"
                         }
                     },
                     "500": {
                         "description": "Internal Server Error",
                         "schema": {
-                            "type": "string"
+                            "$ref": "#/definitions/server.ErrorResponse"
                         }
                     }
                 }
@@ -433,7 +433,7 @@
                     "500": {
                         "description": "Internal Server Error",
                         "schema": {
-                            "type": "string"
+                            "$ref": "#/definitions/server.ErrorResponse"
                         }
                     }
                 }
@@ -494,6 +494,17 @@
                     "additionalProperties": {
                         "$ref": "#/definitions/server.PackageResponse"
                     }
+                }
+            }
+        },
+        "server.ErrorResponse": {
+            "type": "object",
+            "properties": {
+                "code": {
+                    "type": "string"
+                },
+                "message": {
+                    "type": "string"
                 }
             }
         },

--- a/internal/server/api.go
+++ b/internal/server/api.go
@@ -141,7 +141,7 @@ func (h *APIHandler) HandlePackagePath(w http.ResponseWriter, r *http.Request) {
 	ecosystem := chi.URLParam(r, "ecosystem")
 	wildcard := chi.URLParam(r, "*")
 	if err := validatePackagePath(wildcard); err != nil {
-		http.Error(w, err.Error(), http.StatusBadRequest)
+		badRequest(w, err.Error())
 		return
 	}
 	segments := splitWildcardPath(wildcard)
@@ -279,7 +279,7 @@ func (h *APIHandler) HandleVulnsPath(w http.ResponseWriter, r *http.Request) {
 	ecosystem := chi.URLParam(r, "ecosystem")
 	wildcard := chi.URLParam(r, "*")
 	if err := validatePackagePath(wildcard); err != nil {
-		http.Error(w, err.Error(), http.StatusBadRequest)
+		badRequest(w, err.Error())
 		return
 	}
 	segments := splitWildcardPath(wildcard)

--- a/internal/server/api.go
+++ b/internal/server/api.go
@@ -147,7 +147,7 @@ func (h *APIHandler) HandlePackagePath(w http.ResponseWriter, r *http.Request) {
 	segments := splitWildcardPath(wildcard)
 
 	if ecosystem == "" || len(segments) == 0 {
-		http.Error(w, "ecosystem and name are required", http.StatusBadRequest)
+		badRequest(w, "ecosystem and name are required")
 		return
 	}
 
@@ -194,12 +194,12 @@ func (h *APIHandler) HandlePackagePath(w http.ResponseWriter, r *http.Request) {
 func (h *APIHandler) getPackage(w http.ResponseWriter, r *http.Request, ecosystem, name string) {
 	info, err := h.enrichment.EnrichPackage(r.Context(), ecosystem, name)
 	if err != nil {
-		http.Error(w, "failed to enrich package", http.StatusInternalServerError)
+		writeError(w, http.StatusBadGateway, ErrCodeUpstream, "failed to enrich package")
 		return
 	}
 
 	if info == nil {
-		http.Error(w, "package not found", http.StatusNotFound)
+		notFound(w, "package not found")
 		return
 	}
 
@@ -221,7 +221,7 @@ func (h *APIHandler) getPackage(w http.ResponseWriter, r *http.Request, ecosyste
 func (h *APIHandler) getVersion(w http.ResponseWriter, r *http.Request, ecosystem, name, version string) {
 	result, err := h.enrichment.EnrichFull(r.Context(), ecosystem, name, version)
 	if err != nil {
-		http.Error(w, "failed to enrich version", http.StatusInternalServerError)
+		writeError(w, http.StatusBadGateway, ErrCodeUpstream, "failed to enrich version")
 		return
 	}
 
@@ -285,7 +285,7 @@ func (h *APIHandler) HandleVulnsPath(w http.ResponseWriter, r *http.Request) {
 	segments := splitWildcardPath(wildcard)
 
 	if ecosystem == "" || len(segments) == 0 {
-		http.Error(w, "ecosystem and name are required", http.StatusBadRequest)
+		badRequest(w, "ecosystem and name are required")
 		return
 	}
 
@@ -306,7 +306,7 @@ func (h *APIHandler) HandleVulnsPath(w http.ResponseWriter, r *http.Request) {
 
 	vulns, err := h.enrichment.CheckVulnerabilities(r.Context(), ecosystem, name, version)
 	if err != nil {
-		http.Error(w, "failed to check vulnerabilities", http.StatusInternalServerError)
+		writeError(w, http.StatusBadGateway, ErrCodeUpstream, "failed to check vulnerabilities")
 		return
 	}
 
@@ -338,19 +338,19 @@ func (h *APIHandler) HandleVulnsPath(w http.ResponseWriter, r *http.Request) {
 // @Produce json
 // @Param request body OutdatedRequest true "Packages to check"
 // @Success 200 {object} OutdatedResponse
-// @Failure 400 {string} string
-// @Failure 500 {string} string
+// @Failure 400 {object} ErrorResponse
+// @Failure 500 {object} ErrorResponse
 // @Router /api/outdated [post]
 func (h *APIHandler) HandleOutdated(w http.ResponseWriter, r *http.Request) {
 	r.Body = http.MaxBytesReader(w, r.Body, maxBodySize)
 	var req OutdatedRequest
 	if err := json.NewDecoder(r.Body).Decode(&req); err != nil {
-		http.Error(w, "invalid request body", http.StatusBadRequest)
+		badRequest(w, "invalid request body")
 		return
 	}
 
 	if len(req.Packages) == 0 {
-		http.Error(w, "packages list is required", http.StatusBadRequest)
+		badRequest(w, "packages list is required")
 		return
 	}
 
@@ -384,19 +384,19 @@ func (h *APIHandler) HandleOutdated(w http.ResponseWriter, r *http.Request) {
 // @Produce json
 // @Param request body BulkRequest true "PURLs"
 // @Success 200 {object} BulkResponse
-// @Failure 400 {string} string
-// @Failure 500 {string} string
+// @Failure 400 {object} ErrorResponse
+// @Failure 500 {object} ErrorResponse
 // @Router /api/bulk [post]
 func (h *APIHandler) HandleBulkLookup(w http.ResponseWriter, r *http.Request) {
 	r.Body = http.MaxBytesReader(w, r.Body, maxBodySize)
 	var req BulkRequest
 	if err := json.NewDecoder(r.Body).Decode(&req); err != nil {
-		http.Error(w, "invalid request body", http.StatusBadRequest)
+		badRequest(w, "invalid request body")
 		return
 	}
 
 	if len(req.PURLs) == 0 {
-		http.Error(w, "purls list is required", http.StatusBadRequest)
+		badRequest(w, "purls list is required")
 		return
 	}
 
@@ -484,15 +484,15 @@ type SearchPackageResult struct {
 // @Param q query string true "Query"
 // @Param ecosystem query string false "Ecosystem"
 // @Success 200 {object} SearchResponse
-// @Failure 400 {string} string
-// @Failure 500 {string} string
+// @Failure 400 {object} ErrorResponse
+// @Failure 500 {object} ErrorResponse
 // @Router /api/search [get]
 func (h *APIHandler) HandleSearch(w http.ResponseWriter, r *http.Request) {
 	query := r.URL.Query().Get("q")
 	ecosystem := r.URL.Query().Get("ecosystem")
 
 	if query == "" {
-		http.Error(w, "query parameter 'q' is required", http.StatusBadRequest)
+		badRequest(w, "query parameter 'q' is required")
 		return
 	}
 
@@ -502,7 +502,7 @@ func (h *APIHandler) HandleSearch(w http.ResponseWriter, r *http.Request) {
 	// Search in database
 	results, err := h.db.SearchPackages(query, ecosystem, limit, (page-1)*limit)
 	if err != nil {
-		http.Error(w, "search failed", http.StatusInternalServerError)
+		internalError(w, "search failed")
 		return
 	}
 
@@ -546,7 +546,7 @@ func (h *APIHandler) HandleSearch(w http.ResponseWriter, r *http.Request) {
 func writeJSON(w http.ResponseWriter, v any) {
 	w.Header().Set("Content-Type", "application/json")
 	if err := json.NewEncoder(w).Encode(v); err != nil {
-		http.Error(w, "failed to encode response", http.StatusInternalServerError)
+		internalError(w, "failed to encode response")
 	}
 }
 
@@ -581,8 +581,8 @@ type PackageListResult struct {
 // @Param ecosystem query string false "Ecosystem"
 // @Param sort query string false "Sort" Enums(hits,name,size,cached_at,ecosystem,vulns)
 // @Success 200 {object} PackagesListResponse
-// @Failure 400 {string} string
-// @Failure 500 {string} string
+// @Failure 400 {object} ErrorResponse
+// @Failure 500 {object} ErrorResponse
 // @Router /api/packages [get]
 func (h *APIHandler) HandlePackagesList(w http.ResponseWriter, r *http.Request) {
 	ecosystem := r.URL.Query().Get("ecosystem")
@@ -600,7 +600,7 @@ func (h *APIHandler) HandlePackagesList(w http.ResponseWriter, r *http.Request) 
 		"vulns":       true,
 	}
 	if !validSorts[sortBy] {
-		http.Error(w, "invalid sort parameter", http.StatusBadRequest)
+		badRequest(w, "invalid sort parameter")
 		return
 	}
 
@@ -609,7 +609,7 @@ func (h *APIHandler) HandlePackagesList(w http.ResponseWriter, r *http.Request) 
 
 	packages, err := h.db.ListCachedPackages(ecosystem, sortBy, limit, (page-1)*limit)
 	if err != nil {
-		http.Error(w, "failed to list packages", http.StatusInternalServerError)
+		internalError(w, "failed to list packages")
 		return
 	}
 

--- a/internal/server/browse.go
+++ b/internal/server/browse.go
@@ -131,7 +131,7 @@ func (s *Server) handleBrowsePath(w http.ResponseWriter, r *http.Request) {
 	ecosystem := chi.URLParam(r, "ecosystem")
 	wildcard := chi.URLParam(r, "*")
 	if err := validatePackagePath(wildcard); err != nil {
-		http.Error(w, err.Error(), http.StatusBadRequest)
+		badRequest(w, err.Error())
 		return
 	}
 	segments := splitWildcardPath(wildcard)
@@ -187,7 +187,7 @@ func (s *Server) handleComparePath(w http.ResponseWriter, r *http.Request) {
 	ecosystem := chi.URLParam(r, "ecosystem")
 	wildcard := chi.URLParam(r, "*")
 	if err := validatePackagePath(wildcard); err != nil {
-		http.Error(w, err.Error(), http.StatusBadRequest)
+		badRequest(w, err.Error())
 		return
 	}
 	segments := splitWildcardPath(wildcard)

--- a/internal/server/browse.go
+++ b/internal/server/browse.go
@@ -117,8 +117,8 @@ type BrowseFileInfo struct {
 // @Param version path string true "Version"
 // @Param path query string false "Directory path inside the archive"
 // @Success 200 {object} BrowseListResponse
-// @Failure 404 {string} string
-// @Failure 500 {string} string
+// @Failure 404 {object} ErrorResponse
+// @Failure 500 {object} ErrorResponse
 // @Router /api/browse/{ecosystem}/{name}/{version} [get]
 // handleBrowsePath dispatches /api/browse/{ecosystem}/* to the appropriate browse handler.
 // It resolves namespaced package names by consulting the database.
@@ -137,7 +137,7 @@ func (s *Server) handleBrowsePath(w http.ResponseWriter, r *http.Request) {
 	segments := splitWildcardPath(wildcard)
 
 	if ecosystem == "" || len(segments) < 2 {
-		http.Error(w, "ecosystem, name, and version required", http.StatusBadRequest)
+		badRequest(w, "ecosystem, name, and version required")
 		return
 	}
 
@@ -161,7 +161,7 @@ func (s *Server) handleBrowsePath(w http.ResponseWriter, r *http.Request) {
 			rest = nameVersionSegments[len(nameVersionSegments)-1:]
 		}
 		if len(rest) != 1 {
-			http.Error(w, "not found", http.StatusNotFound)
+			notFound(w, "not found")
 			return
 		}
 		s.browseFile(w, r, ecosystem, name, rest[0], filePath)
@@ -175,7 +175,7 @@ func (s *Server) handleBrowsePath(w http.ResponseWriter, r *http.Request) {
 		rest = segments[len(segments)-1:]
 	}
 	if len(rest) != 1 {
-		http.Error(w, "not found", http.StatusNotFound)
+		notFound(w, "not found")
 		return
 	}
 	s.browseList(w, r, ecosystem, name, rest[0])
@@ -193,7 +193,7 @@ func (s *Server) handleComparePath(w http.ResponseWriter, r *http.Request) {
 	segments := splitWildcardPath(wildcard)
 
 	if ecosystem == "" || len(segments) < 3 {
-		http.Error(w, "ecosystem, name, fromVersion, and toVersion required", http.StatusBadRequest)
+		badRequest(w, "ecosystem, name, fromVersion, and toVersion required")
 		return
 	}
 
@@ -213,12 +213,12 @@ func (s *Server) browseList(w http.ResponseWriter, r *http.Request, ecosystem, n
 	versionPURL := purl.MakePURLString(ecosystem, name, version)
 	artifacts, err := s.db.GetArtifactsByVersionPURL(versionPURL)
 	if err != nil {
-		http.Error(w, "version not found", http.StatusNotFound)
+		notFound(w, "version not found")
 		return
 	}
 
 	if len(artifacts) == 0 {
-		http.Error(w, "no artifacts cached", http.StatusNotFound)
+		notFound(w, "no artifacts cached")
 		return
 	}
 
@@ -232,7 +232,7 @@ func (s *Server) browseList(w http.ResponseWriter, r *http.Request, ecosystem, n
 	}
 
 	if cachedArtifact == nil {
-		http.Error(w, "artifact not cached", http.StatusNotFound)
+		notFound(w, "artifact not cached")
 		return
 	}
 
@@ -240,7 +240,7 @@ func (s *Server) browseList(w http.ResponseWriter, r *http.Request, ecosystem, n
 	artifactReader, err := s.storage.Open(r.Context(), cachedArtifact.StoragePath.String)
 	if err != nil {
 		s.logger.Error("failed to read artifact from storage", "error", err)
-		http.Error(w, "failed to read artifact", http.StatusInternalServerError)
+		internalError(w, "failed to read artifact")
 		return
 	}
 	defer func() { _ = artifactReader.Close() }()
@@ -249,7 +249,7 @@ func (s *Server) browseList(w http.ResponseWriter, r *http.Request, ecosystem, n
 	archiveReader, err := openArchive(cachedArtifact.Filename, artifactReader, ecosystem)
 	if err != nil {
 		s.logger.Error("failed to open archive", "error", err, "filename", cachedArtifact.Filename)
-		http.Error(w, "failed to open archive", http.StatusInternalServerError)
+		internalError(w, "failed to open archive")
 		return
 	}
 	defer func() { _ = archiveReader.Close() }()
@@ -258,7 +258,7 @@ func (s *Server) browseList(w http.ResponseWriter, r *http.Request, ecosystem, n
 	files, err := archiveReader.ListDir(dirPath)
 	if err != nil {
 		s.logger.Error("failed to list directory", "error", err, "path", dirPath)
-		http.Error(w, "failed to list directory", http.StatusInternalServerError)
+		internalError(w, "failed to list directory")
 		return
 	}
 
@@ -293,13 +293,13 @@ func (s *Server) browseList(w http.ResponseWriter, r *http.Request, ecosystem, n
 // @Param version path string true "Version"
 // @Param filepath path string true "File path inside the archive"
 // @Success 200 {file} file
-// @Failure 400 {string} string
-// @Failure 404 {string} string
-// @Failure 500 {string} string
+// @Failure 400 {object} ErrorResponse
+// @Failure 404 {object} ErrorResponse
+// @Failure 500 {object} ErrorResponse
 // @Router /api/browse/{ecosystem}/{name}/{version}/file/{filepath} [get]
 func (s *Server) browseFile(w http.ResponseWriter, r *http.Request, ecosystem, name, version, filePath string) {
 	if filePath == "" {
-		http.Error(w, "file path required", http.StatusBadRequest)
+		badRequest(w, "file path required")
 		return
 	}
 
@@ -307,12 +307,12 @@ func (s *Server) browseFile(w http.ResponseWriter, r *http.Request, ecosystem, n
 	versionPURL := purl.MakePURLString(ecosystem, name, version)
 	artifacts, err := s.db.GetArtifactsByVersionPURL(versionPURL)
 	if err != nil {
-		http.Error(w, "version not found", http.StatusNotFound)
+		notFound(w, "version not found")
 		return
 	}
 
 	if len(artifacts) == 0 {
-		http.Error(w, "no artifacts cached", http.StatusNotFound)
+		notFound(w, "no artifacts cached")
 		return
 	}
 
@@ -326,7 +326,7 @@ func (s *Server) browseFile(w http.ResponseWriter, r *http.Request, ecosystem, n
 	}
 
 	if cachedArtifact == nil {
-		http.Error(w, "artifact not cached", http.StatusNotFound)
+		notFound(w, "artifact not cached")
 		return
 	}
 
@@ -334,7 +334,7 @@ func (s *Server) browseFile(w http.ResponseWriter, r *http.Request, ecosystem, n
 	artifactReader, err := s.storage.Open(r.Context(), cachedArtifact.StoragePath.String)
 	if err != nil {
 		s.logger.Error("failed to read artifact from storage", "error", err)
-		http.Error(w, "failed to read artifact", http.StatusInternalServerError)
+		internalError(w, "failed to read artifact")
 		return
 	}
 	defer func() { _ = artifactReader.Close() }()
@@ -343,7 +343,7 @@ func (s *Server) browseFile(w http.ResponseWriter, r *http.Request, ecosystem, n
 	archiveReader, err := openArchive(cachedArtifact.Filename, artifactReader, ecosystem)
 	if err != nil {
 		s.logger.Error("failed to open archive", "error", err, "filename", cachedArtifact.Filename)
-		http.Error(w, "failed to open archive", http.StatusInternalServerError)
+		internalError(w, "failed to open archive")
 		return
 	}
 	defer func() { _ = archiveReader.Close() }()
@@ -352,11 +352,11 @@ func (s *Server) browseFile(w http.ResponseWriter, r *http.Request, ecosystem, n
 	fileReader, err := archiveReader.Extract(filePath)
 	if err != nil {
 		if strings.Contains(err.Error(), "not found") {
-			http.Error(w, "file not found", http.StatusNotFound)
+			notFound(w, "file not found")
 			return
 		}
 		s.logger.Error("failed to extract file", "error", err, "path", filePath)
-		http.Error(w, "failed to extract file", http.StatusInternalServerError)
+		internalError(w, "failed to extract file")
 		return
 	}
 	defer func() { _ = fileReader.Close() }()
@@ -496,8 +496,8 @@ type BrowseSourceData struct {
 // @Param fromVersion path string true "From version"
 // @Param toVersion path string true "To version"
 // @Success 200 {object} map[string]any
-// @Failure 404 {string} string
-// @Failure 500 {string} string
+// @Failure 404 {object} ErrorResponse
+// @Failure 500 {object} ErrorResponse
 // @Router /api/compare/{ecosystem}/{name}/{fromVersion}/{toVersion} [get]
 func (s *Server) compareDiff(w http.ResponseWriter, r *http.Request, ecosystem, name, fromVersion, toVersion string) {
 	// Get artifacts for both versions
@@ -506,13 +506,13 @@ func (s *Server) compareDiff(w http.ResponseWriter, r *http.Request, ecosystem, 
 
 	fromArtifacts, err := s.db.GetArtifactsByVersionPURL(fromPURL)
 	if err != nil || len(fromArtifacts) == 0 {
-		http.Error(w, "from version not found or not cached", http.StatusNotFound)
+		notFound(w, "from version not found or not cached")
 		return
 	}
 
 	toArtifacts, err := s.db.GetArtifactsByVersionPURL(toPURL)
 	if err != nil || len(toArtifacts) == 0 {
-		http.Error(w, "to version not found or not cached", http.StatusNotFound)
+		notFound(w, "to version not found or not cached")
 		return
 	}
 
@@ -532,7 +532,7 @@ func (s *Server) compareDiff(w http.ResponseWriter, r *http.Request, ecosystem, 
 	}
 
 	if fromArtifact == nil || toArtifact == nil {
-		http.Error(w, "one or both versions not cached", http.StatusNotFound)
+		notFound(w, "one or both versions not cached")
 		return
 	}
 
@@ -540,7 +540,7 @@ func (s *Server) compareDiff(w http.ResponseWriter, r *http.Request, ecosystem, 
 	fromReader, err := s.storage.Open(r.Context(), fromArtifact.StoragePath.String)
 	if err != nil {
 		s.logger.Error("failed to open from artifact", "error", err)
-		http.Error(w, "failed to read from version", http.StatusInternalServerError)
+		internalError(w, "failed to read from version")
 		return
 	}
 	defer func() { _ = fromReader.Close() }()
@@ -548,7 +548,7 @@ func (s *Server) compareDiff(w http.ResponseWriter, r *http.Request, ecosystem, 
 	toReader, err := s.storage.Open(r.Context(), toArtifact.StoragePath.String)
 	if err != nil {
 		s.logger.Error("failed to open to artifact", "error", err)
-		http.Error(w, "failed to read to version", http.StatusInternalServerError)
+		internalError(w, "failed to read to version")
 		return
 	}
 	defer func() { _ = toReader.Close() }()
@@ -556,7 +556,7 @@ func (s *Server) compareDiff(w http.ResponseWriter, r *http.Request, ecosystem, 
 	fromArchive, err := openArchive(fromArtifact.Filename, fromReader, ecosystem)
 	if err != nil {
 		s.logger.Error("failed to open from archive", "error", err)
-		http.Error(w, "failed to open from archive", http.StatusInternalServerError)
+		internalError(w, "failed to open from archive")
 		return
 	}
 	defer func() { _ = fromArchive.Close() }()
@@ -564,7 +564,7 @@ func (s *Server) compareDiff(w http.ResponseWriter, r *http.Request, ecosystem, 
 	toArchive, err := openArchive(toArtifact.Filename, toReader, ecosystem)
 	if err != nil {
 		s.logger.Error("failed to open to archive", "error", err)
-		http.Error(w, "failed to open to archive", http.StatusInternalServerError)
+		internalError(w, "failed to open to archive")
 		return
 	}
 	defer func() { _ = toArchive.Close() }()
@@ -573,7 +573,7 @@ func (s *Server) compareDiff(w http.ResponseWriter, r *http.Request, ecosystem, 
 	result, err := diff.Compare(fromArchive, toArchive)
 	if err != nil {
 		s.logger.Error("failed to generate diff", "error", err)
-		http.Error(w, "failed to generate diff", http.StatusInternalServerError)
+		internalError(w, "failed to generate diff")
 		return
 	}
 

--- a/internal/server/errors.go
+++ b/internal/server/errors.go
@@ -1,0 +1,42 @@
+package server
+
+import (
+	"encoding/json"
+	"net/http"
+)
+
+// Error codes returned in API error responses. These are stable identifiers
+// that clients can match on; the message text is for humans and may change.
+const (
+	ErrCodeBadRequest = "BAD_REQUEST"
+	ErrCodeNotFound   = "NOT_FOUND"
+	ErrCodeUpstream   = "UPSTREAM_ERROR"
+	ErrCodeInternal   = "INTERNAL_ERROR"
+)
+
+// ErrorResponse is the JSON body returned for API errors.
+type ErrorResponse struct {
+	Code    string `json:"code"`
+	Message string `json:"message"`
+}
+
+// writeError sends a JSON error response with the given status, code and
+// user-facing message. Internal error details should be logged separately
+// by the caller, never passed as the message.
+func writeError(w http.ResponseWriter, status int, code, message string) {
+	w.Header().Set("Content-Type", "application/json")
+	w.WriteHeader(status)
+	_ = json.NewEncoder(w).Encode(ErrorResponse{Code: code, Message: message})
+}
+
+func badRequest(w http.ResponseWriter, message string) {
+	writeError(w, http.StatusBadRequest, ErrCodeBadRequest, message)
+}
+
+func notFound(w http.ResponseWriter, message string) {
+	writeError(w, http.StatusNotFound, ErrCodeNotFound, message)
+}
+
+func internalError(w http.ResponseWriter, message string) {
+	writeError(w, http.StatusInternalServerError, ErrCodeInternal, message)
+}

--- a/internal/server/errors_test.go
+++ b/internal/server/errors_test.go
@@ -1,0 +1,93 @@
+package server
+
+import (
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+)
+
+func TestWriteError(t *testing.T) {
+	tests := []struct {
+		name    string
+		fn      func(w http.ResponseWriter)
+		status  int
+		code    string
+		message string
+	}{
+		{
+			name:    "badRequest",
+			fn:      func(w http.ResponseWriter) { badRequest(w, "missing field") },
+			status:  http.StatusBadRequest,
+			code:    ErrCodeBadRequest,
+			message: "missing field",
+		},
+		{
+			name:    "notFound",
+			fn:      func(w http.ResponseWriter) { notFound(w, "package not found") },
+			status:  http.StatusNotFound,
+			code:    ErrCodeNotFound,
+			message: "package not found",
+		},
+		{
+			name:    "internalError",
+			fn:      func(w http.ResponseWriter) { internalError(w, "boom") },
+			status:  http.StatusInternalServerError,
+			code:    ErrCodeInternal,
+			message: "boom",
+		},
+		{
+			name: "upstream",
+			fn: func(w http.ResponseWriter) {
+				writeError(w, http.StatusBadGateway, ErrCodeUpstream, "registry unreachable")
+			},
+			status:  http.StatusBadGateway,
+			code:    ErrCodeUpstream,
+			message: "registry unreachable",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			w := httptest.NewRecorder()
+			tt.fn(w)
+
+			if w.Code != tt.status {
+				t.Errorf("status = %d, want %d", w.Code, tt.status)
+			}
+			if ct := w.Header().Get("Content-Type"); ct != "application/json" {
+				t.Errorf("Content-Type = %q, want application/json", ct)
+			}
+
+			var resp ErrorResponse
+			if err := json.Unmarshal(w.Body.Bytes(), &resp); err != nil {
+				t.Fatalf("response body is not valid JSON: %v (body: %q)", err, w.Body.String())
+			}
+			if resp.Code != tt.code {
+				t.Errorf("code = %q, want %q", resp.Code, tt.code)
+			}
+			if resp.Message != tt.message {
+				t.Errorf("message = %q, want %q", resp.Message, tt.message)
+			}
+		})
+	}
+}
+
+func TestAPIErrorResponseShape(t *testing.T) {
+	w := httptest.NewRecorder()
+	badRequest(w, "x")
+
+	var raw map[string]any
+	if err := json.Unmarshal(w.Body.Bytes(), &raw); err != nil {
+		t.Fatalf("invalid JSON: %v", err)
+	}
+	if _, ok := raw["code"]; !ok {
+		t.Error("response missing 'code' field")
+	}
+	if _, ok := raw["message"]; !ok {
+		t.Error("response missing 'message' field")
+	}
+	if len(raw) != 2 {
+		t.Errorf("response has unexpected fields: %v", raw)
+	}
+}

--- a/internal/server/mirror_api.go
+++ b/internal/server/mirror_api.go
@@ -23,17 +23,13 @@ func (h *MirrorAPIHandler) HandleCreate(w http.ResponseWriter, r *http.Request) 
 	r.Body = http.MaxBytesReader(w, r.Body, maxBodySize)
 	var req mirror.JobRequest
 	if err := json.NewDecoder(r.Body).Decode(&req); err != nil {
-		w.Header().Set("Content-Type", "application/json")
-		w.WriteHeader(http.StatusBadRequest)
-		writeJSON(w, map[string]string{"error": "invalid request body"})
+		badRequest(w, "invalid request body")
 		return
 	}
 
 	id, err := h.jobs.Create(req)
 	if err != nil {
-		w.Header().Set("Content-Type", "application/json")
-		w.WriteHeader(http.StatusBadRequest)
-		writeJSON(w, map[string]string{"error": err.Error()})
+		badRequest(w, "invalid mirror job request")
 		return
 	}
 
@@ -47,13 +43,10 @@ func (h *MirrorAPIHandler) HandleGet(w http.ResponseWriter, r *http.Request) {
 	id := chi.URLParam(r, "id")
 	job := h.jobs.Get(id)
 	if job == nil {
-		w.Header().Set("Content-Type", "application/json")
-		w.WriteHeader(http.StatusNotFound)
-		writeJSON(w, map[string]string{"error": "job not found"})
+		notFound(w, "job not found")
 		return
 	}
 
-	w.Header().Set("Content-Type", "application/json")
 	writeJSON(w, job)
 }
 
@@ -61,11 +54,8 @@ func (h *MirrorAPIHandler) HandleGet(w http.ResponseWriter, r *http.Request) {
 func (h *MirrorAPIHandler) HandleCancel(w http.ResponseWriter, r *http.Request) {
 	id := chi.URLParam(r, "id")
 	if h.jobs.Cancel(id) {
-		w.Header().Set("Content-Type", "application/json")
 		writeJSON(w, map[string]string{"status": "canceled"})
 	} else {
-		w.Header().Set("Content-Type", "application/json")
-		w.WriteHeader(http.StatusNotFound)
-		writeJSON(w, map[string]string{"error": "job not found or not running"})
+		notFound(w, "job not found or not running")
 	}
 }

--- a/internal/server/server.go
+++ b/internal/server/server.go
@@ -826,20 +826,20 @@ type StatsResponse struct {
 // @Tags meta
 // @Produce json
 // @Success 200 {object} StatsResponse
-// @Failure 500 {string} string
+// @Failure 500 {object} ErrorResponse
 // @Router /stats [get]
 func (s *Server) handleStats(w http.ResponseWriter, r *http.Request) {
 	ctx := r.Context()
 
 	count, err := s.db.GetCachedArtifactCount()
 	if err != nil {
-		http.Error(w, "failed to get artifact count", http.StatusInternalServerError)
+		internalError(w, "failed to get artifact count")
 		return
 	}
 
 	size, err := s.db.GetTotalCacheSize()
 	if err != nil {
-		http.Error(w, "failed to get cache size", http.StatusInternalServerError)
+		internalError(w, "failed to get cache size")
 		return
 	}
 


### PR DESCRIPTION
API handlers returned errors via `http.Error` as text/plain with ad-hoc strings, while the mirror API used a different `{"error": "..."}` shape and leaked raw `err.Error()` to clients on job creation failure.

Adds `ErrorResponse{Code, Message}` in `internal/server/errors.go` with four stable codes (`BAD_REQUEST`, `NOT_FOUND`, `UPSTREAM_ERROR`, `INTERNAL_ERROR`) and `writeError` plus `badRequest`/`notFound`/`internalError` shorthands. All JSON API handlers in `api.go`, `browse.go`, `mirror_api.go` and the `/stats` endpoint now return:

```json
{"code": "NOT_FOUND", "message": "package not found"}
```

Enrichment failures now report 502 `UPSTREAM_ERROR` rather than 500, since the proxy itself is fine.

Two surfaces deliberately left as-is. Protocol handlers in `internal/handler/` serve real package-manager clients (npm, pip, cargo, etc.) that expect protocol-native responses, so JSON errors there would break installs. HTML page handlers in `server.go` (`showPackage`, `showVersion`, search/list pages) keep text/plain since they render templates, not JSON.

Swagger `@Failure` annotations updated to `{object} ErrorResponse` and `docs/swagger` regenerated.

Fixes #76