### PR TITLE
Add PROXY_UI_URL for separate UI/package URL advertisement

### DIFF
--- a/README.md
+++ b/README.md
@@ -424,6 +424,7 @@ The proxy can be configured via:
 ```bash
 PROXY_LISTEN=:8080
 PROXY_BASE_URL=http://localhost:8080
+PROXY_UI_URL=http://localhost:8080  # Optional; defaults to PROXY_BASE_URL
 PROXY_STORAGE_URL=file:///var/cache/proxy/artifacts
 PROXY_DATABASE_DRIVER=sqlite
 PROXY_DATABASE_PATH=./cache/proxy.db
@@ -934,47 +935,45 @@ When running behind nginx, Apache, or another reverse proxy, set `base_url` to y
 base_url: "https://proxy.example.com"
 ```
 
-nginx example:
+If the UI is reached on a different hostname than the package endpoints — for example, the UI exposed publicly on a domain while build machines hit a Docker network alias — set `ui_base_url` separately. `base_url` is the URL package managers and metadata rewriting use; `ui_base_url` is the URL advertised to humans visiting the web UI (canonical/`og:url` tags and the install guide banner):
+
+```yaml
+base_url: "http://pkg-proxy:8080"        # internal alias for build machines
+ui_base_url: "https://proxy.example.com/ui"  # public UI URL
+```
+
+When unset, `ui_base_url` defaults to `base_url`.
+
+> **Warning:** the proxy serves the UI and package endpoints on the same listener. Setting `ui_base_url` only changes what URL the UI advertises to humans; it does not stop package endpoints from being reachable on the same hostname and port. When fronting the proxy with a public reverse proxy, restrict the public route to `PathPrefix(/ui)` (or your proxy's equivalent), otherwise `/npm`, `/pypi`, and the other package endpoints stay exposed alongside the UI.
+
+nginx example, restricting the public host to the UI while leaving package endpoints reachable only on the internal listener:
 
 ```nginx
 server {
     listen 443 ssl;
     server_name proxy.example.com;
 
-    location / {
+    location /ui/ {
         proxy_pass http://127.0.0.1:8080;
         proxy_set_header Host $host;
         proxy_set_header X-Real-IP $remote_addr;
         proxy_buffering off;
+    }
+
+    location / {
+        return 404;
     }
 }
 ```
 
-The UI is mounted under `/ui` so you can apply different access rules to it than to the package endpoints — for example, require auth for humans browsing the UI while leaving `/npm`, `/pypi`, and other package endpoints open to unauthenticated build machines:
+Traefik example using `PathPrefix(/ui)` so the public router only matches UI traffic:
 
-```nginx
-server {
-    listen 443 ssl;
-    server_name proxy.example.com;
-
-    # Web UI — require auth
-    location /ui/ {
-        auth_basic "git-pkgs proxy";
-        auth_basic_user_file /etc/nginx/.htpasswd;
-        proxy_pass http://127.0.0.1:8080;
-        proxy_set_header Host $host;
-        proxy_set_header X-Real-IP $remote_addr;
-        proxy_buffering off;
-    }
-
-    # Package endpoints — open to build machines
-    location / {
-        proxy_pass http://127.0.0.1:8080;
-        proxy_set_header Host $host;
-        proxy_set_header X-Real-IP $remote_addr;
-        proxy_buffering off;
-    }
-}
+```yaml
+labels:
+  traefik.enable: "true"
+  traefik.http.services.pkg-proxy.loadbalancer.server.port: "8080"
+  traefik.http.routers.pkg-proxy.rule: "Host(`proxy.example.com`) && PathPrefix(`/ui`)"
+  traefik.http.routers.pkg-proxy.entrypoints: "websecure"
 ```
 
 ## Cache Management

--- a/config.example.yaml
+++ b/config.example.yaml
@@ -4,9 +4,16 @@
 # Server listen address
 listen: ":8080"
 
-# Public URL where this proxy is accessible
-# Used for rewriting package metadata URLs
+# Public URL where package endpoints are reachable.
+# Used for rewriting package metadata URLs and shown in install guide snippets
+# so users know what to point their package manager at.
 base_url: "http://localhost:8080"
+
+# Public URL where the web UI is reached. Defaults to base_url when unset.
+# Set this separately when the UI is served on a different hostname than the
+# package endpoints — for example, the UI on a public domain behind auth while
+# build machines hit a Docker network alias for the package endpoints.
+# ui_base_url: "https://proxy.example.com/ui"
 
 # Artifact storage configuration
 storage:

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -17,7 +17,8 @@ See `config.example.yaml` in the repository root for a complete example.
 | Config | Environment | Flag | Default | Description |
 |--------|-------------|------|---------|-------------|
 | `listen` | `PROXY_LISTEN` | `-listen` | `:8080` | Address to listen on |
-| `base_url` | `PROXY_BASE_URL` | `-base-url` | `http://localhost:8080` | Public URL for the proxy |
+| `base_url` | `PROXY_BASE_URL` | `-base-url` | `http://localhost:8080` | Public URL package managers use to reach this proxy |
+| `ui_base_url` | `PROXY_UI_URL` | - | (defaults to `base_url`) | Public URL where the web UI is reached. Set separately when the UI lives behind a different hostname than package endpoints (e.g. public domain vs Docker network alias). Used for canonical/og:url tags and the install guide banner. The proxy still serves package endpoints on the same listener, so any reverse proxy fronting the UI publicly should restrict the public route to `PathPrefix(/ui)` to avoid exposing package endpoints. |
 
 ## Storage
 

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -66,10 +66,19 @@ type Config struct {
 	// Listen is the address to listen on (e.g., ":8080", "127.0.0.1:8080").
 	Listen string `json:"listen" yaml:"listen"`
 
-	// BaseURL is the public URL where this proxy is accessible.
-	// Used for rewriting package metadata URLs.
+	// BaseURL is the public URL where package endpoints are reachable.
+	// Used for rewriting package metadata URLs and shown to humans on the
+	// install guide so they know what to point their package manager at.
 	// Example: "https://proxy.example.com" or "http://localhost:8080"
 	BaseURL string `json:"base_url" yaml:"base_url"`
+
+	// UIBaseURL is the public URL where the web UI is reachable. Defaults to
+	// BaseURL when unset. Set this separately when the UI is served on a
+	// different hostname than the package endpoints — for example, the UI on a
+	// public domain behind auth while build machines hit a Docker network alias
+	// for the package endpoints.
+	// Example: "https://proxy.example.com/ui"
+	UIBaseURL string `json:"ui_base_url" yaml:"ui_base_url"`
 
 	// Storage configures artifact storage.
 	Storage StorageConfig `json:"storage" yaml:"storage"`
@@ -365,6 +374,7 @@ func Load(path string) (*Config, error) {
 // Environment variables use the PROXY_ prefix:
 //   - PROXY_LISTEN
 //   - PROXY_BASE_URL
+//   - PROXY_UI_URL
 //   - PROXY_STORAGE_PATH
 //   - PROXY_STORAGE_MAX_SIZE
 //   - PROXY_DATABASE_PATH
@@ -377,6 +387,9 @@ func (c *Config) LoadFromEnv() {
 	}
 	if v := os.Getenv("PROXY_BASE_URL"); v != "" {
 		c.BaseURL = v
+	}
+	if v := os.Getenv("PROXY_UI_URL"); v != "" {
+		c.UIBaseURL = v
 	}
 	if v := os.Getenv("PROXY_STORAGE_URL"); v != "" {
 		c.Storage.URL = v
@@ -452,6 +465,16 @@ func (c *Config) LoadFromEnv() {
 	}
 }
 
+// validateAbsoluteURL returns an error if value is not a parseable URL with
+// both a scheme and host. fieldName is used in the error message.
+func validateAbsoluteURL(fieldName, value string) error {
+	u, err := url.Parse(value)
+	if err != nil || u.Scheme == "" || u.Host == "" {
+		return fmt.Errorf("invalid %s %q: must be an absolute URL", fieldName, value)
+	}
+	return nil
+}
+
 // Validate checks the configuration for errors.
 func (c *Config) Validate() error {
 	if c.Listen == "" {
@@ -459,6 +482,11 @@ func (c *Config) Validate() error {
 	}
 	if c.BaseURL == "" {
 		return fmt.Errorf("base_url is required")
+	}
+	if c.UIBaseURL == "" {
+		c.UIBaseURL = c.BaseURL
+	} else if err := validateAbsoluteURL("ui_base_url", c.UIBaseURL); err != nil {
+		return err
 	}
 	if c.Storage.URL == "" && c.Storage.Path == "" {
 		return fmt.Errorf("storage.url or storage.path is required")
@@ -508,9 +536,8 @@ func (c *Config) Validate() error {
 
 	// Validate direct serve base URL if specified
 	if c.Storage.DirectServeBaseURL != "" {
-		u, err := url.Parse(c.Storage.DirectServeBaseURL)
-		if err != nil || u.Scheme == "" || u.Host == "" {
-			return fmt.Errorf("invalid storage.direct_serve_base_url %q: must be an absolute URL", c.Storage.DirectServeBaseURL)
+		if err := validateAbsoluteURL("storage.direct_serve_base_url", c.Storage.DirectServeBaseURL); err != nil {
+			return err
 		}
 	}
 

--- a/internal/config/config_test.go
+++ b/internal/config/config_test.go
@@ -268,6 +268,7 @@ func TestLoadFromEnv(t *testing.T) {
 
 	t.Setenv("PROXY_LISTEN", ":9000")
 	t.Setenv("PROXY_BASE_URL", "https://env.example.com")
+	t.Setenv("PROXY_UI_URL", "https://ui.env.example.com/ui")
 	t.Setenv("PROXY_STORAGE_PATH", "/env/cache")
 	t.Setenv("PROXY_LOG_LEVEL", testLevelDebug)
 	t.Setenv("PROXY_UPSTREAM_MAVEN", "https://maven.example.com/repository/maven-public")
@@ -285,6 +286,9 @@ func TestLoadFromEnv(t *testing.T) {
 	}
 	if cfg.BaseURL != "https://env.example.com" {
 		t.Errorf("BaseURL = %q, want %q", cfg.BaseURL, "https://env.example.com")
+	}
+	if cfg.UIBaseURL != "https://ui.env.example.com/ui" {
+		t.Errorf("UIBaseURL = %q, want %q", cfg.UIBaseURL, "https://ui.env.example.com/ui")
 	}
 	if cfg.Storage.Path != "/env/cache" {
 		t.Errorf("Storage.Path = %q, want %q", cfg.Storage.Path, "/env/cache")
@@ -617,6 +621,40 @@ func TestLoadDirectServeFromEnv(t *testing.T) {
 	}
 	if cfg.Storage.DirectServeBaseURL != "https://cdn.example.com" {
 		t.Errorf("Storage.DirectServeBaseURL = %q, want %q", cfg.Storage.DirectServeBaseURL, "https://cdn.example.com")
+	}
+}
+
+func TestValidateUIBaseURLDefaultsToBaseURL(t *testing.T) {
+	cfg := Default()
+	cfg.BaseURL = "https://proxy.example.com"
+	cfg.UIBaseURL = ""
+
+	if err := cfg.Validate(); err != nil {
+		t.Fatalf("unexpected validation error: %v", err)
+	}
+	if cfg.UIBaseURL != "https://proxy.example.com" {
+		t.Errorf("UIBaseURL = %q, want it to default to BaseURL %q", cfg.UIBaseURL, "https://proxy.example.com")
+	}
+}
+
+func TestValidateUIBaseURL(t *testing.T) {
+	cfg := Default()
+
+	cfg.UIBaseURL = "not a url"
+	if err := cfg.Validate(); err == nil {
+		t.Error("expected validation error for relative ui_base_url")
+	}
+
+	cfg = Default()
+	cfg.UIBaseURL = "://bad"
+	if err := cfg.Validate(); err == nil {
+		t.Error("expected validation error for unparseable ui_base_url")
+	}
+
+	cfg = Default()
+	cfg.UIBaseURL = "https://ui.example.com/ui"
+	if err := cfg.Validate(); err != nil {
+		t.Errorf("unexpected error for valid ui_base_url: %v", err)
 	}
 }
 

--- a/internal/server/browse.go
+++ b/internal/server/browse.go
@@ -478,6 +478,7 @@ func isLikelyText(filename string) bool {
 
 // BrowseSourceData contains data for the browse source page.
 type BrowseSourceData struct {
+	Layout
 	Ecosystem   string
 	PackageName string
 	Version     string
@@ -583,6 +584,7 @@ func (s *Server) compareDiff(w http.ResponseWriter, r *http.Request, ecosystem, 
 
 // ComparePageData contains data for the version comparison page.
 type ComparePageData struct {
+	Layout
 	Ecosystem   string
 	PackageName string
 	FromVersion string

--- a/internal/server/dashboard.go
+++ b/internal/server/dashboard.go
@@ -8,6 +8,7 @@ import (
 
 // DashboardData contains data for rendering the dashboard.
 type DashboardData struct {
+	Layout
 	Stats           DashboardStats
 	EnrichmentStats EnrichmentStatsView
 	RecentPackages  []PackageInfo
@@ -60,6 +61,7 @@ type RegistryConfig struct {
 
 // PackageShowData contains data for rendering the package show page.
 type PackageShowData struct {
+	Layout
 	Package         *database.Package
 	Versions        []database.Version
 	Vulnerabilities []database.Vulnerability
@@ -68,6 +70,7 @@ type PackageShowData struct {
 
 // VersionShowData contains data for rendering the version show page.
 type VersionShowData struct {
+	Layout
 	Package           *database.Package
 	Version           *database.Version
 	Artifacts         []database.Artifact
@@ -79,6 +82,7 @@ type VersionShowData struct {
 
 // SearchPageData contains data for rendering the search results page.
 type SearchPageData struct {
+	Layout
 	Query      string
 	Ecosystem  string
 	Results    []SearchResultItem
@@ -104,6 +108,7 @@ type SearchResultItem struct {
 
 // PackagesListPageData contains data for rendering the packages list page.
 type PackagesListPageData struct {
+	Layout
 	Ecosystem  string
 	SortBy     string
 	Results    []SearchResultItem

--- a/internal/server/layout.go
+++ b/internal/server/layout.go
@@ -1,0 +1,19 @@
+package server
+
+import "net/http"
+
+// Layout carries per-request fields consumed by the shared base template
+// (canonical URL, og:url). It is embedded in every page data struct so that
+// templates can reference {{.UIBaseURL}} and {{.CanonicalPath}} alongside the
+// page's own fields.
+type Layout struct {
+	UIBaseURL     string
+	CanonicalPath string
+}
+
+func (s *Server) layoutFor(r *http.Request) Layout {
+	return Layout{
+		UIBaseURL:     s.cfg.UIBaseURL,
+		CanonicalPath: r.URL.Path,
+	}
+}

--- a/internal/server/server.go
+++ b/internal/server/server.go
@@ -300,6 +300,7 @@ func (s *Server) Start() error {
 	s.logger.Info("starting server",
 		"listen", s.cfg.Listen,
 		"base_url", s.cfg.BaseURL,
+		"ui_url", s.cfg.UIBaseURL,
 		"storage", s.storage.URL(),
 		"database", s.cfg.Database.Path)
 	go s.updateCacheStatsMetrics()
@@ -402,6 +403,7 @@ func (s *Server) handleRoot(w http.ResponseWriter, r *http.Request) {
 
 	// Build dashboard data
 	data := DashboardData{
+		Layout: s.layoutFor(r),
 		Stats: DashboardStats{
 			CachedArtifacts: stats.TotalArtifacts,
 			TotalSize:       formatSize(stats.TotalSize),
@@ -488,8 +490,12 @@ func (s *Server) handleOpenAPIJSON(w http.ResponseWriter, _ *http.Request) {
 
 func (s *Server) handleInstall(w http.ResponseWriter, r *http.Request) {
 	data := struct {
+		Layout
+		BaseURL    string
 		Registries []RegistryConfig
 	}{
+		Layout:     s.layoutFor(r),
+		BaseURL:    s.cfg.BaseURL,
 		Registries: getRegistryConfigs(s.cfg.BaseURL),
 	}
 
@@ -552,6 +558,7 @@ func (s *Server) handleSearch(w http.ResponseWriter, r *http.Request) {
 	totalPages := int((total + int64(limit) - 1) / int64(limit))
 
 	data := SearchPageData{
+		Layout:     s.layoutFor(r),
 		Query:      query,
 		Ecosystem:  ecosystem,
 		Results:    items,
@@ -627,6 +634,7 @@ func (s *Server) handlePackagesList(w http.ResponseWriter, r *http.Request) {
 	totalPages := int((total + int64(limit) - 1) / int64(limit))
 
 	data := PackagesListPageData{
+		Layout:     s.layoutFor(r),
 		Ecosystem:  ecosystem,
 		SortBy:     sortBy,
 		Results:    items,
@@ -670,7 +678,7 @@ func (s *Server) handlePackagePath(w http.ResponseWriter, r *http.Request) {
 		if seg == "compare" && i > 0 && i < len(segments)-1 {
 			name := strings.Join(segments[:i], "/")
 			versions := strings.Join(segments[i+1:], "/")
-			s.showComparePage(w, ecosystem, name, versions)
+			s.showComparePage(w, r, ecosystem, name, versions)
 			return
 		}
 	}
@@ -690,7 +698,7 @@ func (s *Server) handlePackagePath(w http.ResponseWriter, r *http.Request) {
 		// segment is a version (if present) and everything else is the name.
 		if len(segments) == 1 {
 			// Single segment, no DB match: try package show (will 404).
-			s.showPackage(w, ecosystem, segments[0])
+			s.showPackage(w, r, ecosystem, segments[0])
 			return
 		}
 		name = strings.Join(segments[:len(segments)-1], "/")
@@ -699,17 +707,17 @@ func (s *Server) handlePackagePath(w http.ResponseWriter, r *http.Request) {
 
 	switch {
 	case len(rest) == 0 && !browse:
-		s.showPackage(w, ecosystem, name)
+		s.showPackage(w, r, ecosystem, name)
 	case len(rest) == 1 && browse:
-		s.showBrowseSource(w, ecosystem, name, rest[0])
+		s.showBrowseSource(w, r, ecosystem, name, rest[0])
 	case len(rest) == 1:
-		s.showVersion(w, ecosystem, name, rest[0])
+		s.showVersion(w, r, ecosystem, name, rest[0])
 	default:
 		http.Error(w, "not found", http.StatusNotFound)
 	}
 }
 
-func (s *Server) showPackage(w http.ResponseWriter, ecosystem, name string) {
+func (s *Server) showPackage(w http.ResponseWriter, r *http.Request, ecosystem, name string) {
 	pkg, err := s.db.GetPackageByEcosystemName(ecosystem, name)
 	if err != nil {
 		s.logger.Error("failed to get package", "error", err, "ecosystem", ecosystem, "name", name)
@@ -734,6 +742,7 @@ func (s *Server) showPackage(w http.ResponseWriter, ecosystem, name string) {
 	}
 
 	data := PackageShowData{
+		Layout:          s.layoutFor(r),
 		Package:         pkg,
 		Versions:        versions,
 		Vulnerabilities: vulns,
@@ -745,7 +754,7 @@ func (s *Server) showPackage(w http.ResponseWriter, ecosystem, name string) {
 	}
 }
 
-func (s *Server) showVersion(w http.ResponseWriter, ecosystem, name, version string) {
+func (s *Server) showVersion(w http.ResponseWriter, r *http.Request, ecosystem, name, version string) {
 	pkg, err := s.db.GetPackageByEcosystemName(ecosystem, name)
 	if err != nil || pkg == nil {
 		s.logger.Error("failed to get package", "error", err)
@@ -784,6 +793,7 @@ func (s *Server) showVersion(w http.ResponseWriter, ecosystem, name, version str
 	}
 
 	data := VersionShowData{
+		Layout:            s.layoutFor(r),
 		Package:           pkg,
 		Version:           ver,
 		Artifacts:         artifacts,
@@ -798,8 +808,9 @@ func (s *Server) showVersion(w http.ResponseWriter, ecosystem, name, version str
 	}
 }
 
-func (s *Server) showBrowseSource(w http.ResponseWriter, ecosystem, name, version string) {
+func (s *Server) showBrowseSource(w http.ResponseWriter, r *http.Request, ecosystem, name, version string) {
 	data := BrowseSourceData{
+		Layout:      s.layoutFor(r),
 		Ecosystem:   ecosystem,
 		PackageName: name,
 		Version:     version,
@@ -811,7 +822,7 @@ func (s *Server) showBrowseSource(w http.ResponseWriter, ecosystem, name, versio
 	}
 }
 
-func (s *Server) showComparePage(w http.ResponseWriter, ecosystem, name, versions string) {
+func (s *Server) showComparePage(w http.ResponseWriter, r *http.Request, ecosystem, name, versions string) {
 	const compareVersionParts = 2
 	parts := strings.Split(versions, "...")
 	if len(parts) != compareVersionParts {
@@ -820,6 +831,7 @@ func (s *Server) showComparePage(w http.ResponseWriter, ecosystem, name, version
 	}
 
 	data := ComparePageData{
+		Layout:      s.layoutFor(r),
 		Ecosystem:   ecosystem,
 		PackageName: name,
 		FromVersion: parts[0],

--- a/internal/server/templates/layout/base.html
+++ b/internal/server/templates/layout/base.html
@@ -5,6 +5,12 @@
     <meta charset="UTF-8">
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
     <title>{{block "title" .}}git-pkgs proxy{{end}}</title>
+    {{if .UIBaseURL}}
+    <link rel="canonical" href="{{.UIBaseURL}}{{.CanonicalPath}}">
+    <meta property="og:url" content="{{.UIBaseURL}}{{.CanonicalPath}}">
+    <meta property="og:title" content="{{template "title" .}}">
+    <meta property="og:site_name" content="git-pkgs proxy">
+    {{end}}
     <script src="/ui/static/tailwind.js"></script>
     <script>
       tailwind.config = { darkMode: 'class' }

--- a/internal/server/templates/pages/install.html
+++ b/internal/server/templates/pages/install.html
@@ -8,6 +8,15 @@
     </p>
 </div>
 
+{{if and .UIBaseURL .BaseURL (ne .UIBaseURL .BaseURL)}}
+<div class="mb-8 p-4 bg-amber-50 dark:bg-amber-950 border border-amber-200 dark:border-amber-900 rounded-xl text-sm">
+    <p class="text-amber-900 dark:text-amber-100">
+        This UI is hosted at <code class="font-mono">{{.UIBaseURL}}</code>, but package managers should be configured to use
+        <code class="font-mono">{{.BaseURL}}</code> for the URLs shown below.
+    </p>
+</div>
+{{end}}
+
 <div class="bg-white dark:bg-gray-900 rounded-xl shadow-sm border border-gray-200 dark:border-gray-800">
     <div class="divide-y divide-gray-200 dark:divide-gray-800">
         {{range .Registries}}

--- a/internal/server/templates_test.go
+++ b/internal/server/templates_test.go
@@ -37,7 +37,12 @@ func TestTemplatesRenderAllPages(t *testing.T) {
 				{Ecosystem: "cargo", Name: "serde", Version: "1.0.0", Size: "200 KB", CachedAt: "1 hour ago"},
 			},
 		}},
-		{"install", struct{ Registries []RegistryConfig }{
+		{"install", struct {
+			Layout
+			BaseURL    string
+			Registries []RegistryConfig
+		}{
+			BaseURL:    "http://localhost:8080",
 			Registries: getRegistryConfigs("http://localhost:8080"),
 		}},
 		{"search", SearchPageData{
@@ -150,6 +155,108 @@ func TestTemplatesRenderAllPages(t *testing.T) {
 				t.Error("rendered page doesn't look like HTML")
 			}
 		})
+	}
+}
+
+func TestRenderEmitsCanonicalAndOG(t *testing.T) {
+	templates := &Templates{}
+
+	data := DashboardData{
+		Layout: Layout{
+			UIBaseURL:     "https://ui.example.com/ui",
+			CanonicalPath: "/ui/",
+		},
+	}
+
+	w := httptest.NewRecorder()
+	if err := templates.Render(w, "dashboard", data); err != nil {
+		t.Fatalf("Render failed: %v", err)
+	}
+
+	body := w.Body.String()
+	want := []string{
+		`<link rel="canonical" href="https://ui.example.com/ui/ui/">`,
+		`<meta property="og:url" content="https://ui.example.com/ui/ui/">`,
+		`<meta property="og:site_name" content="git-pkgs proxy">`,
+	}
+	for _, s := range want {
+		if !strings.Contains(body, s) {
+			t.Errorf("rendered body missing %q", s)
+		}
+	}
+}
+
+func TestRenderOmitsCanonicalWhenUIBaseURLUnset(t *testing.T) {
+	templates := &Templates{}
+
+	w := httptest.NewRecorder()
+	if err := templates.Render(w, "dashboard", DashboardData{}); err != nil {
+		t.Fatalf("Render failed: %v", err)
+	}
+
+	body := w.Body.String()
+	if strings.Contains(body, `rel="canonical"`) {
+		t.Error("canonical tag should be omitted when UIBaseURL is empty")
+	}
+	if strings.Contains(body, `property="og:url"`) {
+		t.Error("og:url tag should be omitted when UIBaseURL is empty")
+	}
+}
+
+func TestInstallPageBannerWhenUIDiffersFromBaseURL(t *testing.T) {
+	templates := &Templates{}
+
+	data := struct {
+		Layout
+		BaseURL    string
+		Registries []RegistryConfig
+	}{
+		Layout: Layout{
+			UIBaseURL:     "https://ui.example.com/ui",
+			CanonicalPath: "/ui/install",
+		},
+		BaseURL:    "http://pkg-proxy:8080",
+		Registries: getRegistryConfigs("http://pkg-proxy:8080"),
+	}
+
+	w := httptest.NewRecorder()
+	if err := templates.Render(w, "install", data); err != nil {
+		t.Fatalf("Render failed: %v", err)
+	}
+
+	body := w.Body.String()
+	if !strings.Contains(body, "https://ui.example.com/ui") || !strings.Contains(body, "http://pkg-proxy:8080") {
+		t.Error("install banner should mention both UIBaseURL and BaseURL when they differ")
+	}
+	if !strings.Contains(body, "package managers should be configured") {
+		t.Error("install banner copy missing")
+	}
+}
+
+func TestInstallPageNoBannerWhenURLsMatch(t *testing.T) {
+	templates := &Templates{}
+
+	data := struct {
+		Layout
+		BaseURL    string
+		Registries []RegistryConfig
+	}{
+		Layout: Layout{
+			UIBaseURL:     "http://localhost:8080",
+			CanonicalPath: "/ui/install",
+		},
+		BaseURL:    "http://localhost:8080",
+		Registries: getRegistryConfigs("http://localhost:8080"),
+	}
+
+	w := httptest.NewRecorder()
+	if err := templates.Render(w, "install", data); err != nil {
+		t.Fatalf("Render failed: %v", err)
+	}
+
+	body := w.Body.String()
+	if strings.Contains(body, "package managers should be configured") {
+		t.Error("install banner should be hidden when UIBaseURL == BaseURL")
 	}
 }
 


### PR DESCRIPTION
Addresses the dual-URL ask from https://github.com/git-pkgs/proxy/issues/123#issuecomment-4529587861.

Adds `UIBaseURL` (env `PROXY_UI_URL`), advertised separately from `BaseURL` for deployments where the UI is reached on a public domain (behind auth) while build machines hit a Docker network alias for the package endpoints. Defaults to `BaseURL` when unset.

Consumers in this PR:

- Logged alongside `base_url` at startup.
- `<link rel="canonical">` and `og:url` / `og:title` / `og:site_name` in every UI page, omitted when `UIBaseURL` is empty.
- Banner on the install guide when `UIBaseURL` differs from `BaseURL`, clarifying that the URLs in the snippets are the package endpoint and that the UI itself lives elsewhere.

`BaseURL` keeps its existing meaning: the URL that package managers and metadata rewriting use.

Docs also call out the same-port caveat raised in https://github.com/git-pkgs/proxy/issues/123#issuecomment-4640233760: setting `ui_base_url` only changes what URL the UI advertises, the listener still serves package endpoints, so any reverse proxy fronting the UI publicly must restrict the public route to `PathPrefix(/ui)`. nginx and Traefik examples in the README show the pattern.