### PR TITLE
Upgrade to Go 1.26.6

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -13,7 +13,6 @@ jobs:
     strategy:
       matrix:
         os: [ubuntu-latest, macos-latest, windows-latest]
-        go-version: ['1.26.5']
     runs-on: ${{ matrix.os }}
 
     steps:
@@ -24,7 +23,7 @@ jobs:
       - name: Set up Go
         uses: actions/setup-go@b7ad1dad31e06c5925ef5d2fc7ad053ef454303e # v7.0.0
         with:
-          go-version: ${{ matrix.go-version }}
+          go-version-file: go.mod
 
       - name: Build
         run: go build -v ./...
@@ -42,7 +41,7 @@ jobs:
       - name: Set up Go
         uses: actions/setup-go@b7ad1dad31e06c5925ef5d2fc7ad053ef454303e # v7.0.0
         with:
-          go-version: '1.26.5'
+          go-version-file: go.mod
 
       - name: golangci-lint
         run: go tool golangci-lint run ./...

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -13,7 +13,7 @@ jobs:
     strategy:
       matrix:
         os: [ubuntu-latest, macos-latest, windows-latest]
-        go-version: ['1.25']
+        go-version: ['1.26.5']
     runs-on: ${{ matrix.os }}
 
     steps:
@@ -42,7 +42,7 @@ jobs:
       - name: Set up Go
         uses: actions/setup-go@b7ad1dad31e06c5925ef5d2fc7ad053ef454303e # v7.0.0
         with:
-          go-version: '1.25'
+          go-version: '1.26.5'
 
       - name: golangci-lint
         run: go tool golangci-lint run ./...

--- a/.github/workflows/swagger.yml
+++ b/.github/workflows/swagger.yml
@@ -19,7 +19,7 @@ jobs:
       - name: Set up Go
         uses: actions/setup-go@b7ad1dad31e06c5925ef5d2fc7ad053ef454303e # v7.0.0
         with:
-          go-version: '1.26.5'
+          go-version-file: go.mod
 
       - name: Install swag
         run: go install github.com/swaggo/swag/cmd/swag@latest

--- a/.github/workflows/swagger.yml
+++ b/.github/workflows/swagger.yml
@@ -19,7 +19,7 @@ jobs:
       - name: Set up Go
         uses: actions/setup-go@b7ad1dad31e06c5925ef5d2fc7ad053ef454303e # v7.0.0
         with:
-          go-version: '1.25'
+          go-version: '1.26.5'
 
       - name: Install swag
         run: go install github.com/swaggo/swag/cmd/swag@latest

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM --platform=$BUILDPLATFORM golang:1.26.5-alpine AS builder
+FROM --platform=$BUILDPLATFORM golang:1.26.6-alpine AS builder
 
 WORKDIR /src
 

--- a/README.md
+++ b/README.md
@@ -1024,7 +1024,7 @@ The proxy will recreate the database on next start.
 
 Requirements:
 
-- Go 1.26.5 or later
+- Go (the project version is declared in `go.mod`)
 
 ```bash
 git clone https://github.com/git-pkgs/proxy.git

--- a/README.md
+++ b/README.md
@@ -1024,7 +1024,7 @@ The proxy will recreate the database on next start.
 
 Requirements:
 
-- Go 1.25 or later
+- Go 1.26.5 or later
 
 ```bash
 git clone https://github.com/git-pkgs/proxy.git

--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/git-pkgs/proxy
 
-go 1.25.6
+go 1.26.5
 
 require (
 	github.com/BurntSushi/toml v1.6.0

--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,8 @@
 module github.com/git-pkgs/proxy
 
-go 1.26.5
+go 1.25.6
+
+toolchain go1.26.6
 
 require (
 	github.com/BurntSushi/toml v1.6.0


### PR DESCRIPTION
Select Go 1.26.6 through the `toolchain` directive in `go.mod` while keeping the module compatibility floor at Go 1.25.6. CI, release, and Swagger workflows read the selected version from `go.mod`, and Docker uses the matching Go image.