### PR TITLE
Multi container registry support

### DIFF
--- a/internal/handler/container.go
+++ b/internal/handler/container.go
@@ -89,23 +89,26 @@ func (h *ContainerHandler) handleBlobDownload(w http.ResponseWriter, r *http.Req
 
 	h.proxy.Logger.Info("container blob request", "name", name, "digest", digest)
 
-	// Get auth token for upstream
-	token, err := h.getAuthToken(r.Context(), name, "pull")
-	if err != nil {
-		h.proxy.Logger.Error("failed to get auth token", "error", err)
-		h.containerError(w, http.StatusUnauthorized, "UNAUTHORIZED", "failed to authenticate")
+	// For HEAD requests, just proxy to upstream
+	if r.Method == http.MethodHead {
+		h.proxyBlobHead(w, r, name, digest)
 		return
 	}
 
-	// For HEAD requests, just proxy to upstream
-	if r.Method == http.MethodHead {
-		h.proxyBlobHead(w, r, name, digest, token)
-		return
-	}
+	var headers http.Header
+
+		// Get auth token for upstream
+		token, err := h.getAuthToken(r.Context(), name, "pull")
+		if err != nil {
+			h.proxy.Logger.Error("failed to get auth token", "error", err)
+			h.containerError(w, http.StatusUnauthorized, "UNAUTHORIZED", "failed to authenticate")
+			return
+		}
+
+		headers = http.Header{"Authorization": {"Bearer " + token}}
 
 	// Try to get from cache, or fetch from upstream with auth
 	filename := digest
-	headers := http.Header{"Authorization": {"Bearer " + token}}
 	result, err := h.proxy.GetOrFetchArtifactFromURLWithHeaders(
 		r.Context(),
 		"oci",
@@ -144,14 +147,6 @@ func (h *ContainerHandler) handleManifest(w http.ResponseWriter, r *http.Request
 
 	h.proxy.Logger.Info("container manifest request", "name", name, "reference", reference)
 
-	// Get auth token
-	token, err := h.getAuthToken(r.Context(), name, "pull")
-	if err != nil {
-		h.proxy.Logger.Error("failed to get auth token", "error", err)
-		h.containerError(w, http.StatusUnauthorized, "UNAUTHORIZED", "failed to authenticate")
-		return
-	}
-
 	// Proxy to upstream
 	upstreamURL := fmt.Sprintf("%s/v2/%s/manifests/%s", h.registryURL, name, reference)
 
@@ -161,7 +156,11 @@ func (h *ContainerHandler) handleManifest(w http.ResponseWriter, r *http.Request
 		return
 	}
 
-	req.Header.Set("Authorization", "Bearer "+token)
+	if err := h.authReq(req, name); err != nil {
+		h.proxy.Logger.Error("failed to get auth token", "error", err)
+		h.containerError(w, http.StatusUnauthorized, "UNAUTHORIZED", "failed to authenticate")
+		return
+	}
 
 	// Forward Accept header for content negotiation
 	if accept := r.Header.Get("Accept"); accept != "" {
@@ -209,13 +208,6 @@ func (h *ContainerHandler) handleTagsList(w http.ResponseWriter, r *http.Request
 		return
 	}
 
-	// Get auth token
-	token, err := h.getAuthToken(r.Context(), name, "pull")
-	if err != nil {
-		h.containerError(w, http.StatusUnauthorized, "UNAUTHORIZED", "failed to authenticate")
-		return
-	}
-
 	upstreamURL := fmt.Sprintf("%s/v2/%s/tags/list", h.registryURL, name)
 	if r.URL.RawQuery != "" {
 		upstreamURL += "?" + r.URL.RawQuery
@@ -227,7 +219,10 @@ func (h *ContainerHandler) handleTagsList(w http.ResponseWriter, r *http.Request
 		return
 	}
 
-	req.Header.Set("Authorization", "Bearer "+token)
+	if err := h.authReq(req, name); err != nil {
+		h.containerError(w, http.StatusUnauthorized, "UNAUTHORIZED", "failed to authenticate")
+		return
+	}
 
 	resp, err := h.proxy.HTTPClient.Do(req)
 	if err != nil {
@@ -239,6 +234,18 @@ func (h *ContainerHandler) handleTagsList(w http.ResponseWriter, r *http.Request
 	w.Header().Set("Content-Type", "application/json")
 	w.WriteHeader(resp.StatusCode)
 	_, _ = io.Copy(w, resp.Body)
+}
+
+func (h *ContainerHandler) authReq(req *http.Request, name string) error {
+
+	// Get auth token
+	token, err := h.getAuthToken(req.Context(), name, "pull")
+	if err != nil {
+		return err
+	}
+	req.Header.Set("Authorization", "Bearer "+token)
+
+	return nil
 }
 
 // getAuthToken gets a bearer token for the specified repository.
@@ -279,7 +286,7 @@ func (h *ContainerHandler) getAuthToken(_ interface{ Done() <-chan struct{} }, r
 }
 
 // proxyBlobHead handles HEAD requests for blobs.
-func (h *ContainerHandler) proxyBlobHead(w http.ResponseWriter, r *http.Request, name, digest, token string) {
+func (h *ContainerHandler) proxyBlobHead(w http.ResponseWriter, r *http.Request, name, digest string) {
 	upstreamURL := fmt.Sprintf("%s/v2/%s/blobs/%s", h.registryURL, name, digest)
 
 	req, err := http.NewRequestWithContext(r.Context(), http.MethodHead, upstreamURL, nil)
@@ -288,7 +295,10 @@ func (h *ContainerHandler) proxyBlobHead(w http.ResponseWriter, r *http.Request,
 		return
 	}
 
-	req.Header.Set("Authorization", "Bearer "+token)
+	if err := h.authReq(req, name); err != nil {
+		h.containerError(w, http.StatusUnauthorized, "UNAUTHORIZED", "failed to authenticate")
+		return
+	}
 
 	resp, err := h.proxy.HTTPClient.Do(req)
 	if err != nil {

--- a/internal/handler/container.go
+++ b/internal/handler/container.go
@@ -97,6 +97,7 @@ func (h *ContainerHandler) handleBlobDownload(w http.ResponseWriter, r *http.Req
 
 	var headers http.Header
 
+	if h.authURL != "" {
 		// Get auth token for upstream
 		token, err := h.getAuthToken(r.Context(), name, "pull")
 		if err != nil {
@@ -106,6 +107,7 @@ func (h *ContainerHandler) handleBlobDownload(w http.ResponseWriter, r *http.Req
 		}
 
 		headers = http.Header{"Authorization": {"Bearer " + token}}
+	}
 
 	// Try to get from cache, or fetch from upstream with auth
 	filename := digest
@@ -236,7 +238,12 @@ func (h *ContainerHandler) handleTagsList(w http.ResponseWriter, r *http.Request
 	_, _ = io.Copy(w, resp.Body)
 }
 
+// authReq adds the authentication headers to a request, if required.
 func (h *ContainerHandler) authReq(req *http.Request, name string) error {
+	if h.authURL == "" {
+		// no authentication required
+		return nil
+	}
 
 	// Get auth token
 	token, err := h.getAuthToken(req.Context(), name, "pull")
@@ -251,6 +258,10 @@ func (h *ContainerHandler) authReq(req *http.Request, name string) error {
 // getAuthToken gets a bearer token for the specified repository.
 // Docker Hub requires auth even for public images.
 func (h *ContainerHandler) getAuthToken(_ interface{ Done() <-chan struct{} }, repository, action string) (string, error) {
+	if h.authURL == "" {
+		panic("getAuthToken: should not have been called if auth is not configured")
+	}
+
 	// For Docker Hub: https://auth.docker.io/token?service=registry.docker.io&scope=repository:{repo}:pull
 	authURL := fmt.Sprintf("%s/token?service=registry.docker.io&scope=repository:%s:%s",
 		h.authURL, repository, action)

--- a/internal/handler/container.go
+++ b/internal/handler/container.go
@@ -27,12 +27,20 @@ type ContainerHandler struct {
 	proxyURL    string
 }
 
-// NewContainerHandler creates a new container registry protocol handler.
-func NewContainerHandler(proxy *Proxy, proxyURL string) *ContainerHandler {
+// NewDockerHubHandler creates a new container registry protocol handler for Docker Hub.
+func NewDockerHubHandler(proxy *Proxy, proxyURL string) *ContainerHandler {
 	return &ContainerHandler{
 		proxy:       proxy,
 		registryURL: dockerHubRegistry,
 		authURL:     dockerHubAuth,
+		proxyURL:    strings.TrimSuffix(proxyURL, "/"),
+	}
+}
+
+func NewContainerHandler(proxy *Proxy, proxyURL string, registryDomain string) *ContainerHandler {
+	return &ContainerHandler{
+		proxy:       proxy,
+		registryURL: "https://" + registryDomain,
 		proxyURL:    strings.TrimSuffix(proxyURL, "/"),
 	}
 }

--- a/internal/handler/container_test.go
+++ b/internal/handler/container_test.go
@@ -222,7 +222,7 @@ func (f *mockFetcherWithHeaders) Head(_ context.Context, _ string) (int64, strin
 }
 
 func TestContainerHandler_Routes_VersionCheck(t *testing.T) {
-	h := NewContainerHandler(nil, "http://localhost:8080")
+	h := NewDockerHubHandler(nil, "http://localhost:8080")
 
 	handler := h.Routes()
 	if handler == nil {

--- a/internal/server/server.go
+++ b/internal/server/server.go
@@ -58,9 +58,9 @@ import (
 	"strings"
 	"time"
 
+	"github.com/git-pkgs/cooldown"
 	swaggerdoc "github.com/git-pkgs/proxy/docs/swagger"
 	"github.com/git-pkgs/proxy/internal/config"
-	"github.com/git-pkgs/cooldown"
 	"github.com/git-pkgs/proxy/internal/database"
 	"github.com/git-pkgs/proxy/internal/enrichment"
 	"github.com/git-pkgs/proxy/internal/handler"
@@ -84,12 +84,12 @@ const (
 
 // Server is the main proxy server.
 type Server struct {
-	cfg       *config.Config
-	db        *database.DB
-	storage   storage.Storage
-	logger    *slog.Logger
-	http      *http.Server
-	templates *Templates
+	cfg         *config.Config
+	db          *database.DB
+	storage     storage.Storage
+	logger      *slog.Logger
+	http        *http.Server
+	templates   *Templates
 	cancel      context.CancelFunc
 	healthCache *healthCache
 }
@@ -215,7 +215,8 @@ func (s *Server) Start() error {
 	condaHandler := handler.NewCondaHandler(proxy, s.cfg.BaseURL)
 	cranHandler := handler.NewCRANHandler(proxy, s.cfg.BaseURL)
 	juliaHandler := handler.NewJuliaHandler(proxy, s.cfg.BaseURL)
-	containerHandler := handler.NewContainerHandler(proxy, s.cfg.BaseURL)
+	dockerHandler := handler.NewDockerHubHandler(proxy, s.cfg.BaseURL)
+	registryK8sHandler := handler.NewContainerHandler(proxy, s.cfg.BaseURL, "registry.k8s.io")
 	debianHandler := handler.NewDebianHandler(proxy, s.cfg.BaseURL)
 	rpmHandler := handler.NewRPMHandler(proxy, s.cfg.BaseURL)
 
@@ -234,7 +235,8 @@ func (s *Server) Start() error {
 	r.Mount("/conda", http.StripPrefix("/conda", condaHandler.Routes()))
 	r.Mount("/cran", http.StripPrefix("/cran", cranHandler.Routes()))
 	r.Mount("/julia", http.StripPrefix("/julia", juliaHandler.Routes()))
-	r.Mount("/v2", http.StripPrefix("/v2", containerHandler.Routes()))
+	r.Mount("/v2", http.StripPrefix("/v2", dockerHandler.Routes()))
+	r.Mount("/v2/registry.k8s.io", http.StripPrefix("/v2/registry.k8s.io", registryK8sHandler.Routes()))
 	r.Mount("/debian", http.StripPrefix("/debian", debianHandler.Routes()))
 	r.Mount("/rpm", http.StripPrefix("/rpm", rpmHandler.Routes()))
 


### PR DESCRIPTION
for https://github.com/git-pkgs/proxy/issues/56

Open issues:

- registry.k8s.io is hardcoded, no configuration
- no authentication for registries yet (should probably detect the auth URL from the registry response headers)
- cache directory does not account for registry: `registry.k8s.io/kube-apiserver` becomes `cache/artifacts/oci/kube-apiserver`