### PR TITLE
fix: decode PURL percent-encoding in versions and package paths

### DIFF
--- a/internal/database/queries.go
+++ b/internal/database/queries.go
@@ -443,11 +443,14 @@ func (db *DB) GetMostPopularPackages(limit int) ([]PopularPackage, error) {
 }
 
 type RecentPackage struct {
-	Ecosystem string    `db:"ecosystem"`
-	Name      string    `db:"name"`
-	Version   string    `db:"version"`
-	CachedAt  time.Time `db:"fetched_at"`
-	Size      int64     `db:"size"`
+	Ecosystem   string    `db:"ecosystem"`
+	Name        string    `db:"name"`
+	VersionPURL string    `db:"version_purl"`
+	CachedAt    time.Time `db:"fetched_at"`
+	Size        int64     `db:"size"`
+	// Version is derived from VersionPURL rather than selected, so that the
+	// PURL percent-encoding is decoded (e.g. "%2B" back to "+").
+	Version string `db:"-"`
 }
 
 func (db *DB) GetRecentlyCachedPackages(limit int) ([]RecentPackage, error) {
@@ -461,10 +464,10 @@ func (db *DB) GetRecentlyCachedPackages(limit int) ([]RecentPackage, error) {
 	}
 
 	var packages []RecentPackage
-	// We need to extract version from the purl since there's no separate version column
+	// There is no separate version column, so the full version PURL is selected
+	// and the version is decoded from it in Go.
 	query := db.Rebind(`
-		SELECT p.ecosystem, p.name,
-		       SUBSTR(v.purl, INSTR(v.purl, '@') + 1) as version,
+		SELECT p.ecosystem, p.name, v.purl as version_purl,
 		       a.fetched_at, COALESCE(a.size, 0) as size
 		FROM artifacts a
 		JOIN versions v ON v.purl = a.version_purl
@@ -474,24 +477,12 @@ func (db *DB) GetRecentlyCachedPackages(limit int) ([]RecentPackage, error) {
 		LIMIT ?
 	`)
 
-	// For postgres, use different string function
-	if db.dialect == DialectPostgres {
-		query = db.Rebind(`
-			SELECT p.ecosystem, p.name,
-			       SUBSTRING(v.purl FROM POSITION('@' IN v.purl) + 1) as version,
-			       a.fetched_at, COALESCE(a.size, 0) as size
-			FROM artifacts a
-			JOIN versions v ON v.purl = a.version_purl
-			JOIN packages p ON p.purl = v.package_purl
-			WHERE a.storage_path IS NOT NULL AND a.fetched_at IS NOT NULL
-			ORDER BY a.fetched_at DESC
-			LIMIT ?
-		`)
-	}
-
 	err = db.Select(&packages, query, limit)
 	if err != nil {
 		return nil, err
+	}
+	for i := range packages {
+		packages[i].Version = VersionFromPURL(packages[i].VersionPURL)
 	}
 	return packages, nil
 }

--- a/internal/database/types.go
+++ b/internal/database/types.go
@@ -51,6 +51,19 @@ func (v *Version) Version() string {
 	return VersionFromPURL(v.PURL)
 }
 
+// EscapedVersion returns the version escaped for use as a single URL path
+// segment.
+//
+// Version returns decoded text, which is what should be shown to a user but is
+// not safe to drop into a link: html/template preserves reserved characters and
+// existing escapes in a URL, so "release/1" would split into two path segments,
+// "v1?build" would start a query string, and a literal "%2B" would be read back
+// as "+". Escaping here and decoding in splitWildcardPath round-trips the value,
+// so the link resolves to the version that was stored.
+func (v *Version) EscapedVersion() string {
+	return url.PathEscape(v.Version())
+}
+
 // DisplayPURL returns the PURL with its path components percent-decoded, for
 // showing in the UI. The stored PURL keeps the canonical encoding (which is
 // what the API and all lookups use); this is only a readable rendering, so that

--- a/internal/database/types.go
+++ b/internal/database/types.go
@@ -2,6 +2,7 @@ package database
 
 import (
 	"database/sql"
+	"net/url"
 	"strings"
 	"time"
 )
@@ -47,10 +48,66 @@ type Version struct {
 // Version extracts the version string from the PURL.
 // e.g., "pkg:npm/lodash@4.17.21" -> "4.17.21"
 func (v *Version) Version() string {
-	if idx := strings.LastIndex(v.PURL, "@"); idx >= 0 {
-		return v.PURL[idx+1:]
+	return VersionFromPURL(v.PURL)
+}
+
+// DisplayPURL returns the PURL with its path components percent-decoded, for
+// showing in the UI. The stored PURL keeps the canonical encoding (which is
+// what the API and all lookups use); this is only a readable rendering, so that
+// a version like "7.91+dfsg1-2ubuntu0.1" is not shown as "7.91%2Bdfsg1-2ubuntu0.1"
+// and an npm scope is shown as "@babel" rather than "%40babel". Qualifiers and
+// subpath keep their encoding, since decoding those would be ambiguous.
+func (v *Version) DisplayPURL() string {
+	base, suffix := v.PURL, ""
+	if i := strings.IndexAny(base, "?#"); i >= 0 {
+		base, suffix = base[:i], base[i:]
 	}
-	return ""
+
+	name, version := base, ""
+	if idx := strings.LastIndex(base, "@"); idx >= 0 {
+		name, version = base[:idx], "@"+decodePURLComponent(base[idx+1:])
+	}
+
+	parts := strings.Split(name, "/")
+	for i, part := range parts {
+		parts[i] = decodePURLComponent(part)
+	}
+	return strings.Join(parts, "/") + version + suffix
+}
+
+// VersionFromPURL extracts the decoded version string from a PURL.
+//
+// PURL percent-encodes characters that are not safe in a path component, so a
+// Debian version like "7.91+dfsg1-2ubuntu0.1" is stored as
+// "pkg:deb/nmap@7.91%2Bdfsg1-2ubuntu0.1". The raw substring after "@" is
+// therefore not the version: it must be percent-decoded before being displayed
+// or used to build a URL, otherwise "%2B" leaks into the UI and round-tripping
+// the value back into a PURL double-encodes it.
+//
+// e.g., "pkg:npm/lodash@4.17.21" -> "4.17.21"
+func VersionFromPURL(p string) string {
+	// Qualifiers ("?key=value") and subpath ("#path") follow the version.
+	if i := strings.IndexAny(p, "?#"); i >= 0 {
+		p = p[:i]
+	}
+	idx := strings.LastIndex(p, "@")
+	if idx < 0 {
+		return ""
+	}
+	return decodePURLComponent(p[idx+1:])
+}
+
+// decodePURLComponent percent-decodes a single PURL path component, returning
+// the input unchanged if it is not valid percent-encoding.
+func decodePURLComponent(s string) string {
+	if !strings.Contains(s, "%") {
+		return s
+	}
+	decoded, err := url.PathUnescape(s)
+	if err != nil {
+		return s
+	}
+	return decoded
 }
 
 // Artifact represents a cached artifact in the database.

--- a/internal/database/version_purl_test.go
+++ b/internal/database/version_purl_test.go
@@ -1,0 +1,114 @@
+package database
+
+import (
+	"database/sql"
+	"testing"
+	"time"
+)
+
+func TestVersionFromPURL(t *testing.T) {
+	tests := []struct {
+		name string
+		purl string
+		want string
+	}{
+		{"simple", "pkg:npm/lodash@4.17.21", "4.17.21"},
+		{"namespaced", "pkg:composer/symfony/console@6.0.0", "6.0.0"},
+		// Debian/Ubuntu versions routinely contain "+", which PURL encodes.
+		{"encoded plus", "pkg:deb/nmap@7.91%2Bdfsg1%2Breally7.80%2Bdfsg1-2ubuntu0.1", "7.91+dfsg1+really7.80+dfsg1-2ubuntu0.1"},
+		{"encoded epoch", "pkg:deb/curl@1%3A7.81.0-1", "1:7.81.0-1"},
+		{"encoded plus with qualifier", "pkg:deb/nmap@7.91%2Bdfsg1?repository_url=http%3A%2F%2Fexample.com", "7.91+dfsg1"},
+		{"tilde is not encoded", "pkg:deb/foo@1.0~rc1", "1.0~rc1"},
+		{"no version", "pkg:npm/lodash", ""},
+		{"invalid escape passed through", "pkg:npm/lodash@1.0%zz", "1.0%zz"},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if got := VersionFromPURL(tt.purl); got != tt.want {
+				t.Errorf("VersionFromPURL(%q) = %q, want %q", tt.purl, got, tt.want)
+			}
+			v := &Version{PURL: tt.purl}
+			if got := v.Version(); got != tt.want {
+				t.Errorf("Version.Version() for %q = %q, want %q", tt.purl, got, tt.want)
+			}
+		})
+	}
+}
+
+func TestVersionDisplayPURL(t *testing.T) {
+	tests := []struct {
+		name string
+		purl string
+		want string
+	}{
+		{"simple", "pkg:npm/lodash@4.17.21", "pkg:npm/lodash@4.17.21"},
+		{
+			"encoded plus",
+			"pkg:deb/nmap@7.91%2Bdfsg1%2Breally7.80%2Bdfsg1-2ubuntu0.1",
+			"pkg:deb/nmap@7.91+dfsg1+really7.80+dfsg1-2ubuntu0.1",
+		},
+		{
+			"qualifier preserved",
+			"pkg:deb/nmap@7.91%2Bdfsg1?repository_url=http%3A%2F%2Fexample.com",
+			"pkg:deb/nmap@7.91+dfsg1?repository_url=http%3A%2F%2Fexample.com",
+		},
+		// The namespace is encoded too: MakePURLString("npm", "@babel/core", …)
+		// produces "pkg:npm/%40babel/core@…".
+		{"encoded npm scope", "pkg:npm/%40babel/core@7.0.0", "pkg:npm/@babel/core@7.0.0"},
+		{"encoded scope without version", "pkg:npm/%40babel/core", "pkg:npm/@babel/core"},
+		{"no version", "pkg:npm/lodash", "pkg:npm/lodash"},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			v := &Version{PURL: tt.purl}
+			if got := v.DisplayPURL(); got != tt.want {
+				t.Errorf("DisplayPURL() for %q = %q, want %q", tt.purl, got, tt.want)
+			}
+		})
+	}
+}
+
+// TestGetRecentlyCachedPackagesDecodesVersion guards the dashboard's "recently
+// cached" list, which derives the version from the version PURL.
+func TestGetRecentlyCachedPackagesDecodesVersion(t *testing.T) {
+	runWithBothDatabases(t, func(t *testing.T, db *DB) {
+		const versionPURL = "pkg:deb/nmap@7.91%2Bdfsg1%2Breally7.80%2Bdfsg1-2ubuntu0.1"
+
+		if err := db.UpsertPackage(&Package{
+			PURL: "pkg:deb/nmap", Ecosystem: "deb", Name: "nmap",
+		}); err != nil {
+			t.Fatalf("UpsertPackage failed: %v", err)
+		}
+		if err := db.UpsertVersion(&Version{
+			PURL: versionPURL, PackagePURL: "pkg:deb/nmap",
+		}); err != nil {
+			t.Fatalf("UpsertVersion failed: %v", err)
+		}
+		if err := db.UpsertArtifact(&Artifact{
+			VersionPURL: versionPURL,
+			Filename:    "nmap_7.91+dfsg1+really7.80+dfsg1-2ubuntu0.1_amd64.deb",
+			UpstreamURL: "http://archive.ubuntu.com/ubuntu/pool/universe/n/nmap/nmap.deb",
+			StoragePath: sql.NullString{String: "/cache/nmap.deb", Valid: true},
+			FetchedAt:   sql.NullTime{Time: time.Now(), Valid: true},
+		}); err != nil {
+			t.Fatalf("UpsertArtifact failed: %v", err)
+		}
+
+		recent, err := db.GetRecentlyCachedPackages(10)
+		if err != nil {
+			t.Fatalf("GetRecentlyCachedPackages failed: %v", err)
+		}
+		if len(recent) != 1 {
+			t.Fatalf("expected 1 recent package, got %d", len(recent))
+		}
+		const want = "7.91+dfsg1+really7.80+dfsg1-2ubuntu0.1"
+		if recent[0].Version != want {
+			t.Errorf("Version = %q, want %q", recent[0].Version, want)
+		}
+		if recent[0].VersionPURL != versionPURL {
+			t.Errorf("VersionPURL = %q, want %q", recent[0].VersionPURL, versionPURL)
+		}
+	})
+}

--- a/internal/database/version_purl_test.go
+++ b/internal/database/version_purl_test.go
@@ -2,6 +2,7 @@ package database
 
 import (
 	"database/sql"
+	"net/url"
 	"testing"
 	"time"
 )
@@ -31,6 +32,50 @@ func TestVersionFromPURL(t *testing.T) {
 			v := &Version{PURL: tt.purl}
 			if got := v.Version(); got != tt.want {
 				t.Errorf("Version.Version() for %q = %q, want %q", tt.purl, got, tt.want)
+			}
+		})
+	}
+}
+
+// TestVersionEscapedVersion checks the value the templates put in a URL. It
+// must survive the round trip back through the router: escaping here and
+// decoding per path segment on the way in has to yield the original version.
+func TestVersionEscapedVersion(t *testing.T) {
+	tests := []struct {
+		name string
+		purl string
+		want string
+	}{
+		{"simple", "pkg:npm/lodash@4.17.21", "4.17.21"},
+		// "+" is legal in a path segment, so it stays literal and the UI keeps
+		// showing the version the way Debian writes it.
+		{"plus stays literal", "pkg:deb/nmap@7.91%2Bdfsg1-2ubuntu0.1", "7.91+dfsg1-2ubuntu0.1"},
+		// A slash would otherwise split the version into two path segments.
+		{"slash", "pkg:golang/example@release%2F1", "release%2F1"},
+		// A question mark would otherwise start the query string.
+		{"question mark", "pkg:npm/example@v1%3Fbuild", "v1%3Fbuild"},
+		// A version containing a literal "%2B" is stored double-encoded; the
+		// link must re-encode it or it decodes back to "+" instead.
+		{"literal percent escape", "pkg:npm/example@1.0%252B", "1.0%252B"},
+		{"space", "pkg:npm/example@1.0%20beta", "1.0%20beta"},
+		{"no version", "pkg:npm/lodash", ""},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			v := &Version{PURL: tt.purl}
+			got := v.EscapedVersion()
+			if got != tt.want {
+				t.Errorf("EscapedVersion() for %q = %q, want %q", tt.purl, got, tt.want)
+			}
+			// The router decodes each path segment, which must give back the
+			// version the page displays.
+			decoded, err := url.PathUnescape(got)
+			if err != nil {
+				t.Fatalf("PathUnescape(%q) failed: %v", got, err)
+			}
+			if decoded != v.Version() {
+				t.Errorf("round trip for %q = %q, want %q", tt.purl, decoded, v.Version())
 			}
 		})
 	}

--- a/internal/handler/debian_test.go
+++ b/internal/handler/debian_test.go
@@ -12,6 +12,11 @@ func TestDebianHandler_parsePoolPath(t *testing.T) {
 		{"pool/main/libn/libncurses/libncurses6_6.2-1_amd64.deb", "libncurses6", "6.2-1", "amd64"},
 		{"pool/contrib/v/virtualbox/virtualbox_6.1.38-1_amd64.deb", "virtualbox", "6.1.38-1", "amd64"},
 		{"pool/main/g/git/git_2.39.2-1_arm64.deb", "git", "2.39.2-1", "arm64"},
+		{
+			"pool/universe/n/nmap/nmap_7.91+dfsg1+really7.80+dfsg1-2ubuntu0.1_amd64.deb",
+			"nmap", "7.91+dfsg1+really7.80+dfsg1-2ubuntu0.1", "amd64",
+		},
+		{"pool/main/o/openssl/openssl_3.0.2-0ubuntu1.15~build1_amd64.deb", "openssl", "3.0.2-0ubuntu1.15~build1", "amd64"},
 		{"invalid/path", "", "", ""},
 		{"pool/main/n/nginx/nginx.deb", "", "", ""},
 	})

--- a/internal/server/api.go
+++ b/internal/server/api.go
@@ -139,12 +139,11 @@ type BulkResponse struct {
 // Resolves namespaced package names (Composer vendor/name, npm @scope/name) from the path.
 func (h *APIHandler) HandlePackagePath(w http.ResponseWriter, r *http.Request) {
 	ecosystem := chi.URLParam(r, "ecosystem")
-	wildcard := chi.URLParam(r, "*")
-	if err := validatePackagePath(wildcard); err != nil {
+	segments, err := packagePathSegments(r)
+	if err != nil {
 		badRequest(w, err.Error())
 		return
 	}
-	segments := splitWildcardPath(wildcard)
 
 	if ecosystem == "" || len(segments) == 0 {
 		badRequest(w, "ecosystem and name are required")
@@ -277,12 +276,11 @@ func (h *APIHandler) getVersion(w http.ResponseWriter, r *http.Request, ecosyste
 // Supports both {name} and {name}/{version} paths with namespaced package names.
 func (h *APIHandler) HandleVulnsPath(w http.ResponseWriter, r *http.Request) {
 	ecosystem := chi.URLParam(r, "ecosystem")
-	wildcard := chi.URLParam(r, "*")
-	if err := validatePackagePath(wildcard); err != nil {
+	segments, err := packagePathSegments(r)
+	if err != nil {
 		badRequest(w, err.Error())
 		return
 	}
-	segments := splitWildcardPath(wildcard)
 
 	if ecosystem == "" || len(segments) == 0 {
 		badRequest(w, "ecosystem and name are required")

--- a/internal/server/browse.go
+++ b/internal/server/browse.go
@@ -129,12 +129,11 @@ type BrowseFileInfo struct {
 //	{name}/{version}/file/{path}  -> browse file
 func (s *Server) handleBrowsePath(w http.ResponseWriter, r *http.Request) {
 	ecosystem := chi.URLParam(r, "ecosystem")
-	wildcard := chi.URLParam(r, "*")
-	if err := validatePackagePath(wildcard); err != nil {
+	segments, err := packagePathSegments(r)
+	if err != nil {
 		badRequest(w, err.Error())
 		return
 	}
-	segments := splitWildcardPath(wildcard)
 
 	if ecosystem == "" || len(segments) < 2 {
 		badRequest(w, "ecosystem, name, and version required")
@@ -185,12 +184,11 @@ func (s *Server) handleBrowsePath(w http.ResponseWriter, r *http.Request) {
 // Supported paths: {name}/{fromVersion}/{toVersion}
 func (s *Server) handleComparePath(w http.ResponseWriter, r *http.Request) {
 	ecosystem := chi.URLParam(r, "ecosystem")
-	wildcard := chi.URLParam(r, "*")
-	if err := validatePackagePath(wildcard); err != nil {
+	segments, err := packagePathSegments(r)
+	if err != nil {
 		badRequest(w, err.Error())
 		return
 	}
-	segments := splitWildcardPath(wildcard)
 
 	if ecosystem == "" || len(segments) < 3 {
 		badRequest(w, "ecosystem, name, fromVersion, and toVersion required")
@@ -477,11 +475,16 @@ func isLikelyText(filename string) bool {
 }
 
 // BrowseSourceData contains data for the browse source page.
+//
+// Version is the decoded version, for display. EscapedVersion is the same value
+// escaped as a single URL path segment and is what the links and the browse API
+// calls must use; see database.Version.EscapedVersion.
 type BrowseSourceData struct {
 	Layout
-	Ecosystem   string
-	PackageName string
-	Version     string
+	Ecosystem      string
+	PackageName    string
+	Version        string
+	EscapedVersion string
 }
 
 // handleBrowseSource is now showBrowseSource in server.go, dispatched via handlePackagePath.
@@ -583,12 +586,17 @@ func (s *Server) compareDiff(w http.ResponseWriter, r *http.Request, ecosystem, 
 }
 
 // ComparePageData contains data for the version comparison page.
+//
+// FromVersion and ToVersion are decoded, for display; the Escaped variants are
+// the path-segment form used to build the compare API URL.
 type ComparePageData struct {
 	Layout
-	Ecosystem   string
-	PackageName string
-	FromVersion string
-	ToVersion   string
+	Ecosystem          string
+	PackageName        string
+	FromVersion        string
+	ToVersion          string
+	EscapedFromVersion string
+	EscapedToVersion   string
 }
 
 // handleComparePage is now showComparePage in server.go, dispatched via handlePackagePath.

--- a/internal/server/browse_test.go
+++ b/internal/server/browse_test.go
@@ -415,8 +415,10 @@ func TestHandleBrowseSourcePage(t *testing.T) {
 	if !strings.Contains(body, "const packageName = 'test-browse'") {
 		t.Error("browse source page missing packageName variable")
 	}
-	if !strings.Contains(body, "const version = '1.0.0'") {
-		t.Error("browse source page missing version variable")
+	// The version reaches the browse API as one path segment, so the page holds
+	// its escaped form.
+	if !strings.Contains(body, "const versionPath = '1.0.0'") {
+		t.Error("browse source page missing versionPath variable")
 	}
 
 	// Verify content type
@@ -582,12 +584,13 @@ func TestHandleComparePage(t *testing.T) {
 
 	body := w.Body.String()
 
-	// Check that versions are set correctly in JavaScript
-	if !strings.Contains(body, "const fromVersion = '1.0.0'") {
-		t.Error("page should set fromVersion")
+	// Check that versions are set correctly in JavaScript. The compare API takes
+	// each version as a path segment, so the page holds their escaped forms.
+	if !strings.Contains(body, "const fromVersionPath = '1.0.0'") {
+		t.Error("page should set fromVersionPath")
 	}
-	if !strings.Contains(body, "const toVersion = '2.0.0'") {
-		t.Error("page should set toVersion")
+	if !strings.Contains(body, "const toVersionPath = '2.0.0'") {
+		t.Error("page should set toVersionPath")
 	}
 
 	// Test invalid format (missing separator)

--- a/internal/server/resolve.go
+++ b/internal/server/resolve.go
@@ -2,11 +2,13 @@ package server
 
 import (
 	"fmt"
+	"net/http"
 	"net/url"
 	"strings"
 	"unicode"
 
 	"github.com/git-pkgs/proxy/internal/database"
+	"github.com/go-chi/chi/v5"
 )
 
 // maxPackagePathLen bounds the wildcard portion of package routes (name plus
@@ -14,10 +16,38 @@ import (
 // longer, so 512 leaves room without admitting pathological inputs.
 const maxPackagePathLen = 512
 
+// packagePathSegments validates the wildcard portion of a package route and
+// splits it into decoded path segments.
+func packagePathSegments(r *http.Request) ([]string, error) {
+	wildcard := chi.URLParam(r, "*")
+	encoded := wildcardIsEncoded(r)
+	if err := validatePackagePath(wildcard, encoded); err != nil {
+		return nil, err
+	}
+
+	return splitWildcardPath(wildcard, encoded), nil
+}
+
+// wildcardIsEncoded reports whether the chi wildcard for this request is still
+// percent-encoded.
+//
+// chi routes on r.URL.RawPath when it is set and on r.URL.Path otherwise, and
+// net/url only sets RawPath when the request's escaping differs from the
+// canonical encoding of the decoded path. A version such as "release%2F1" is
+// therefore routed raw, while "1.0%252B" (a version whose text contains a
+// literal "%2B") encodes canonically and arrives already decoded once. The
+// distinction decides whether the segments still need decoding: decoding the
+// second case again would turn it into "1.0+" and resolve a different version.
+func wildcardIsEncoded(r *http.Request) bool {
+	return r.URL.RawPath != ""
+}
+
 // validatePackagePath rejects wildcard package paths that cannot be valid in
 // any supported ecosystem. It is a coarse filter applied before database or
 // enrichment lookups; ecosystem-specific name rules are layered on top.
-func validatePackagePath(path string) error {
+//
+// encoded has the meaning described on wildcardIsEncoded.
+func validatePackagePath(path string, encoded bool) error {
 	if path == "" {
 		return fmt.Errorf("package name required")
 	}
@@ -26,22 +56,28 @@ func validatePackagePath(path string) error {
 	}
 	// Validate the decoded segments: the handlers work with decoded values, so
 	// an escape such as "%00" or "%2E%2E" must not slip past these checks.
-	for _, seg := range splitWildcardPath(path) {
-		// A decoded segment can itself contain slashes (from "%2F"), and the
-		// segments are later rejoined into a package name that registries
-		// interpolate straight into an upstream URL. Check every path element,
-		// not just the segment as a whole, or "a%2F..%2F..%2Fb" traverses.
-		for _, elem := range strings.Split(seg, "/") {
-			if elem == ".." {
-				return fmt.Errorf("package path contains parent directory segment")
+	for _, seg := range splitWildcardPath(path, encoded) {
+		// Each segment is checked both as the handlers see it and decoded once
+		// more: a segment can reach a handler with escapes intact, and the
+		// upstream registry is then the one that decodes them.
+		for _, value := range []string{seg, decodePathSegment(seg)} {
+			// A decoded segment can itself contain slashes (from "%2F"), and
+			// the segments are later rejoined into a package name that
+			// registries interpolate straight into an upstream URL. Check every
+			// path element, not just the segment as a whole, or
+			// "a%2F..%2F..%2Fb" traverses.
+			for _, elem := range strings.Split(value, "/") {
+				if elem == ".." {
+					return fmt.Errorf("package path contains parent directory segment")
+				}
 			}
-		}
-		for _, r := range seg {
-			if r == 0 {
-				return fmt.Errorf("package path contains null byte")
-			}
-			if unicode.IsControl(r) {
-				return fmt.Errorf("package path contains control character %#U", r)
+			for _, r := range value {
+				if r == 0 {
+					return fmt.Errorf("package path contains null byte")
+				}
+				if unicode.IsControl(r) {
+					return fmt.Errorf("package path contains control character %#U", r)
+				}
 			}
 		}
 	}
@@ -75,18 +111,21 @@ func resolvePackageName(db *database.DB, ecosystem string, segments []string) (n
 // splitWildcardPath splits a chi wildcard path value into segments,
 // trimming any leading/trailing slashes.
 //
-// chi routes on the raw (still percent-encoded) path whenever the request URL
-// contains an escape, so each segment is decoded after splitting. Splitting
+// When encoded is set the value is still percent-encoded (see
+// wildcardIsEncoded), so each segment is decoded after splitting. Splitting
 // first keeps an encoded "%2F" inside a name from being mistaken for a
 // separator. Decoding matters for versions such as "1.0%2Bbuild1", which must
 // reach the handlers as "1.0+build1" so that rebuilding the PURL yields the
 // value that was stored rather than a double-encoded one.
-func splitWildcardPath(path string) []string {
+func splitWildcardPath(path string, encoded bool) []string {
 	path = strings.Trim(path, "/")
 	if path == "" {
 		return nil
 	}
 	segments := strings.Split(path, "/")
+	if !encoded {
+		return segments
+	}
 	for i, seg := range segments {
 		segments[i] = decodePathSegment(seg)
 	}

--- a/internal/server/resolve.go
+++ b/internal/server/resolve.go
@@ -2,6 +2,7 @@ package server
 
 import (
 	"fmt"
+	"net/url"
 	"strings"
 	"unicode"
 
@@ -23,12 +24,25 @@ func validatePackagePath(path string) error {
 	if len(path) > maxPackagePathLen {
 		return fmt.Errorf("package path exceeds %d bytes", maxPackagePathLen)
 	}
-	for _, r := range path {
-		if r == 0 {
-			return fmt.Errorf("package path contains null byte")
+	// Validate the decoded segments: the handlers work with decoded values, so
+	// an escape such as "%00" or "%2E%2E" must not slip past these checks.
+	for _, seg := range splitWildcardPath(path) {
+		// A decoded segment can itself contain slashes (from "%2F"), and the
+		// segments are later rejoined into a package name that registries
+		// interpolate straight into an upstream URL. Check every path element,
+		// not just the segment as a whole, or "a%2F..%2F..%2Fb" traverses.
+		for _, elem := range strings.Split(seg, "/") {
+			if elem == ".." {
+				return fmt.Errorf("package path contains parent directory segment")
+			}
 		}
-		if unicode.IsControl(r) {
-			return fmt.Errorf("package path contains control character %#U", r)
+		for _, r := range seg {
+			if r == 0 {
+				return fmt.Errorf("package path contains null byte")
+			}
+			if unicode.IsControl(r) {
+				return fmt.Errorf("package path contains control character %#U", r)
+			}
 		}
 	}
 	return nil
@@ -60,10 +74,34 @@ func resolvePackageName(db *database.DB, ecosystem string, segments []string) (n
 
 // splitWildcardPath splits a chi wildcard path value into segments,
 // trimming any leading/trailing slashes.
+//
+// chi routes on the raw (still percent-encoded) path whenever the request URL
+// contains an escape, so each segment is decoded after splitting. Splitting
+// first keeps an encoded "%2F" inside a name from being mistaken for a
+// separator. Decoding matters for versions such as "1.0%2Bbuild1", which must
+// reach the handlers as "1.0+build1" so that rebuilding the PURL yields the
+// value that was stored rather than a double-encoded one.
 func splitWildcardPath(path string) []string {
 	path = strings.Trim(path, "/")
 	if path == "" {
 		return nil
 	}
-	return strings.Split(path, "/")
+	segments := strings.Split(path, "/")
+	for i, seg := range segments {
+		segments[i] = decodePathSegment(seg)
+	}
+	return segments
+}
+
+// decodePathSegment percent-decodes a single URL path segment, returning it
+// unchanged if it is not valid percent-encoding.
+func decodePathSegment(seg string) string {
+	if !strings.Contains(seg, "%") {
+		return seg
+	}
+	decoded, err := url.PathUnescape(seg)
+	if err != nil {
+		return seg
+	}
+	return decoded
 }

--- a/internal/server/resolve_test.go
+++ b/internal/server/resolve_test.go
@@ -104,6 +104,14 @@ func TestSplitWildcardPath(t *testing.T) {
 		{"symfony/console/6.0.0/browse", []string{"symfony", "console", "6.0.0", "browse"}},
 		{"", nil},
 		{"/", nil},
+		// chi routes on the raw path when the URL contains an escape, so
+		// segments arrive percent-encoded and must be decoded.
+		{"nmap/7.91%2Bdfsg1%2Breally7.80%2Bdfsg1-2ubuntu0.1", []string{"nmap", "7.91+dfsg1+really7.80+dfsg1-2ubuntu0.1"}},
+		{"%40babel/core/7.0.0", []string{"@babel", "core", "7.0.0"}},
+		// An encoded separator stays inside its segment rather than splitting.
+		{"vendor%2Fname/1.0.0", []string{"vendor/name", "1.0.0"}},
+		// Invalid escapes are passed through untouched.
+		{"lodash/1.0%zz", []string{"lodash", "1.0%zz"}},
 	}
 
 	for _, tt := range tests {
@@ -132,8 +140,19 @@ func TestValidatePackagePath(t *testing.T) {
 		{"composer namespaced", "symfony/console/6.0.0", false},
 		{"maven coordinates", "org.apache.commons/commons-lang3/3.12.0", false},
 		{"unicode", "café/1.0.0", false},
+		{"encoded plus in version", "nmap/7.91%2Bdfsg1-2ubuntu0.1", false},
 		{"empty", "", true},
 		{"null byte", "lodash\x00/4.17.21", true},
+		{"encoded null byte", "lodash/%00", true},
+		{"encoded newline", "lodash/1.0%0A", true},
+		{"parent segment", "lodash/../4.17.21", true},
+		{"encoded parent segment", "lodash/%2E%2E/4.17.21", true},
+		// A decoded segment can contain slashes, so traversal can hide inside
+		// one segment. Registries interpolate the resolved name straight into
+		// an upstream URL, and Go sends dot-segments verbatim.
+		{"traversal inside one segment", "pkg%2F..%2F..%2Fadmin", true},
+		{"traversal via encoded dots and slash", "pkg%2f%2e%2e%2fadmin", true},
+		{"encoded slash alone is allowed", "vendor%2Fname/1.0.0", false},
 		{"null byte suffix", "lodash\x00", true},
 		{"newline", "lodash\n4.17.21", true},
 		{"carriage return", "lodash\r", true},

--- a/internal/server/resolve_test.go
+++ b/internal/server/resolve_test.go
@@ -1,12 +1,15 @@
 package server
 
 import (
+	"net/http"
+	"net/http/httptest"
 	"os"
 	"path/filepath"
 	"strings"
 	"testing"
 
 	"github.com/git-pkgs/proxy/internal/database"
+	"github.com/go-chi/chi/v5"
 )
 
 func newTestDB(t *testing.T) (*database.DB, func()) {
@@ -95,34 +98,44 @@ func TestResolvePackageName(t *testing.T) {
 
 func TestSplitWildcardPath(t *testing.T) {
 	tests := []struct {
-		input string
-		want  []string
+		input   string
+		encoded bool
+		want    []string
 	}{
-		{"lodash", []string{"lodash"}},
-		{"lodash/4.17.21", []string{"lodash", "4.17.21"}},
-		{"monolog/monolog", []string{"monolog", "monolog"}},
-		{"symfony/console/6.0.0/browse", []string{"symfony", "console", "6.0.0", "browse"}},
-		{"", nil},
-		{"/", nil},
-		// chi routes on the raw path when the URL contains an escape, so
-		// segments arrive percent-encoded and must be decoded.
-		{"nmap/7.91%2Bdfsg1%2Breally7.80%2Bdfsg1-2ubuntu0.1", []string{"nmap", "7.91+dfsg1+really7.80+dfsg1-2ubuntu0.1"}},
-		{"%40babel/core/7.0.0", []string{"@babel", "core", "7.0.0"}},
+		{"lodash", false, []string{"lodash"}},
+		{"lodash/4.17.21", false, []string{"lodash", "4.17.21"}},
+		{"monolog/monolog", false, []string{"monolog", "monolog"}},
+		{"symfony/console/6.0.0/browse", false, []string{"symfony", "console", "6.0.0", "browse"}},
+		{"", false, nil},
+		{"/", false, nil},
+		// chi routes on the raw path when it differs from the canonical
+		// encoding of the decoded path, so segments arrive percent-encoded and
+		// must be decoded.
+		{
+			"nmap/7.91%2Bdfsg1%2Breally7.80%2Bdfsg1-2ubuntu0.1", true,
+			[]string{"nmap", "7.91+dfsg1+really7.80+dfsg1-2ubuntu0.1"},
+		},
+		{"%40babel/core/7.0.0", true, []string{"@babel", "core", "7.0.0"}},
 		// An encoded separator stays inside its segment rather than splitting.
-		{"vendor%2Fname/1.0.0", []string{"vendor/name", "1.0.0"}},
+		{"vendor%2Fname/1.0.0", true, []string{"vendor/name", "1.0.0"}},
 		// Invalid escapes are passed through untouched.
-		{"lodash/1.0%zz", []string{"lodash", "1.0%zz"}},
+		{"lodash/1.0%zz", true, []string{"lodash", "1.0%zz"}},
+		// When chi routed on the already-decoded path, an escape that survived
+		// is part of the value: a version whose text is "1.0%2B" reaches here
+		// as "1.0%2B" and decoding it again would yield "1.0+".
+		{"nmap/1.0%2B", false, []string{"nmap", "1.0%2B"}},
 	}
 
 	for _, tt := range tests {
-		got := splitWildcardPath(tt.input)
+		got := splitWildcardPath(tt.input, tt.encoded)
 		if len(got) != len(tt.want) {
-			t.Errorf("splitWildcardPath(%q) = %v, want %v", tt.input, got, tt.want)
+			t.Errorf("splitWildcardPath(%q, %v) = %v, want %v", tt.input, tt.encoded, got, tt.want)
 			continue
 		}
 		for i := range got {
 			if got[i] != tt.want[i] {
-				t.Errorf("splitWildcardPath(%q)[%d] = %q, want %q", tt.input, i, got[i], tt.want[i])
+				t.Errorf("splitWildcardPath(%q, %v)[%d] = %q, want %q",
+					tt.input, tt.encoded, i, got[i], tt.want[i])
 			}
 		}
 	}
@@ -164,9 +177,64 @@ func TestValidatePackagePath(t *testing.T) {
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			err := validatePackagePath(tt.path)
-			if (err != nil) != tt.wantErr {
-				t.Errorf("validatePackagePath(%q) error = %v, wantErr %v", tt.path, err, tt.wantErr)
+			// The verdict must not depend on whether chi routed on the raw or
+			// on the already-decoded path: an escape that reaches a handler
+			// undecoded is decoded by the upstream registry instead, so it is
+			// rejected either way.
+			for _, encoded := range []bool{false, true} {
+				err := validatePackagePath(tt.path, encoded)
+				if (err != nil) != tt.wantErr {
+					t.Errorf("validatePackagePath(%q, %v) error = %v, wantErr %v",
+						tt.path, encoded, err, tt.wantErr)
+				}
+			}
+		})
+	}
+}
+
+// TestPackagePathSegments drives the real router, which is what decides whether
+// the wildcard still carries percent-encoding. Go decodes the request path
+// itself unless the escaping is non-canonical, so the same version can arrive
+// either way and only one of the two forms may be decoded again.
+func TestPackagePathSegments(t *testing.T) {
+	tests := []struct {
+		name   string
+		target string
+		want   []string
+	}{
+		{"plain", "/pkg/npm/lodash/4.17.21", []string{"lodash", "4.17.21"}},
+		{"encoded plus", "/pkg/deb/nmap/7.91%2Bdfsg1-2ubuntu0.1", []string{"nmap", "7.91+dfsg1-2ubuntu0.1"}},
+		{"decoded plus", "/pkg/deb/nmap/7.91+dfsg1-2ubuntu0.1", []string{"nmap", "7.91+dfsg1-2ubuntu0.1"}},
+		// An encoded slash is one segment, not a separator.
+		{"encoded slash", "/pkg/composer/vendor%2Fname/1.0.0", []string{"vendor/name", "1.0.0"}},
+		{"question mark", "/pkg/npm/example/v1%3Fbuild", []string{"example", "v1?build"}},
+		// "1.0%252B" is the escaped form of the version "1.0%2B"; net/url
+		// already decoded it once, so it must not be decoded again.
+		{"literal percent escape", "/pkg/npm/example/1.0%252B", []string{"example", "1.0%2B"}},
+		{"browse suffix", "/pkg/deb/nmap/7.91%2Bdfsg1/browse", []string{"nmap", "7.91+dfsg1", "browse"}},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			var got []string
+			var gotErr error
+
+			router := chi.NewRouter()
+			router.Get("/pkg/{ecosystem}/*", func(_ http.ResponseWriter, r *http.Request) {
+				got, gotErr = packagePathSegments(r)
+			})
+			router.ServeHTTP(httptest.NewRecorder(), httptest.NewRequest("GET", tt.target, nil))
+
+			if gotErr != nil {
+				t.Fatalf("packagePathSegments(%q) failed: %v", tt.target, gotErr)
+			}
+			if len(got) != len(tt.want) {
+				t.Fatalf("segments for %q = %v, want %v", tt.target, got, tt.want)
+			}
+			for i := range got {
+				if got[i] != tt.want[i] {
+					t.Errorf("segments for %q [%d] = %q, want %q", tt.target, i, got[i], tt.want[i])
+				}
 			}
 		})
 	}

--- a/internal/server/server.go
+++ b/internal/server/server.go
@@ -54,6 +54,7 @@ import (
 	"fmt"
 	"log/slog"
 	"net/http"
+	"net/url"
 	"strconv"
 	"strings"
 	"time"
@@ -668,12 +669,11 @@ func (s *Server) handlePackagesList(w http.ResponseWriter, r *http.Request) {
 //	{name}/compare/{v1}...{v2}   -> compare versions
 func (s *Server) handlePackagePath(w http.ResponseWriter, r *http.Request) {
 	ecosystem := chi.URLParam(r, "ecosystem")
-	wildcard := chi.URLParam(r, "*")
-	if err := validatePackagePath(wildcard); err != nil {
+	segments, err := packagePathSegments(r)
+	if err != nil {
 		http.Error(w, err.Error(), http.StatusBadRequest)
 		return
 	}
-	segments := splitWildcardPath(wildcard)
 
 	if ecosystem == "" || len(segments) == 0 {
 		http.Error(w, "ecosystem and package name required", http.StatusBadRequest)
@@ -817,10 +817,11 @@ func (s *Server) showVersion(w http.ResponseWriter, r *http.Request, ecosystem, 
 
 func (s *Server) showBrowseSource(w http.ResponseWriter, r *http.Request, ecosystem, name, version string) {
 	data := BrowseSourceData{
-		Layout:      s.layoutFor(r),
-		Ecosystem:   ecosystem,
-		PackageName: name,
-		Version:     version,
+		Layout:         s.layoutFor(r),
+		Ecosystem:      ecosystem,
+		PackageName:    name,
+		Version:        version,
+		EscapedVersion: url.PathEscape(version),
 	}
 
 	if err := s.templates.Render(w, "browse_source", data); err != nil {
@@ -838,11 +839,13 @@ func (s *Server) showComparePage(w http.ResponseWriter, r *http.Request, ecosyst
 	}
 
 	data := ComparePageData{
-		Layout:      s.layoutFor(r),
-		Ecosystem:   ecosystem,
-		PackageName: name,
-		FromVersion: parts[0],
-		ToVersion:   parts[1],
+		Layout:             s.layoutFor(r),
+		Ecosystem:          ecosystem,
+		PackageName:        name,
+		FromVersion:        parts[0],
+		ToVersion:          parts[1],
+		EscapedFromVersion: url.PathEscape(parts[0]),
+		EscapedToVersion:   url.PathEscape(parts[1]),
 	}
 
 	if err := s.templates.Render(w, "compare_versions", data); err != nil {

--- a/internal/server/server_test.go
+++ b/internal/server/server_test.go
@@ -4,12 +4,16 @@ import (
 	"database/sql"
 	"encoding/json"
 	"fmt"
+	"html"
 	"io"
 	"log/slog"
 	"net/http"
 	"net/http/httptest"
+	"net/url"
 	"os"
 	"path/filepath"
+	"regexp"
+	"strconv"
 	"strings"
 	"testing"
 	"time"
@@ -18,6 +22,7 @@ import (
 	"github.com/git-pkgs/proxy/internal/database"
 	"github.com/git-pkgs/proxy/internal/handler"
 	"github.com/git-pkgs/proxy/internal/storage"
+	"github.com/git-pkgs/purl"
 	"github.com/git-pkgs/registries/fetch"
 	"github.com/go-chi/chi/v5"
 )
@@ -813,6 +818,185 @@ func TestVersionShowPage_PlusInVersion(t *testing.T) {
 			t.Errorf("GET %s: expected status 200, got %d", path, w.Code)
 		}
 	}
+}
+
+// TestVersionURLEscaping covers versions whose characters are significant in a
+// URL path: "/" splits off another path segment, "?" starts a query string, and
+// a literal "%xx" is read back as the character it encodes. The pages show the
+// decoded version but must build every link from a separately escaped value,
+// and those links have to resolve back to the same version.
+func TestVersionURLEscaping(t *testing.T) {
+	// A second version is needed for the compare controls to be rendered.
+	const otherVersion = "1.0.0"
+
+	tests := []struct {
+		name    string
+		version string
+	}{
+		{"slash", "release/1"},
+		{"question mark", "v1?build"},
+		{"literal percent escape", "1.0%2B"},
+		{"plus", "7.91+dfsg1-2ubuntu0.1"},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			ts := newTestServer(t)
+			defer ts.close()
+			seedEscapingVersions(t, ts.db, tt.version, otherVersion)
+
+			// The package page links to the escaped version.
+			escaped := url.PathEscape(tt.version)
+			versionPath := "/ui/package/deb/nmap/" + escaped
+			packagePage := ts.getOK(t, "/ui/package/deb/nmap")
+			if !containsValue(attrValues(packagePage, "href"), versionPath) {
+				t.Fatalf("package page has no link to %q; hrefs: %v",
+					versionPath, attrValues(packagePage, "href"))
+			}
+
+			ts.checkVersionAndBrowsePages(t, versionPath, tt.version, escaped)
+			ts.checkComparePage(t, packagePage, tt.version, escaped, otherVersion)
+		})
+	}
+}
+
+// seedEscapingVersions stores a Debian package with the given versions, each
+// with a cached artifact so that the version page offers its browse link.
+func seedEscapingVersions(t *testing.T, db *database.DB, versions ...string) {
+	t.Helper()
+
+	pkg := &database.Package{PURL: "pkg:deb/nmap", Ecosystem: "deb", Name: "nmap"}
+	if err := db.UpsertPackage(pkg); err != nil {
+		t.Fatalf("failed to upsert package: %v", err)
+	}
+	for _, v := range versions {
+		versionPURL := purl.MakePURLString("deb", "nmap", v)
+		if err := db.UpsertVersion(&database.Version{
+			PURL: versionPURL, PackagePURL: pkg.PURL,
+		}); err != nil {
+			t.Fatalf("failed to upsert version %q: %v", v, err)
+		}
+		if err := db.UpsertArtifact(&database.Artifact{
+			VersionPURL: versionPURL,
+			Filename:    "nmap.deb",
+			UpstreamURL: "http://archive.ubuntu.com/ubuntu/pool/universe/n/nmap/nmap.deb",
+			StoragePath: sql.NullString{String: "/cache/nmap.deb", Valid: true},
+			FetchedAt:   sql.NullTime{Time: time.Now(), Valid: true},
+		}); err != nil {
+			t.Fatalf("failed to upsert artifact for %q: %v", v, err)
+		}
+	}
+}
+
+// checkVersionAndBrowsePages follows a version link from the package page and
+// then the browse link from the version page, checking that both resolve to the
+// stored version and display it decoded.
+func (ts *testServer) checkVersionAndBrowsePages(t *testing.T, versionPath, version, escaped string) {
+	t.Helper()
+
+	versionPage := ts.getOK(t, versionPath)
+	wantPURL := "pkg:deb/nmap@" + version
+	if !strings.Contains(html.UnescapeString(versionPage), wantPURL) {
+		t.Errorf("version page does not show %q", wantPURL)
+	}
+
+	browsePath := versionPath + "/browse"
+	if !containsValue(attrValues(versionPage, "href"), browsePath) {
+		t.Fatalf("version page has no browse link to %q; hrefs: %v",
+			browsePath, attrValues(versionPage, "href"))
+	}
+
+	browsePage := ts.getOK(t, browsePath)
+	if !strings.Contains(html.UnescapeString(browsePage), "nmap@"+version) {
+		t.Errorf("browse page does not show the decoded version %q", version)
+	}
+	// The browse API is called with the escaped version, not with the text shown
+	// in the heading.
+	if got := jsConstant(t, browsePage, "versionPath"); got != escaped {
+		t.Errorf("browse page passes %q to the browse API, want %q", got, escaped)
+	}
+}
+
+// checkComparePage builds the compare URL the way the package page's script
+// does, from the values its checkboxes carry, and checks the page it reaches.
+func (ts *testServer) checkComparePage(t *testing.T, packagePage, version, escaped, otherVersion string) {
+	t.Helper()
+
+	selectable := attrValues(packagePage, "data-version-path")
+	if !containsValue(selectable, escaped) {
+		t.Fatalf("package page compare data holds %v, want %q", selectable, escaped)
+	}
+
+	comparePage := ts.getOK(t, "/ui/package/deb/nmap/compare/"+escaped+"..."+otherVersion)
+	decoded := html.UnescapeString(comparePage)
+	for _, want := range []string{version, otherVersion} {
+		if !strings.Contains(decoded, want) {
+			t.Errorf("compare page does not show version %q", want)
+		}
+	}
+	if got := jsConstant(t, comparePage, "fromVersionPath"); got != escaped {
+		t.Errorf("compare page passes %q to the compare API, want %q", got, escaped)
+	}
+}
+
+// getOK performs a GET against the server and fails the test unless it returns
+// 200, returning the response body.
+func (ts *testServer) getOK(t *testing.T, path string) string {
+	t.Helper()
+
+	req := httptest.NewRequest("GET", path, nil)
+	w := httptest.NewRecorder()
+	ts.handler.ServeHTTP(w, req)
+	if w.Code != http.StatusOK {
+		t.Fatalf("GET %s: expected status 200, got %d", path, w.Code)
+	}
+
+	return w.Body.String()
+}
+
+// attrValues returns the value of every occurrence of an HTML attribute in a
+// rendered page, with HTML entities resolved so that values can be compared
+// against the raw strings they were built from.
+func attrValues(body, attr string) []string {
+	re := regexp.MustCompile(regexp.QuoteMeta(attr) + `="([^"]*)"`)
+
+	var values []string
+	for _, match := range re.FindAllStringSubmatch(body, -1) {
+		values = append(values, html.UnescapeString(match[1]))
+	}
+
+	return values
+}
+
+// jsConstant returns the value of a single-quoted JavaScript string constant in
+// a rendered page. html/template escapes characters that are significant in
+// JavaScript, rendering "+" as "\\u002b" for instance, so the escapes are
+// resolved to recover the value the page actually uses.
+func jsConstant(t *testing.T, body, name string) string {
+	t.Helper()
+
+	re := regexp.MustCompile(`const ` + regexp.QuoteMeta(name) + ` = '([^']*)'`)
+	match := re.FindStringSubmatch(body)
+	if match == nil {
+		t.Fatalf("page does not declare the constant %q", name)
+	}
+
+	unescaped, err := strconv.Unquote(`"` + match[1] + `"`)
+	if err != nil {
+		t.Fatalf("cannot unescape %q: %v", match[1], err)
+	}
+
+	return unescaped
+}
+
+func containsValue(values []string, want string) bool {
+	for _, v := range values {
+		if v == want {
+			return true
+		}
+	}
+
+	return false
 }
 
 func TestPackageShowPage_WithLicense(t *testing.T) {

--- a/internal/server/server_test.go
+++ b/internal/server/server_test.go
@@ -764,6 +764,57 @@ func TestVersionShowPage_NotFoundServer(t *testing.T) {
 	}
 }
 
+// TestVersionShowPage_PlusInVersion covers Debian/Ubuntu style versions such as
+// nmap's "7.91+dfsg1+really7.80+dfsg1-2ubuntu0.1". PURL percent-encodes "+" as
+// "%2B", so the UI must show the decoded version and resolve both the decoded
+// and the still-encoded form of the URL back to the same version.
+func TestVersionShowPage_PlusInVersion(t *testing.T) {
+	ts := newTestServer(t)
+	defer ts.close()
+
+	const version = "7.91+dfsg1+really7.80+dfsg1-2ubuntu0.1"
+	const versionPURL = "pkg:deb/nmap@7.91%2Bdfsg1%2Breally7.80%2Bdfsg1-2ubuntu0.1"
+
+	pkg := &database.Package{PURL: "pkg:deb/nmap", Ecosystem: "deb", Name: "nmap"}
+	if err := ts.db.UpsertPackage(pkg); err != nil {
+		t.Fatalf("failed to upsert package: %v", err)
+	}
+	if err := ts.db.UpsertVersion(&database.Version{
+		PURL: versionPURL, PackagePURL: pkg.PURL,
+	}); err != nil {
+		t.Fatalf("failed to upsert version: %v", err)
+	}
+
+	// The package page must link to and display the decoded version.
+	req := httptest.NewRequest("GET", "/ui/package/deb/nmap", nil)
+	w := httptest.NewRecorder()
+	ts.handler.ServeHTTP(w, req)
+	if w.Code != http.StatusOK {
+		t.Fatalf("package page: expected status 200, got %d", w.Code)
+	}
+	body := w.Body.String()
+	if strings.Contains(body, "%2B") {
+		t.Error("package page leaks PURL percent-encoding into the UI")
+	}
+	// html/template renders "+" as the "&#43;" entity inside attributes and text.
+	if !strings.Contains(body, "7.91&#43;dfsg1&#43;really7.80&#43;dfsg1-2ubuntu0.1") {
+		t.Error("expected package page to show the decoded version")
+	}
+
+	// Both the decoded and the encoded URL must reach the version page.
+	for _, path := range []string{
+		"/ui/package/deb/nmap/" + version,
+		"/ui/package/deb/nmap/7.91%2Bdfsg1%2Breally7.80%2Bdfsg1-2ubuntu0.1",
+	} {
+		req := httptest.NewRequest("GET", path, nil)
+		w := httptest.NewRecorder()
+		ts.handler.ServeHTTP(w, req)
+		if w.Code != http.StatusOK {
+			t.Errorf("GET %s: expected status 200, got %d", path, w.Code)
+		}
+	}
+}
+
 func TestPackageShowPage_WithLicense(t *testing.T) {
 	ts := newTestServer(t)
 	defer ts.close()

--- a/internal/server/templates/pages/browse_source.html
+++ b/internal/server/templates/pages/browse_source.html
@@ -7,7 +7,7 @@
         <span class="mx-2">/</span>
         <a href="/ui/package/{{.Ecosystem}}/{{.PackageName}}" class="hover:text-gray-900 dark:hover:text-gray-100">{{.PackageName}}</a>
         <span class="mx-2">/</span>
-        <a href="/ui/package/{{.Ecosystem}}/{{.PackageName}}/{{.Version}}" class="hover:text-gray-900 dark:hover:text-gray-100">{{.Version}}</a>
+        <a href="/ui/package/{{.Ecosystem}}/{{.PackageName}}/{{.EscapedVersion}}" class="hover:text-gray-900 dark:hover:text-gray-100">{{.Version}}</a>
         <span class="mx-2">/</span>
         <span>Browse Source</span>
     </nav>
@@ -51,7 +51,10 @@
 <script>
 const ecosystem = '{{.Ecosystem}}';
 const packageName = '{{.PackageName}}';
-const version = '{{.Version}}';
+// The browse API takes the version as one path segment, so the escaped form is
+// used here: a version such as "release/1" or "v1?build" would otherwise change
+// the request path rather than travel inside it.
+const versionPath = '{{.EscapedVersion}}';
 let currentPath = '';
 
 // Escape a string for safe interpolation into HTML attributes and content.
@@ -65,7 +68,7 @@ function escapeHTML(str) {
 // Load file tree for a directory
 async function loadFileTree(path = '') {
     try {
-        const url = `/ui/api/browse/${ecosystem}/${packageName}/${version}?path=${encodeURIComponent(path)}`;
+        const url = `/ui/api/browse/${ecosystem}/${packageName}/${versionPath}?path=${encodeURIComponent(path)}`;
         const response = await fetch(url);
         if (!response.ok) throw new Error('Failed to load directory');
 
@@ -137,7 +140,7 @@ function renderFileTree(files, basePath) {
 // Load and display file content
 async function loadFile(path) {
     try {
-        const url = `/ui/api/browse/${ecosystem}/${packageName}/${version}/file/${path}`;
+        const url = `/ui/api/browse/${ecosystem}/${packageName}/${versionPath}/file/${path}`;
         const response = await fetch(url);
         if (!response.ok) throw new Error('Failed to load file');
 

--- a/internal/server/templates/pages/compare_versions.html
+++ b/internal/server/templates/pages/compare_versions.html
@@ -74,12 +74,14 @@
 <script>
 const ecosystem = '{{.Ecosystem}}';
 const packageName = '{{.PackageName}}';
-const fromVersion = '{{.FromVersion}}';
-const toVersion = '{{.ToVersion}}';
+// Each version is one path segment of the compare API URL, so the escaped form
+// is used rather than the decoded text shown in the heading above.
+const fromVersionPath = '{{.EscapedFromVersion}}';
+const toVersionPath = '{{.EscapedToVersion}}';
 
 async function loadDiff() {
     try {
-        const url = `/ui/api/compare/${ecosystem}/${packageName}/${fromVersion}/${toVersion}`;
+        const url = `/ui/api/compare/${ecosystem}/${packageName}/${fromVersionPath}/${toVersionPath}`;
         const response = await fetch(url);
 
         if (!response.ok) {

--- a/internal/server/templates/pages/package_show.html
+++ b/internal/server/templates/pages/package_show.html
@@ -64,7 +64,7 @@
         <div class="px-6 py-3 flex items-center justify-between version-row">
             <div class="flex items-center gap-3">
                 <input type="checkbox" class="version-checkbox hidden" data-version="{{.Version}}" />
-                <a href="/ui/package/{{$.Package.Ecosystem}}/{{$.Package.Name}}/{{.Version}}" class="font-mono text-sm hover:text-blue-600 dark:hover:text-blue-400">{{.PURL}}</a>
+                <a href="/ui/package/{{$.Package.Ecosystem}}/{{$.Package.Name}}/{{.Version}}" class="font-mono text-sm hover:text-blue-600 dark:hover:text-blue-400">{{.DisplayPURL}}</a>
                 {{if .Yanked}}<span class="ml-2 inline-flex items-center px-2 py-0.5 rounded text-xs font-medium bg-red-100 text-red-700 dark:bg-red-900 dark:text-red-300">yanked</span>{{end}}
             </div>
             {{if .PublishedAt.Valid}}<span class="text-sm text-gray-500 dark:text-gray-400">{{.PublishedAt.Time.Format "2006-01-02"}}</span>{{end}}

--- a/internal/server/templates/pages/package_show.html
+++ b/internal/server/templates/pages/package_show.html
@@ -63,8 +63,8 @@
         {{range .Versions}}
         <div class="px-6 py-3 flex items-center justify-between version-row">
             <div class="flex items-center gap-3">
-                <input type="checkbox" class="version-checkbox hidden" data-version="{{.Version}}" />
-                <a href="/ui/package/{{$.Package.Ecosystem}}/{{$.Package.Name}}/{{.Version}}" class="font-mono text-sm hover:text-blue-600 dark:hover:text-blue-400">{{.DisplayPURL}}</a>
+                <input type="checkbox" class="version-checkbox hidden" data-version-path="{{.EscapedVersion}}" />
+                <a href="/ui/package/{{$.Package.Ecosystem}}/{{$.Package.Name}}/{{.EscapedVersion}}" class="font-mono text-sm hover:text-blue-600 dark:hover:text-blue-400">{{.DisplayPURL}}</a>
                 {{if .Yanked}}<span class="ml-2 inline-flex items-center px-2 py-0.5 rounded text-xs font-medium bg-red-100 text-red-700 dark:bg-red-900 dark:text-red-300">yanked</span>{{end}}
             </div>
             {{if .PublishedAt.Valid}}<span class="text-sm text-gray-500 dark:text-gray-400">{{.PublishedAt.Time.Format "2006-01-02"}}</span>{{end}}
@@ -120,9 +120,11 @@ document.addEventListener('change', function(e) {
         const checked = document.querySelectorAll('.version-checkbox:checked');
 
         if (checked.length === 2) {
-            // Navigate to compare page
-            const v1 = checked[0].dataset.version;
-            const v2 = checked[1].dataset.version;
+            // Navigate to compare page. The checkboxes carry the version
+            // already escaped as a path segment, so a version containing "/",
+            // "?" or a literal "%" does not break out of the segment.
+            const v1 = checked[0].dataset.versionPath;
+            const v2 = checked[1].dataset.versionPath;
             window.location.href = `/ui/package/${ecosystem}/${packageName}/compare/${v1}...${v2}`;
         } else if (checked.length > 2) {
             // Uncheck the oldest selection

--- a/internal/server/templates/pages/version_show.html
+++ b/internal/server/templates/pages/version_show.html
@@ -22,7 +22,7 @@
     {{end}}
     {{if .HasCachedArtifact}}
     <div class="mt-4">
-        <a href="/ui/package/{{.Package.Ecosystem}}/{{.Package.Name}}/{{.Version.Version}}/browse"
+        <a href="/ui/package/{{.Package.Ecosystem}}/{{.Package.Name}}/{{.Version.EscapedVersion}}/browse"
            class="inline-flex items-center px-4 py-2 bg-blue-600 text-white rounded-lg hover:bg-blue-700 transition-colors">
             <svg class="w-4 h-4 mr-2" fill="none" stroke="currentColor" viewBox="0 0 24 24">
                 <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M3 7v10a2 2 0 002 2h14a2 2 0 002-2V9a2 2 0 00-2-2h-6l-2-2H5a2 2 0 00-2 2z"></path>

--- a/internal/server/templates/pages/version_show.html
+++ b/internal/server/templates/pages/version_show.html
@@ -1,4 +1,4 @@
-{{define "title"}}{{.Package.Name}}@{{.Version.PURL}} - git-pkgs proxy{{end}}
+{{define "title"}}{{.Version.DisplayPURL}} - git-pkgs proxy{{end}}
 
 {{define "content"}}
 <div class="mb-6">
@@ -9,7 +9,7 @@
     </nav>
     <div class="flex items-center gap-3 mb-2">
         {{template "ecosystem_badge" .Package.Ecosystem}}
-        <h1 class="text-3xl font-bold font-mono">{{.Version.PURL}}</h1>
+        <h1 class="text-3xl font-bold font-mono">{{.Version.DisplayPURL}}</h1>
         {{if .IsOutdated}}
         <span class="inline-flex items-center px-2 py-1 rounded text-sm font-medium bg-amber-100 text-amber-700 dark:bg-amber-900 dark:text-amber-300">outdated</span>
         {{end}}


### PR DESCRIPTION
another claude generated patch to fix the following behaviour:
<img width="536" height="178" alt="image" src="https://github.com/user-attachments/assets/2fbdd9c5-7019-420c-b299-002aef4846f3" />

## Problem

Package versions containing `+` were unusable in the UI. Reported against `nmap_7.91+dfsg1+really7.80+dfsg1-2ubuntu0.1_amd64.deb` from the Ubuntu archive (PROXY_UPSTREAM_DEBIAN=[http://archive.ubuntu.com/ubuntu](http://archive.ubuntu.com/ubuntu)), which displayed as `@7.91%2Bdfsg1%2Breally7.80%2Bdfsg1-2ubuntu0.1`.

The artifact download itself was always fine — the bug was in reading the version back out of the PURL. PURL percent-encodes `+` in path components, so the version is stored as `pkg:deb/nmap@7.91%2Bdfsg1%2B…`. Two places treated the raw substring after `@` as the version:

1. **Display** — `Version.Version()` (`strings.LastIndex(purl, "@")`) and the SQL  `SUBSTR(v.purl, INSTR(v.purl,'@') + 1)` in `GetRecentlyCachedPackages` never decoded, so `%2B` leaked into the dashboard and package pages.
2. **Round-trip** — that encoded string went into the version link. chi routes on `r.URL.RawPath` whenever the URL contains an escape, so the handler received `7.91%2B…` back and re-encoded it into `pkg:deb/nmap@7.91%252B…`. **The version page 404'd.**

This affects any ecosystem with non-alphanumeric version characters, not just Debian: npm scoped packages had the same problem via `%40`.

## Changes

- `internal/database/types.go` — add `VersionFromPURL` (strips qualifiers/subpath, then percent-decodes); `Version.Version()` uses it. Add `Version.DisplayPURL()` for  a readable PURL in the UI, decoding all path components.
- `internal/database/queries.go` — `GetRecentlyCachedPackages` selects `v.purl` and  derives the version in Go. This also removes the duplicated Postgres-specific  `SUBSTRING`/`POSITION` variant of the query.
- `internal/server/resolve.go` — `splitWildcardPath` percent-decodes each segment  *after* splitting, so an encoded `%2F` inside a name is not mistaken for a  separator.
- Templates use `DisplayPURL` for version headings and labels.

**Storage is unchanged.** Stored PURLs keep their canonical encoding (`%2B`, `%40`), which is what the API, cache keys and all lookups use. This is display and inbound routing only, so no cache migration is needed. Old encoded URLs still resolve, so existing bookmarks keep working.

## Security

`validatePackagePath` now validates the *decoded* segments and rejects `..` path elements. This closes a traversal vector: package names are rejoined and interpolated straight into upstream URLs by several registries (e.g.
`fmt.Sprintf("%s/web/packages/%s/DESCRIPTION", baseURL, name)` for CRAN), and Go sends dot-segments verbatim for the upstream to resolve. `GET /api/package/cran/pkg%2F..%2F..%2Fadmin` now returns 400 instead of reaching upstream as `/web/packages/pkg/../../admin/DESCRIPTION`.

Note this is stricter than before the change: the original code had no `..` check at all, so a literal `../..` also passed validation.

## Testing

- New: `internal/database/version_purl_test.go` (`VersionFromPURL`, `DisplayPURL`,   and `GetRecentlyCachedPackages` decoding under both sqlite and Postgres).
- Extended: `resolve_test.go` (segment decoding, traversal rejection),  `server_test.go` (version page reachable via both encoded and decoded URLs),  `debian_test.go` (pool paths with `+` and `~`).
- Each new test was confirmed to fail without the fix.
- Verified end-to-end against the real Ubuntu archive with 12 packages across  deb/npm/cargo/pypi, following every version link the UI generates: all 200, no  encoding leaks. Version shapes covered include multiple `+`, `+` after `-`,  `~dfsg`, leading `0~`, and npm `@scope`. `~` is correctly left unencoded (it is  PURL-safe).
- Full suite and `golangci-lint` pass; the 6 remaining staticcheck warnings are  pre-existing in untouched test files.