### PR TITLE
Log actual database config instead of sqlite path

### DIFF
--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -219,6 +219,21 @@ type DatabaseConfig struct {
 	URL string `json:"url" yaml:"url"`
 }
 
+// String returns a human-readable description of the configured database
+// suitable for logging. For postgres the password in the connection URL is
+// redacted; if the URL cannot be parsed only the driver name is returned to
+// avoid leaking credentials.
+func (d DatabaseConfig) String() string {
+	if d.Driver == "postgres" {
+		u, err := url.Parse(d.URL)
+		if err != nil || u.Host == "" {
+			return "postgres"
+		}
+		return u.Redacted()
+	}
+	return d.Path
+}
+
 // LogConfig configures logging.
 type LogConfig struct {
 	// Level is the minimum log level: "debug", "info", "warn", "error".

--- a/internal/config/config_test.go
+++ b/internal/config/config_test.go
@@ -676,3 +676,24 @@ func TestValidateDirectServeBaseURL(t *testing.T) {
 		t.Errorf("unexpected error for valid direct_serve_base_url: %v", err)
 	}
 }
+
+func TestDatabaseConfigString(t *testing.T) {
+	tests := []struct {
+		name string
+		cfg  DatabaseConfig
+		want string
+	}{
+		{"sqlite", DatabaseConfig{Driver: "sqlite", Path: "./cache/proxy.db"}, "./cache/proxy.db"},
+		{"default driver", DatabaseConfig{Path: "/var/lib/proxy.db"}, "/var/lib/proxy.db"},
+		{"postgres no password", DatabaseConfig{Driver: "postgres", URL: "postgres://user@localhost:5432/proxy"}, "postgres://user@localhost:5432/proxy"},
+		{"postgres redacts password", DatabaseConfig{Driver: "postgres", URL: "postgres://user:secret@localhost:5432/proxy?sslmode=disable"}, "postgres://user:xxxxx@localhost:5432/proxy?sslmode=disable"},
+		{"postgres unparseable url", DatabaseConfig{Driver: "postgres", URL: "host=localhost user=foo password=bar"}, "postgres"},
+		{"postgres ignores sqlite path", DatabaseConfig{Driver: "postgres", URL: "postgres://localhost/db", Path: "./cache/proxy.db"}, "postgres://localhost/db"},
+	}
+
+	for _, tt := range tests {
+		if got := tt.cfg.String(); got != tt.want {
+			t.Errorf("%s: String() = %q, want %q", tt.name, got, tt.want)
+		}
+	}
+}

--- a/internal/server/server.go
+++ b/internal/server/server.go
@@ -302,7 +302,7 @@ func (s *Server) Start() error {
 		"base_url", s.cfg.BaseURL,
 		"ui_url", s.cfg.UIBaseURL,
 		"storage", s.storage.URL(),
-		"database", s.cfg.Database.Path)
+		"database", s.cfg.Database.String())
 	go s.updateCacheStatsMetrics()
 	go s.startEvictionLoop(bgCtx)
 
@@ -927,7 +927,7 @@ func (s *Server) handleStats(w http.ResponseWriter, r *http.Request) {
 		TotalSize:       size,
 		TotalSizeHuman:  formatSize(size),
 		StorageURL:      s.storage.URL(),
-		DatabasePath:    s.cfg.Database.Path,
+		DatabasePath:    s.cfg.Database.String(),
 	}
 
 	w.Header().Set("Content-Type", "application/json")


### PR DESCRIPTION
The startup log and `/stats` endpoint always reported `Database.Path`, which defaults to `./cache/proxy.db` even when `PROXY_DATABASE_DRIVER=postgres` and `PROXY_DATABASE_URL` are set and postgres is actually in use.

This adds `DatabaseConfig.String()` which returns the sqlite path for the sqlite driver, or the postgres connection URL with the password redacted (falling back to just `postgres` if the URL isn't in `postgres://` form, to avoid leaking key=value DSN credentials). Both the startup log and `/stats` now use it.

The `/stats` JSON field is still named `database_path` to avoid breaking existing consumers.

Fixes #173