### PR TITLE
Document upstream.debian in README and config.example.yaml

### DIFF
--- a/README.md
+++ b/README.md
@@ -376,6 +376,13 @@ Replace your existing sources.list entries, then:
 sudo apt update
 ```
 
+The upstream defaults to `http://deb.debian.org/debian`. To proxy a different APT repository (e.g. Ubuntu), set `upstream.debian` in the config file or `PROXY_UPSTREAM_DEBIAN` in the environment:
+
+```yaml
+upstream:
+  debian: "http://archive.ubuntu.com/ubuntu"
+```
+
 ### RPM / Yum / DNF
 
 Configure yum/dnf to use the proxy in `/etc/yum.repos.d/proxy.repo`:

--- a/config.example.yaml
+++ b/config.example.yaml
@@ -95,6 +95,9 @@ upstream:
   # Cargo crate download URL
   cargo_download: "https://static.crates.io/crates"
 
+  # Debian/APT repository URL (used by /debian endpoint)
+  debian: "http://deb.debian.org/debian"
+
   # Authentication for upstream registries
   # Keys are URL prefixes matched against request URLs.
   # Values can reference environment variables using ${VAR_NAME} syntax.


### PR DESCRIPTION
Follow-up to #229, which added `upstream.debian` / `PROXY_UPSTREAM_DEBIAN` but did not update `config.example.yaml` or the README Debian section.