### PR TITLE
fix(upstream): honor npm and Cargo overrides

### DIFF
--- a/internal/handler/cargo.go
+++ b/internal/handler/cargo.go
@@ -6,6 +6,7 @@ import (
 	"errors"
 	"fmt"
 	"net/http"
+	"net/url"
 	"strings"
 	"time"
 
@@ -30,11 +31,18 @@ type CargoHandler struct {
 }
 
 // NewCargoHandler creates a new cargo protocol handler.
-func NewCargoHandler(proxy *Proxy, proxyURL string) *CargoHandler {
+func NewCargoHandler(proxy *Proxy, proxyURL, indexURL, downloadURL string) *CargoHandler {
+	if strings.TrimSpace(indexURL) == "" {
+		indexURL = cargoUpstream
+	}
+	if strings.TrimSpace(downloadURL) == "" {
+		downloadURL = cargoDownloadBase
+	}
+
 	return &CargoHandler{
 		proxy:       proxy,
-		indexURL:    cargoUpstream,
-		downloadURL: cargoDownloadBase,
+		indexURL:    strings.TrimSuffix(indexURL, "/"),
+		downloadURL: strings.TrimSuffix(downloadURL, "/"),
 		proxyURL:    strings.TrimSuffix(proxyURL, "/"),
 	}
 }
@@ -191,7 +199,15 @@ func (h *CargoHandler) handleDownload(w http.ResponseWriter, r *http.Request) {
 	h.proxy.Logger.Info("cargo download request",
 		"crate", name, "version", version, "filename", filename)
 
-	result, err := h.proxy.GetOrFetchArtifact(r.Context(), "cargo", name, version, filename)
+	downloadURL := fmt.Sprintf(
+		"%s/%s/%s",
+		h.downloadURL,
+		url.PathEscape(name),
+		url.PathEscape(filename),
+	)
+	result, err := h.proxy.GetOrFetchArtifactFromURL(
+		r.Context(), "cargo", name, version, filename, downloadURL,
+	)
 	if err != nil {
 		h.proxy.Logger.Error("failed to get artifact", "error", err)
 		http.Error(w, "failed to fetch crate", http.StatusBadGateway)

--- a/internal/handler/cargo_test.go
+++ b/internal/handler/cargo_test.go
@@ -2,6 +2,7 @@ package handler
 
 import (
 	"encoding/json"
+	"io"
 	"log/slog"
 	"net/http"
 	"net/http/httptest"
@@ -10,6 +11,7 @@ import (
 	"time"
 
 	"github.com/git-pkgs/cooldown"
+	"github.com/git-pkgs/registries/fetch"
 )
 
 func cargoTestProxy() *Proxy {
@@ -68,6 +70,64 @@ func TestCargoConfigEndpoint(t *testing.T) {
 	if config.DL != expectedDL {
 		t.Errorf("DL = %q, want %q", config.DL, expectedDL)
 	}
+}
+
+func TestCargoHandlerUsesConfiguredUpstreams(t *testing.T) {
+	t.Run("index", func(t *testing.T) {
+		var requestPath string
+		upstream := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+			requestPath = r.URL.Path
+			w.Header().Set("Content-Type", "text/plain")
+			_, _ = io.WriteString(w, `{"name":"serde","vers":"1.0.0"}`)
+		}))
+		defer upstream.Close()
+
+		proxy, _, _, _ := setupTestProxy(t)
+		proxy.HTTPClient = upstream.Client()
+		h := NewCargoHandler(
+			proxy,
+			"http://proxy.test",
+			upstream.URL+"/index/",
+			"https://crates.example.test/files/",
+		)
+
+		req := httptest.NewRequest(http.MethodGet, "/se/rd/serde", nil)
+		w := httptest.NewRecorder()
+		h.Routes().ServeHTTP(w, req)
+
+		if w.Code != http.StatusOK {
+			t.Fatalf("status = %d, want %d; body: %s", w.Code, http.StatusOK, w.Body.String())
+		}
+		if requestPath != "/index/se/rd/serde" {
+			t.Errorf("upstream path = %q, want %q", requestPath, "/index/se/rd/serde")
+		}
+	})
+
+	t.Run("download", func(t *testing.T) {
+		proxy, _, _, artifactFetcher := setupTestProxy(t)
+		artifactFetcher.artifact = &fetch.Artifact{
+			Body:        io.NopCloser(strings.NewReader("crate")),
+			ContentType: "application/gzip",
+		}
+		h := NewCargoHandler(
+			proxy,
+			"http://proxy.test",
+			"https://index.example.test/root/",
+			"https://crates.example.test/files/",
+		)
+
+		req := httptest.NewRequest(http.MethodGet, "/crates/serde/1.0.0/download", nil)
+		w := httptest.NewRecorder()
+		h.Routes().ServeHTTP(w, req)
+
+		if w.Code != http.StatusOK {
+			t.Fatalf("status = %d, want %d; body: %s", w.Code, http.StatusOK, w.Body.String())
+		}
+		want := "https://crates.example.test/files/serde/serde-1.0.0.crate"
+		if artifactFetcher.fetchedURL != want {
+			t.Errorf("fetched URL = %q, want %q", artifactFetcher.fetchedURL, want)
+		}
+	})
 }
 
 func TestCargoIndexProxy(t *testing.T) {

--- a/internal/handler/cargo_test.go
+++ b/internal/handler/cargo_test.go
@@ -74,9 +74,14 @@ func TestCargoConfigEndpoint(t *testing.T) {
 
 func TestCargoHandlerUsesConfiguredUpstreams(t *testing.T) {
 	t.Run("index", func(t *testing.T) {
-		var requestPath string
+		var requestPath, authHeader string
 		upstream := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 			requestPath = r.URL.Path
+			authHeader = r.Header.Get("Authorization")
+			if authHeader != "Bearer cargo-token" {
+				w.WriteHeader(http.StatusUnauthorized)
+				return
+			}
 			w.Header().Set("Content-Type", "text/plain")
 			_, _ = io.WriteString(w, `{"name":"serde","vers":"1.0.0"}`)
 		}))
@@ -84,6 +89,9 @@ func TestCargoHandlerUsesConfiguredUpstreams(t *testing.T) {
 
 		proxy, _, _, _ := setupTestProxy(t)
 		proxy.HTTPClient = upstream.Client()
+		proxy.AuthForURL = func(string) (string, string) {
+			return "Authorization", "Bearer cargo-token"
+		}
 		h := NewCargoHandler(
 			proxy,
 			"http://proxy.test",
@@ -100,6 +108,9 @@ func TestCargoHandlerUsesConfiguredUpstreams(t *testing.T) {
 		}
 		if requestPath != "/index/se/rd/serde" {
 			t.Errorf("upstream path = %q, want %q", requestPath, "/index/se/rd/serde")
+		}
+		if authHeader != "Bearer cargo-token" {
+			t.Errorf("Authorization = %q, want %q", authHeader, "Bearer cargo-token")
 		}
 	})
 

--- a/internal/handler/handler.go
+++ b/internal/handler/handler.go
@@ -96,6 +96,7 @@ type Proxy struct {
 	// storage at an internal one.
 	DirectServeBaseURL string
 	HTTPClient         *http.Client
+	AuthForURL         func(string) (headerName, headerValue string)
 }
 
 // NewProxy creates a new Proxy with the given dependencies.
@@ -391,6 +392,7 @@ func (p *Proxy) ProxyUpstream(w http.ResponseWriter, r *http.Request, upstreamUR
 			req.Header.Set(header, v)
 		}
 	}
+	p.applyUpstreamAuth(req)
 
 	resp, err := p.HTTPClient.Do(req)
 	if err != nil {
@@ -417,6 +419,7 @@ func (p *Proxy) ProxyFile(w http.ResponseWriter, r *http.Request, upstreamURL st
 		http.Error(w, "failed to create request", http.StatusInternalServerError)
 		return
 	}
+	p.applyUpstreamAuth(req)
 
 	resp, err := p.HTTPClient.Do(req)
 	if err != nil {
@@ -546,6 +549,7 @@ func (p *Proxy) fetchUpstreamMetadata(ctx context.Context, upstreamURL string, e
 		return nil, "", "", zeroTime, fmt.Errorf("creating request: %w", err)
 	}
 	req.Header.Set("Accept", accept)
+	p.applyUpstreamAuth(req)
 
 	if entry != nil && entry.ETag.Valid {
 		req.Header.Set("If-None-Match", entry.ETag.String)
@@ -735,6 +739,7 @@ func (p *Proxy) proxyMetadataStream(w http.ResponseWriter, r *http.Request, upst
 		accept = acceptHeaders[0]
 	}
 	req.Header.Set("Accept", accept)
+	p.applyUpstreamAuth(req)
 
 	for _, header := range []string{headerAcceptEncoding, "If-Modified-Since", "If-None-Match"} {
 		if v := r.Header.Get(header); v != "" {
@@ -757,6 +762,17 @@ func (p *Proxy) proxyMetadataStream(w http.ResponseWriter, r *http.Request, upst
 
 	w.WriteHeader(resp.StatusCode)
 	_, _ = io.Copy(w, resp.Body)
+}
+
+func (p *Proxy) applyUpstreamAuth(req *http.Request) {
+	if p.AuthForURL == nil {
+		return
+	}
+
+	headerName, headerValue := p.AuthForURL(req.URL.String())
+	if headerName != "" && headerValue != "" {
+		req.Header.Set(headerName, headerValue)
+	}
 }
 
 // GetOrFetchArtifactFromURL retrieves an artifact from cache or fetches from a specific URL.

--- a/internal/handler/npm.go
+++ b/internal/handler/npm.go
@@ -27,10 +27,14 @@ type NPMHandler struct {
 }
 
 // NewNPMHandler creates a new npm protocol handler.
-func NewNPMHandler(proxy *Proxy, proxyURL string) *NPMHandler {
+func NewNPMHandler(proxy *Proxy, proxyURL, upstreamURL string) *NPMHandler {
+	if strings.TrimSpace(upstreamURL) == "" {
+		upstreamURL = npmUpstream
+	}
+
 	return &NPMHandler{
 		proxy:       proxy,
-		upstreamURL: npmUpstream,
+		upstreamURL: strings.TrimSuffix(upstreamURL, "/"),
 		proxyURL:    strings.TrimSuffix(proxyURL, "/"),
 	}
 }
@@ -263,7 +267,15 @@ func (h *NPMHandler) handleDownload(w http.ResponseWriter, r *http.Request) {
 	h.proxy.Logger.Info("npm download request",
 		"package", packageName, "version", version, "filename", filename)
 
-	result, err := h.proxy.GetOrFetchArtifact(r.Context(), "npm", packageName, version, filename)
+	downloadURL := fmt.Sprintf(
+		"%s/%s/-/%s",
+		h.upstreamURL,
+		url.PathEscape(packageName),
+		url.PathEscape(filename),
+	)
+	result, err := h.proxy.GetOrFetchArtifactFromURL(
+		r.Context(), "npm", packageName, version, filename, downloadURL,
+	)
 	if err != nil {
 		h.proxy.Logger.Error("failed to get artifact", "error", err)
 		JSONError(w, http.StatusBadGateway, "failed to fetch package")

--- a/internal/handler/npm.go
+++ b/internal/handler/npm.go
@@ -270,7 +270,7 @@ func (h *NPMHandler) handleDownload(w http.ResponseWriter, r *http.Request) {
 	downloadURL := fmt.Sprintf(
 		"%s/%s/-/%s",
 		h.upstreamURL,
-		url.PathEscape(packageName),
+		escapeNPMDownloadPackage(packageName),
 		url.PathEscape(filename),
 	)
 	result, err := h.proxy.GetOrFetchArtifactFromURL(
@@ -283,6 +283,14 @@ func (h *NPMHandler) handleDownload(w http.ResponseWriter, r *http.Request) {
 	}
 
 	ServeArtifact(w, result)
+}
+
+func escapeNPMDownloadPackage(packageName string) string {
+	scope, name, scoped := strings.Cut(packageName, "/")
+	if scoped && strings.HasPrefix(scope, "@") && len(scope) > 1 && name != "" && !strings.Contains(name, "/") {
+		return url.PathEscape(scope) + "/" + url.PathEscape(name)
+	}
+	return url.PathEscape(packageName)
 }
 
 // extractPackageName extracts the package name from the request path.

--- a/internal/handler/npm_test.go
+++ b/internal/handler/npm_test.go
@@ -2,13 +2,16 @@ package handler
 
 import (
 	"encoding/json"
+	"io"
 	"log/slog"
 	"net/http"
 	"net/http/httptest"
+	"strings"
 	"testing"
 	"time"
 
 	"github.com/git-pkgs/cooldown"
+	"github.com/git-pkgs/registries/fetch"
 )
 
 const testVersion100 = "1.0.0"
@@ -44,6 +47,54 @@ func TestNPMExtractVersionFromFilename(t *testing.T) {
 				tt.packageName, tt.filename, got, tt.want)
 		}
 	}
+}
+
+func TestNPMHandlerUsesConfiguredUpstream(t *testing.T) {
+	t.Run("metadata", func(t *testing.T) {
+		var requestPath string
+		upstream := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+			requestPath = r.URL.Path
+			w.Header().Set("Content-Type", "application/json")
+			_, _ = io.WriteString(w, `{"versions":{}}`)
+		}))
+		defer upstream.Close()
+
+		proxy, _, _, _ := setupTestProxy(t)
+		proxy.HTTPClient = upstream.Client()
+		h := NewNPMHandler(proxy, "http://proxy.test", upstream.URL+"/root/")
+
+		req := httptest.NewRequest(http.MethodGet, "/testpkg", nil)
+		w := httptest.NewRecorder()
+		h.Routes().ServeHTTP(w, req)
+
+		if w.Code != http.StatusOK {
+			t.Fatalf("status = %d, want %d; body: %s", w.Code, http.StatusOK, w.Body.String())
+		}
+		if requestPath != "/root/testpkg" {
+			t.Errorf("upstream path = %q, want %q", requestPath, "/root/testpkg")
+		}
+	})
+
+	t.Run("download", func(t *testing.T) {
+		proxy, _, _, artifactFetcher := setupTestProxy(t)
+		artifactFetcher.artifact = &fetch.Artifact{
+			Body:        io.NopCloser(strings.NewReader("package")),
+			ContentType: "application/gzip",
+		}
+		h := NewNPMHandler(proxy, "http://proxy.test", "https://npm.example.test/root/")
+
+		req := httptest.NewRequest(http.MethodGet, "/testpkg/-/testpkg-1.0.0.tgz", nil)
+		w := httptest.NewRecorder()
+		h.Routes().ServeHTTP(w, req)
+
+		if w.Code != http.StatusOK {
+			t.Fatalf("status = %d, want %d; body: %s", w.Code, http.StatusOK, w.Body.String())
+		}
+		want := "https://npm.example.test/root/testpkg/-/testpkg-1.0.0.tgz"
+		if artifactFetcher.fetchedURL != want {
+			t.Errorf("fetched URL = %q, want %q", artifactFetcher.fetchedURL, want)
+		}
+	})
 }
 
 func TestNPMRewriteMetadata(t *testing.T) {

--- a/internal/handler/npm_test.go
+++ b/internal/handler/npm_test.go
@@ -51,9 +51,14 @@ func TestNPMExtractVersionFromFilename(t *testing.T) {
 
 func TestNPMHandlerUsesConfiguredUpstream(t *testing.T) {
 	t.Run("metadata", func(t *testing.T) {
-		var requestPath string
+		var requestPath, authHeader string
 		upstream := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 			requestPath = r.URL.Path
+			authHeader = r.Header.Get("Authorization")
+			if authHeader != "Bearer npm-token" {
+				w.WriteHeader(http.StatusUnauthorized)
+				return
+			}
 			w.Header().Set("Content-Type", "application/json")
 			_, _ = io.WriteString(w, `{"versions":{}}`)
 		}))
@@ -61,6 +66,9 @@ func TestNPMHandlerUsesConfiguredUpstream(t *testing.T) {
 
 		proxy, _, _, _ := setupTestProxy(t)
 		proxy.HTTPClient = upstream.Client()
+		proxy.AuthForURL = func(string) (string, string) {
+			return "Authorization", "Bearer npm-token"
+		}
 		h := NewNPMHandler(proxy, "http://proxy.test", upstream.URL+"/root/")
 
 		req := httptest.NewRequest(http.MethodGet, "/testpkg", nil)
@@ -72,6 +80,9 @@ func TestNPMHandlerUsesConfiguredUpstream(t *testing.T) {
 		}
 		if requestPath != "/root/testpkg" {
 			t.Errorf("upstream path = %q, want %q", requestPath, "/root/testpkg")
+		}
+		if authHeader != "Bearer npm-token" {
+			t.Errorf("Authorization = %q, want %q", authHeader, "Bearer npm-token")
 		}
 	})
 

--- a/internal/handler/npm_test.go
+++ b/internal/handler/npm_test.go
@@ -95,6 +95,27 @@ func TestNPMHandlerUsesConfiguredUpstream(t *testing.T) {
 			t.Errorf("fetched URL = %q, want %q", artifactFetcher.fetchedURL, want)
 		}
 	})
+
+	t.Run("scoped download", func(t *testing.T) {
+		proxy, _, _, artifactFetcher := setupTestProxy(t)
+		artifactFetcher.artifact = &fetch.Artifact{
+			Body:        io.NopCloser(strings.NewReader("package")),
+			ContentType: "application/gzip",
+		}
+		h := NewNPMHandler(proxy, "http://proxy.test", "https://npm.example.test/root/")
+
+		req := httptest.NewRequest(http.MethodGet, "/@scope/name/-/name-1.0.0.tgz", nil)
+		w := httptest.NewRecorder()
+		h.Routes().ServeHTTP(w, req)
+
+		if w.Code != http.StatusOK {
+			t.Fatalf("status = %d, want %d; body: %s", w.Code, http.StatusOK, w.Body.String())
+		}
+		want := "https://npm.example.test/root/@scope/name/-/name-1.0.0.tgz"
+		if artifactFetcher.fetchedURL != want {
+			t.Errorf("fetched URL = %q, want %q", artifactFetcher.fetchedURL, want)
+		}
+	})
 }
 
 func TestNPMRewriteMetadata(t *testing.T) {

--- a/internal/server/server.go
+++ b/internal/server/server.go
@@ -196,8 +196,13 @@ func (s *Server) Start() error {
 	})
 
 	// Mount protocol handlers
-	npmHandler := handler.NewNPMHandler(proxy, s.cfg.BaseURL)
-	cargoHandler := handler.NewCargoHandler(proxy, s.cfg.BaseURL)
+	npmHandler := handler.NewNPMHandler(proxy, s.cfg.BaseURL, s.cfg.Upstream.NPM)
+	cargoHandler := handler.NewCargoHandler(
+		proxy,
+		s.cfg.BaseURL,
+		s.cfg.Upstream.Cargo,
+		s.cfg.Upstream.CargoDownload,
+	)
 	gemHandler := handler.NewGemHandler(proxy, s.cfg.BaseURL)
 	goHandler := handler.NewGoHandler(proxy, s.cfg.BaseURL)
 	hexHandler := handler.NewHexHandler(proxy, s.cfg.BaseURL)

--- a/internal/server/server.go
+++ b/internal/server/server.go
@@ -167,6 +167,7 @@ func (s *Server) Start() error {
 	}
 	proxy := handler.NewProxy(s.db, s.storage, fetcher, resolver, s.logger)
 	proxy.HTTPClient.Timeout = s.cfg.ParseHTTPTimeout()
+	proxy.AuthForURL = s.authForURL
 	proxy.Cooldown = cd
 	proxy.CacheMetadata = s.cfg.CacheMetadata
 	proxy.MetadataTTL = s.cfg.ParseMetadataTTL()

--- a/internal/server/server_test.go
+++ b/internal/server/server_test.go
@@ -67,8 +67,13 @@ func newTestServer(t *testing.T) *testServer {
 	r := chi.NewRouter()
 
 	// Mount handlers
-	npmHandler := handler.NewNPMHandler(proxy, cfg.BaseURL)
-	cargoHandler := handler.NewCargoHandler(proxy, cfg.BaseURL)
+	npmHandler := handler.NewNPMHandler(proxy, cfg.BaseURL, cfg.Upstream.NPM)
+	cargoHandler := handler.NewCargoHandler(
+		proxy,
+		cfg.BaseURL,
+		cfg.Upstream.Cargo,
+		cfg.Upstream.CargoDownload,
+	)
 	gemHandler := handler.NewGemHandler(proxy, cfg.BaseURL)
 	goHandler := handler.NewGoHandler(proxy, cfg.BaseURL)
 	pypiHandler := handler.NewPyPIHandler(proxy, cfg.BaseURL)


### PR DESCRIPTION
## Summary

- pass `upstream.npm` into the npm handler for metadata and tarball requests
- pass `upstream.cargo` and `upstream.cargo_download` into the Cargo handler
- construct artifact download URLs from the configured origins instead of the resolver public defaults
- preserve public defaults for empty settings and normalize trailing slashes
- cover custom origins with path prefixes for npm metadata/downloads and Cargo index/downloads

## Why

The configuration exposed npm and Cargo upstream overrides, but the server did not pass them into either handler. Even when handler metadata origins were changed manually, artifact downloads still used the resolver hard-coded public registries.

## Validation

- `go test -race ./... -count=1`
- `go tool golangci-lint run ./...`