### PR TITLE
Verify cached artifacts on read

### DIFF
--- a/internal/handler/handler.go
+++ b/internal/handler/handler.go
@@ -188,7 +188,16 @@ func (p *Proxy) checkCache(ctx context.Context, pkgPURL, versionPURL, filename s
 		return nil, nil
 	}
 
-	result.Reader = reader
+	result.Reader = newVerifyingReader(reader, artifact.ContentHash.String, ver.Integrity.String,
+		func(reason string) {
+			p.Logger.Error("cached artifact failed integrity check",
+				"purl", versionPURL, "filename", filename,
+				"path", artifact.StoragePath.String, "reason", reason)
+			metrics.RecordIntegrityFailure(pkg.Ecosystem)
+			if err := p.DB.ClearArtifactCache(versionPURL, filename); err != nil {
+				p.Logger.Warn("failed to clear corrupt artifact from cache", "error", err)
+			}
+		})
 	p.recordCacheHit(pkgPURL, versionPURL, filename)
 	return result, nil
 }

--- a/internal/handler/integrity.go
+++ b/internal/handler/integrity.go
@@ -1,0 +1,140 @@
+package handler
+
+import (
+	"crypto/sha256"
+	"crypto/sha512"
+	"crypto/subtle"
+	"encoding/base64"
+	"encoding/hex"
+	"fmt"
+	"hash"
+	"io"
+	"strings"
+)
+
+// parseSRI parses a Subresource Integrity string (e.g. "sha512-abc==") into
+// an algorithm name and raw digest bytes. Returns ok=false for empty,
+// malformed, or unsupported entries. Only the first hash in a multi-hash
+// SRI string is considered.
+func parseSRI(s string) (algo string, digest []byte, ok bool) {
+	s = strings.TrimSpace(s)
+	if s == "" {
+		return "", nil, false
+	}
+	if i := strings.IndexByte(s, ' '); i >= 0 {
+		s = s[:i]
+	}
+	algo, b64, found := strings.Cut(s, "-")
+	if !found {
+		return "", nil, false
+	}
+	d, err := base64.StdEncoding.DecodeString(b64)
+	if err != nil {
+		return "", nil, false
+	}
+	switch algo {
+	case "sha256", "sha384", "sha512":
+		return algo, d, true
+	default:
+		return "", nil, false
+	}
+}
+
+func newSRIHash(algo string) hash.Hash {
+	switch algo {
+	case "sha256":
+		return sha256.New()
+	case "sha384":
+		return sha512.New384()
+	case "sha512":
+		return sha512.New()
+	}
+	return nil
+}
+
+// verifyingReader wraps an io.ReadCloser and computes SHA256 (and optionally
+// a second SRI hash) as bytes are read. When the underlying reader reaches
+// EOF it compares the digests against the expected values and calls
+// onMismatch for each failure. Verification is skipped if the stream was
+// not fully consumed (e.g. client disconnect) to avoid false positives.
+type verifyingReader struct {
+	r          io.ReadCloser
+	sha256     hash.Hash
+	wantSHA256 string
+	sri        hash.Hash
+	sriAlgo    string
+	wantSRI    []byte
+	onMismatch func(reason string)
+	eof        bool
+	verified   bool
+}
+
+func newVerifyingReader(r io.ReadCloser, contentHash, sri string, onMismatch func(string)) io.ReadCloser {
+	if contentHash == "" && sri == "" {
+		return r
+	}
+	v := &verifyingReader{
+		r:          r,
+		onMismatch: onMismatch,
+	}
+	if contentHash != "" {
+		v.sha256 = sha256.New()
+		v.wantSHA256 = contentHash
+	}
+	if algo, digest, ok := parseSRI(sri); ok {
+		v.sri = newSRIHash(algo)
+		v.sriAlgo = algo
+		v.wantSRI = digest
+	}
+	if v.sha256 == nil && v.sri == nil {
+		return r
+	}
+	return v
+}
+
+func (v *verifyingReader) Read(p []byte) (int, error) {
+	n, err := v.r.Read(p)
+	if n > 0 {
+		if v.sha256 != nil {
+			v.sha256.Write(p[:n])
+		}
+		if v.sri != nil {
+			v.sri.Write(p[:n])
+		}
+	}
+	if err == io.EOF {
+		v.eof = true
+		v.verify()
+	}
+	return n, err
+}
+
+func (v *verifyingReader) Close() error {
+	if v.eof {
+		v.verify()
+	}
+	return v.r.Close()
+}
+
+func (v *verifyingReader) verify() {
+	if v.verified {
+		return
+	}
+	v.verified = true
+
+	if v.sha256 != nil {
+		got := hex.EncodeToString(v.sha256.Sum(nil))
+		if subtle.ConstantTimeCompare([]byte(got), []byte(v.wantSHA256)) != 1 {
+			v.onMismatch(fmt.Sprintf("content_hash mismatch: stored=%s computed=%s", v.wantSHA256, got))
+		}
+	}
+	if v.sri != nil {
+		got := v.sri.Sum(nil)
+		if subtle.ConstantTimeCompare(got, v.wantSRI) != 1 {
+			v.onMismatch(fmt.Sprintf("integrity mismatch: %s expected=%s computed=%s",
+				v.sriAlgo,
+				base64.StdEncoding.EncodeToString(v.wantSRI),
+				base64.StdEncoding.EncodeToString(got)))
+		}
+	}
+}

--- a/internal/handler/integrity_test.go
+++ b/internal/handler/integrity_test.go
@@ -1,0 +1,136 @@
+package handler
+
+import (
+	"crypto/sha256"
+	"crypto/sha512"
+	"encoding/base64"
+	"encoding/hex"
+	"io"
+	"strings"
+	"testing"
+)
+
+func sha256Hex(data string) string {
+	sum := sha256.Sum256([]byte(data))
+	return hex.EncodeToString(sum[:])
+}
+
+func sha512SRI(data string) string {
+	sum := sha512.Sum512([]byte(data))
+	return "sha512-" + base64.StdEncoding.EncodeToString(sum[:])
+}
+
+func TestParseSRI(t *testing.T) {
+	tests := []struct {
+		name  string
+		input string
+		algo  string
+		ok    bool
+	}{
+		{"sha512", sha512SRI("hello"), "sha512", true},
+		{"sha256", "sha256-" + base64.StdEncoding.EncodeToString([]byte("0123456789012345678901234567890123456789")), "sha256", true},
+		{"empty", "", "", false},
+		{"no dash", "sha512abc", "", false},
+		{"bad base64", "sha512-not!base64", "", false},
+		{"unsupported algo", "md5-" + base64.StdEncoding.EncodeToString([]byte("x")), "", false},
+		{"multi hash takes first", sha512SRI("a") + " " + sha512SRI("b"), "sha512", true},
+		{"whitespace", "  " + sha512SRI("x") + "  ", "sha512", true},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			algo, digest, ok := parseSRI(tt.input)
+			if ok != tt.ok {
+				t.Fatalf("ok = %v, want %v", ok, tt.ok)
+			}
+			if !tt.ok {
+				return
+			}
+			if algo != tt.algo {
+				t.Errorf("algo = %q, want %q", algo, tt.algo)
+			}
+			if len(digest) == 0 {
+				t.Error("digest is empty")
+			}
+		})
+	}
+}
+
+func TestVerifyingReader(t *testing.T) {
+	const data = "hello world"
+	goodSHA := sha256Hex(data)
+	goodSRI := sha512SRI(data)
+
+	tests := []struct {
+		name      string
+		hash      string
+		sri       string
+		wantCalls int
+	}{
+		{"both match", goodSHA, goodSRI, 0},
+		{"sha256 only match", goodSHA, "", 0},
+		{"sri only match", "", goodSRI, 0},
+		{"sha256 mismatch", sha256Hex("other"), "", 1},
+		{"sri mismatch", "", sha512SRI("other"), 1},
+		{"both mismatch", sha256Hex("other"), sha512SRI("other"), 2},
+		{"no checks", "", "", 0},
+		{"unparseable sri ignored", goodSHA, "garbage", 0},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			var calls []string
+			r := newVerifyingReader(io.NopCloser(strings.NewReader(data)), tt.hash, tt.sri,
+				func(reason string) { calls = append(calls, reason) })
+
+			got, err := io.ReadAll(r)
+			if err != nil {
+				t.Fatalf("ReadAll: %v", err)
+			}
+			if string(got) != data {
+				t.Errorf("data corrupted: got %q", got)
+			}
+			if err := r.Close(); err != nil {
+				t.Fatalf("Close: %v", err)
+			}
+
+			if len(calls) != tt.wantCalls {
+				t.Errorf("onMismatch called %d times, want %d: %v", len(calls), tt.wantCalls, calls)
+			}
+		})
+	}
+}
+
+func TestVerifyingReaderPassthrough(t *testing.T) {
+	src := io.NopCloser(strings.NewReader("x"))
+	r := newVerifyingReader(src, "", "", func(string) { t.Fatal("should not be called") })
+	if r != src {
+		t.Error("expected passthrough when no hashes provided")
+	}
+}
+
+func TestVerifyingReaderPartialRead(t *testing.T) {
+	var calls int
+	r := newVerifyingReader(io.NopCloser(strings.NewReader("hello world")),
+		sha256Hex("hello world"), "", func(string) { calls++ })
+
+	buf := make([]byte, 5)
+	_, _ = r.Read(buf)
+	_ = r.Close()
+
+	if calls != 0 {
+		t.Errorf("onMismatch called %d times for partial read, want 0", calls)
+	}
+}
+
+func TestVerifyingReaderVerifyOnce(t *testing.T) {
+	var calls int
+	r := newVerifyingReader(io.NopCloser(strings.NewReader("x")), sha256Hex("y"), "",
+		func(string) { calls++ })
+	_, _ = io.ReadAll(r)
+	_ = r.Close()
+	_ = r.Close()
+	if calls != 1 {
+		t.Errorf("onMismatch called %d times, want 1", calls)
+	}
+}

--- a/internal/metrics/metrics.go
+++ b/internal/metrics/metrics.go
@@ -120,6 +120,14 @@ var (
 			Help: "Number of currently active requests",
 		},
 	)
+
+	IntegrityFailures = prometheus.NewCounterVec(
+		prometheus.CounterOpts{
+			Name: "proxy_integrity_failures_total",
+			Help: "Cached artifacts that failed hash verification on read",
+		},
+		[]string{"ecosystem"},
+	)
 )
 
 func init() {
@@ -138,6 +146,7 @@ func init() {
 		StorageOperationDuration,
 		StorageErrors,
 		ActiveRequests,
+		IntegrityFailures,
 	)
 }
 
@@ -176,6 +185,11 @@ func RecordUpstreamError(ecosystem, errorType string) {
 // RecordStorageOperation tracks storage operation duration.
 func RecordStorageOperation(operation string, duration time.Duration) {
 	StorageOperationDuration.WithLabelValues(operation).Observe(duration.Seconds())
+}
+
+// RecordIntegrityFailure increments the integrity failure counter.
+func RecordIntegrityFailure(ecosystem string) {
+	IntegrityFailures.WithLabelValues(ecosystem).Inc()
 }
 
 // RecordStorageError increments storage error counter.


### PR DESCRIPTION
Part 1 of #42.

`checkCache` opened the storage reader and streamed it to the client without checking that the bytes still matched what was originally stored, or what the upstream registry declared. Disk corruption, accidental overwrites, or local tampering would be served silently.

Adds `verifyingReader` in `internal/handler/integrity.go` which wraps the storage `io.ReadCloser` and computes SHA256 (compared against `artifact.content_hash`) plus, when `version.integrity` holds an SRI string, the matching sha256/384/512 digest. Hashing happens as bytes stream through so there's no extra read pass or buffering. At EOF the digests are compared and on mismatch the callback fires: error log, `proxy_integrity_failures_total{ecosystem}` increments, and `ClearArtifactCache` nulls the storage path so the next request refetches from upstream.

The client still receives the bad bytes on that one request since we don't know the hash until EOF. In practice every package manager verifies its own checksum and will reject the download, and the cache self-heals on the retry. Verification is skipped when the stream wasn't fully consumed (client disconnect mid-download) so a partial read can't evict a good artifact.

Not covered here: the DirectServe presigned-URL path, where the proxy never sees the bytes. That and parts 2/3 (sigstore attestations, peer verification) are follow-ups.

I looked at using `archives.Reader.Hash` from v0.3.0 but it needs the bytes in memory; `checkCache` streams, so a tee-through-hash wrapper is the better fit here. The archives method will be useful for the browse path where we already buffer.