### PR TITLE
fix(go): return 404 for missing modules

### DIFF
--- a/internal/handler/go.go
+++ b/internal/handler/go.go
@@ -1,9 +1,12 @@
 package handler
 
 import (
+	"errors"
 	"fmt"
 	"net/http"
 	"strings"
+
+	"github.com/git-pkgs/registries/fetch"
 )
 
 const (
@@ -100,6 +103,10 @@ func (h *GoHandler) handleDownload(w http.ResponseWriter, r *http.Request, modul
 
 	result, err := h.proxy.GetOrFetchArtifact(r.Context(), "golang", decodedModule, version, filename)
 	if err != nil {
+		if errors.Is(err, fetch.ErrNotFound) {
+			http.Error(w, "not found", http.StatusNotFound)
+			return
+		}
 		h.proxy.Logger.Error("failed to get artifact", "error", err)
 		http.Error(w, "failed to fetch module", http.StatusBadGateway)
 		return

--- a/internal/handler/go_test.go
+++ b/internal/handler/go_test.go
@@ -1,8 +1,48 @@
 package handler
 
 import (
+	"errors"
+	"net/http"
+	"net/http/httptest"
 	"testing"
+
+	"github.com/git-pkgs/registries/fetch"
 )
+
+func TestGoModuleDownloadUpstreamErrors(t *testing.T) {
+	tests := []struct {
+		name       string
+		fetchErr   error
+		wantStatus int
+	}{
+		{
+			name:       "module not found",
+			fetchErr:   fetch.ErrNotFound,
+			wantStatus: http.StatusNotFound,
+		},
+		{
+			name:       "upstream failure",
+			fetchErr:   errors.New("connection refused"),
+			wantStatus: http.StatusBadGateway,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			proxy, _, _, fetcher := setupTestProxy(t)
+			fetcher.fetchErr = tt.fetchErr
+			handler := NewGoHandler(proxy, "http://localhost:8080")
+
+			req := httptest.NewRequest(http.MethodGet, "/example.com/mod/@v/v1.0.0.zip", nil)
+			resp := httptest.NewRecorder()
+			handler.Routes().ServeHTTP(resp, req)
+
+			if resp.Code != tt.wantStatus {
+				t.Fatalf("status = %d, want %d", resp.Code, tt.wantStatus)
+			}
+		})
+	}
+}
 
 func TestDecodeGoModule(t *testing.T) {
 	tests := []struct {


### PR DESCRIPTION
## Summary

- return HTTP 404 when the upstream Go module mirror reports a missing artifact
- keep other upstream failures at 502 and cover both status paths

## Why

Go only advances from `GOPROXY=<proxy>,direct` when the proxy responds with 404 or 410. The handler was turning the upstream not-found sentinel into 502, which prevented the documented fallback. Fixes #184.

## Validation

- `go test -race ./...`
- `go build ./...`
- `go tool golangci-lint run ./...`
- `go vet ./...`