### PR TITLE
Make upstream HTTP timeout configurable

### DIFF
--- a/config.example.yaml
+++ b/config.example.yaml
@@ -9,6 +9,11 @@ listen: ":8080"
 # so users know what to point their package manager at.
 base_url: "http://localhost:8080"
 
+# Timeout for individual upstream HTTP requests made by protocol handlers
+# (metadata fetches, pass-through file requests). Uses Go duration syntax.
+# Set to "0" to disable the timeout. Default: "30s".
+# http_timeout: "30s"
+
 # Public URL where the web UI is reached. Defaults to base_url when unset.
 # Set this separately when the UI is served on a different hostname than the
 # package endpoints — for example, the UI on a public domain behind auth while

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -276,6 +276,18 @@ metadata_max_size: "100MB"   # default
 
 Or via environment variable: `PROXY_METADATA_MAX_SIZE=250MB`.
 
+## Upstream HTTP timeout
+
+Protocol handlers use a shared HTTP client for upstream requests such as metadata fetches and pass-through file downloads. `http_timeout` sets that client's per-request timeout. Raise it if slow upstreams or large metadata responses cause `context deadline exceeded` errors.
+
+```yaml
+http_timeout: "30s"   # default
+```
+
+Or via environment variable: `PROXY_HTTP_TIMEOUT=2m`.
+
+Set to `"0"` to disable the timeout entirely (requests then rely only on the server's write timeout).
+
 ## Mirror API
 
 The `/api/mirror` endpoints are disabled by default. Enable them to allow starting mirror jobs via HTTP:

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -110,6 +110,12 @@ type Config struct {
 	// size return ErrMetadataTooLarge. Default: "100MB".
 	MetadataMaxSize string `json:"metadata_max_size" yaml:"metadata_max_size"`
 
+	// HTTPTimeout is the timeout for individual upstream HTTP requests made
+	// by protocol handlers (metadata fetches, pass-through file requests).
+	// Uses Go duration syntax (e.g. "30s", "2m"). Default: "30s".
+	// Set to "0" to disable the timeout entirely.
+	HTTPTimeout string `json:"http_timeout" yaml:"http_timeout"`
+
 	// MirrorAPI enables the /api/mirror endpoints for starting mirror jobs via HTTP.
 	// Disabled by default to prevent unauthenticated users from triggering downloads.
 	MirrorAPI bool `json:"mirror_api" yaml:"mirror_api"`
@@ -460,6 +466,9 @@ func (c *Config) LoadFromEnv() {
 	if v := os.Getenv("PROXY_METADATA_MAX_SIZE"); v != "" {
 		c.MetadataMaxSize = v
 	}
+	if v := os.Getenv("PROXY_HTTP_TIMEOUT"); v != "" {
+		c.HTTPTimeout = v
+	}
 	if v := os.Getenv("PROXY_GRADLE_BUILD_CACHE_READ_ONLY"); v != "" {
 		c.Gradle.BuildCache.ReadOnly = v == "true" || v == "1"
 	}
@@ -567,6 +576,10 @@ func (c *Config) Validate() error {
 		return err
 	}
 
+	if err := validateHTTPTimeout(c.HTTPTimeout); err != nil {
+		return err
+	}
+
 	if err := c.Health.Validate(); err != nil {
 		return err
 	}
@@ -636,6 +649,7 @@ func (g *GradleBuildCacheConfig) Validate() error {
 const (
 	defaultMetadataTTL                   = 5 * time.Minute  //nolint:mnd // sensible default
 	defaultDirectServeTTL                = 15 * time.Minute //nolint:mnd // sensible default
+	defaultHTTPTimeout                   = 30 * time.Second //nolint:mnd // sensible default
 	defaultMetadataMaxSize               = 100 << 20
 	defaultGradleBuildCacheMaxUploadSize = 100 << 20
 	defaultGradleBuildCacheSweepInterval = 10 * time.Minute
@@ -654,6 +668,20 @@ func (c *Config) ParseMaxSize() int64 {
 		return 0
 	}
 	return size
+}
+
+func validateHTTPTimeout(s string) error {
+	if s == "" || s == "0" {
+		return nil
+	}
+	d, err := time.ParseDuration(s)
+	if err != nil {
+		return fmt.Errorf("invalid http_timeout %q: %w", s, err)
+	}
+	if d < 0 {
+		return fmt.Errorf("invalid http_timeout %q: must be non-negative", s)
+	}
+	return nil
 }
 
 func validateMetadataMaxSize(s string) error {
@@ -681,6 +709,22 @@ func (c *Config) ParseMetadataMaxSize() int64 {
 		return defaultMetadataMaxSize
 	}
 	return size
+}
+
+// ParseHTTPTimeout returns the upstream HTTP client timeout.
+// Returns 30s if unset, 0 (no timeout) if explicitly set to "0".
+func (c *Config) ParseHTTPTimeout() time.Duration {
+	if c.HTTPTimeout == "" {
+		return defaultHTTPTimeout
+	}
+	if c.HTTPTimeout == "0" {
+		return 0
+	}
+	d, err := time.ParseDuration(c.HTTPTimeout)
+	if err != nil || d < 0 {
+		return defaultHTTPTimeout
+	}
+	return d
 }
 
 // ParseMetadataTTL returns the metadata TTL duration.

--- a/internal/config/config_test.go
+++ b/internal/config/config_test.go
@@ -524,6 +524,69 @@ func TestValidateHealthStorageProbeInterval(t *testing.T) {
 	}
 }
 
+func TestParseHTTPTimeout(t *testing.T) {
+	tests := []struct {
+		name    string
+		timeout string
+		want    time.Duration
+	}{
+		{"empty defaults to 30s", "", 30 * time.Second},
+		{"explicit zero disables", "0", 0},
+		{"2 minutes", "2m", 2 * time.Minute},
+		{"90 seconds", "90s", 90 * time.Second},
+		{"invalid defaults to 30s", "not-a-duration", 30 * time.Second},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			cfg := Default()
+			cfg.HTTPTimeout = tt.timeout
+			got := cfg.ParseHTTPTimeout()
+			if got != tt.want {
+				t.Errorf("ParseHTTPTimeout() = %v, want %v", got, tt.want)
+			}
+		})
+	}
+}
+
+func TestValidateHTTPTimeout(t *testing.T) {
+	cfg := Default()
+	cfg.HTTPTimeout = "not-a-duration"
+	if err := cfg.Validate(); err == nil {
+		t.Error("expected validation error for invalid http_timeout")
+	}
+
+	cfg.HTTPTimeout = "-5s"
+	if err := cfg.Validate(); err == nil {
+		t.Error("expected validation error for negative http_timeout")
+	}
+
+	cfg.HTTPTimeout = "2m"
+	if err := cfg.Validate(); err != nil {
+		t.Errorf("unexpected error for valid http_timeout: %v", err)
+	}
+
+	cfg.HTTPTimeout = "0"
+	if err := cfg.Validate(); err != nil {
+		t.Errorf("unexpected error for zero http_timeout: %v", err)
+	}
+
+	cfg.HTTPTimeout = ""
+	if err := cfg.Validate(); err != nil {
+		t.Errorf("unexpected error for empty http_timeout: %v", err)
+	}
+}
+
+func TestLoadHTTPTimeoutFromEnv(t *testing.T) {
+	cfg := Default()
+	t.Setenv("PROXY_HTTP_TIMEOUT", "90s")
+	cfg.LoadFromEnv()
+
+	if cfg.HTTPTimeout != "90s" {
+		t.Errorf("HTTPTimeout = %q, want %q", cfg.HTTPTimeout, "90s")
+	}
+}
+
 func TestLoadMetadataTTLFromEnv(t *testing.T) {
 	cfg := Default()
 	t.Setenv("PROXY_METADATA_TTL", "10m")

--- a/internal/server/server.go
+++ b/internal/server/server.go
@@ -166,6 +166,7 @@ func (s *Server) Start() error {
 		Packages:   s.cfg.Cooldown.Packages,
 	}
 	proxy := handler.NewProxy(s.db, s.storage, fetcher, resolver, s.logger)
+	proxy.HTTPClient.Timeout = s.cfg.ParseHTTPTimeout()
 	proxy.Cooldown = cd
 	proxy.CacheMetadata = s.cfg.CacheMetadata
 	proxy.MetadataTTL = s.cfg.ParseMetadataTTL()


### PR DESCRIPTION
Adds an `http_timeout` config option (and `PROXY_HTTP_TIMEOUT` env var) to set the per-request timeout on the shared HTTP client that protocol handlers use for upstream metadata fetches and pass-through file requests.

Default remains 30s. Set to `"0"` to disable the timeout entirely (requests then rely only on the server write timeout).

```yaml
http_timeout: "2m"
```

Fixes #187