### PR TITLE
Make built-in upstream URLs configurable

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -4,7 +4,7 @@
 *.dll
 *.so
 *.dylib
-proxy
+/proxy
 
 # Test binary, built with `go test -c`
 *.test

--- a/README.md
+++ b/README.md
@@ -506,6 +506,8 @@ cooldown:
   default: "3d"
 ```
 
+See the [configuration reference](docs/configuration.md#upstream-registries) for every upstream key, environment variable, and default URL.
+
 Run with config file:
 
 ```bash

--- a/cmd/proxy/main.go
+++ b/cmd/proxy/main.go
@@ -75,8 +75,7 @@
 //	PROXY_LOG_LEVEL        - Log level
 //	PROXY_LOG_FORMAT       - Log format
 //	PROXY_ACCESS_LOG_PATH  - JSONL access log path
-//	PROXY_UPSTREAM_MAVEN   - Maven repository upstream URL
-//	PROXY_UPSTREAM_GRADLE_PLUGIN_PORTAL - Gradle Plugin Portal upstream URL
+//	PROXY_UPSTREAM_*       - Upstream URLs and network access controls
 //	PROXY_GRADLE_BUILD_CACHE_READ_ONLY       - Disable Gradle PUT uploads
 //	PROXY_GRADLE_BUILD_CACHE_MAX_UPLOAD_SIZE - Max Gradle PUT request body size
 //	PROXY_GRADLE_BUILD_CACHE_MAX_AGE         - Gradle cache max age eviction
@@ -206,8 +205,31 @@ func runServe() {
 		fmt.Fprintf(os.Stderr, "  PROXY_LOG_LEVEL        Log level\n")
 		fmt.Fprintf(os.Stderr, "  PROXY_LOG_FORMAT       Log format\n")
 		fmt.Fprintf(os.Stderr, "  PROXY_ACCESS_LOG_PATH  JSONL access log path\n")
-		fmt.Fprintf(os.Stderr, "  PROXY_UPSTREAM_MAVEN   Maven repository upstream URL\n")
+		fmt.Fprintf(os.Stderr, "  PROXY_UPSTREAM_ALLOW_PRIVATE_HOSTS  Comma-separated private upstream hosts\n")
+		fmt.Fprintf(os.Stderr, "  PROXY_UPSTREAM_ALLOW_LOOPBACK       Permit loopback upstreams and redirects\n")
+		fmt.Fprintf(os.Stderr, "  PROXY_UPSTREAM_NPM                  npm registry upstream URL\n")
+		fmt.Fprintf(os.Stderr, "  PROXY_UPSTREAM_CARGO                Cargo index upstream URL\n")
+		fmt.Fprintf(os.Stderr, "  PROXY_UPSTREAM_CARGO_DOWNLOAD       Cargo download upstream URL\n")
+		fmt.Fprintf(os.Stderr, "  PROXY_UPSTREAM_GEM                  RubyGems upstream URL\n")
+		fmt.Fprintf(os.Stderr, "  PROXY_UPSTREAM_GO                   Go module proxy upstream URL\n")
+		fmt.Fprintf(os.Stderr, "  PROXY_UPSTREAM_HEX                  Hex repository upstream URL\n")
+		fmt.Fprintf(os.Stderr, "  PROXY_UPSTREAM_HEX_API              Hex API upstream URL\n")
+		fmt.Fprintf(os.Stderr, "  PROXY_UPSTREAM_PUB                  pub registry upstream URL\n")
+		fmt.Fprintf(os.Stderr, "  PROXY_UPSTREAM_PYPI                 PyPI index and API upstream URL\n")
+		fmt.Fprintf(os.Stderr, "  PROXY_UPSTREAM_PYPI_DOWNLOAD        PyPI download upstream URL\n")
+		fmt.Fprintf(os.Stderr, "  PROXY_UPSTREAM_MAVEN                Maven repository upstream URL\n")
 		fmt.Fprintf(os.Stderr, "  PROXY_UPSTREAM_GRADLE_PLUGIN_PORTAL Gradle Plugin Portal upstream URL\n")
+		fmt.Fprintf(os.Stderr, "  PROXY_UPSTREAM_NUGET                NuGet API upstream URL\n")
+		fmt.Fprintf(os.Stderr, "  PROXY_UPSTREAM_NUGET_SEARCH         NuGet search upstream URL\n")
+		fmt.Fprintf(os.Stderr, "  PROXY_UPSTREAM_COMPOSER             Packagist API upstream URL\n")
+		fmt.Fprintf(os.Stderr, "  PROXY_UPSTREAM_COMPOSER_REPOSITORY  Packagist repository upstream URL\n")
+		fmt.Fprintf(os.Stderr, "  PROXY_UPSTREAM_CONAN                Conan registry upstream URL\n")
+		fmt.Fprintf(os.Stderr, "  PROXY_UPSTREAM_CONDA                Conda channel upstream URL\n")
+		fmt.Fprintf(os.Stderr, "  PROXY_UPSTREAM_CRAN                 CRAN mirror upstream URL\n")
+		fmt.Fprintf(os.Stderr, "  PROXY_UPSTREAM_JULIA                Julia package server upstream URL\n")
+		fmt.Fprintf(os.Stderr, "  PROXY_UPSTREAM_OCI_DEFAULT          Default OCI registry upstream URL\n")
+		fmt.Fprintf(os.Stderr, "  PROXY_UPSTREAM_DEBIAN               Debian repository upstream URL\n")
+		fmt.Fprintf(os.Stderr, "  PROXY_UPSTREAM_RPM                  RPM repository upstream URL\n")
 		fmt.Fprintf(os.Stderr, "  PROXY_GRADLE_BUILD_CACHE_READ_ONLY       Disable Gradle PUT uploads\n")
 		fmt.Fprintf(os.Stderr, "  PROXY_GRADLE_BUILD_CACHE_MAX_UPLOAD_SIZE Max Gradle PUT request body size\n")
 		fmt.Fprintf(os.Stderr, "  PROXY_GRADLE_BUILD_CACHE_MAX_AGE         Gradle cache max age eviction\n")

--- a/cmd/proxy/main_test.go
+++ b/cmd/proxy/main_test.go
@@ -1,0 +1,58 @@
+package main
+
+import (
+	"os"
+	"os/exec"
+	"strings"
+	"testing"
+)
+
+func TestServeHelpListsUpstreamEnvironmentVariables(t *testing.T) {
+	cmd := exec.Command(os.Args[0], "-test.run=^TestServeHelpProcess$")
+	cmd.Env = append(os.Environ(), "PROXY_TEST_SERVE_HELP=1")
+	output, err := cmd.CombinedOutput()
+	if err != nil {
+		t.Fatalf("serve help failed: %v\n%s", err, output)
+	}
+
+	variables := []string{
+		"PROXY_UPSTREAM_ALLOW_PRIVATE_HOSTS",
+		"PROXY_UPSTREAM_ALLOW_LOOPBACK",
+		"PROXY_UPSTREAM_NPM",
+		"PROXY_UPSTREAM_CARGO",
+		"PROXY_UPSTREAM_CARGO_DOWNLOAD",
+		"PROXY_UPSTREAM_GEM",
+		"PROXY_UPSTREAM_GO",
+		"PROXY_UPSTREAM_HEX",
+		"PROXY_UPSTREAM_HEX_API",
+		"PROXY_UPSTREAM_PUB",
+		"PROXY_UPSTREAM_PYPI",
+		"PROXY_UPSTREAM_PYPI_DOWNLOAD",
+		"PROXY_UPSTREAM_MAVEN",
+		"PROXY_UPSTREAM_GRADLE_PLUGIN_PORTAL",
+		"PROXY_UPSTREAM_NUGET",
+		"PROXY_UPSTREAM_NUGET_SEARCH",
+		"PROXY_UPSTREAM_COMPOSER",
+		"PROXY_UPSTREAM_COMPOSER_REPOSITORY",
+		"PROXY_UPSTREAM_CONAN",
+		"PROXY_UPSTREAM_CONDA",
+		"PROXY_UPSTREAM_CRAN",
+		"PROXY_UPSTREAM_JULIA",
+		"PROXY_UPSTREAM_OCI_DEFAULT",
+		"PROXY_UPSTREAM_DEBIAN",
+		"PROXY_UPSTREAM_RPM",
+	}
+	for _, variable := range variables {
+		if !strings.Contains(string(output), variable) {
+			t.Errorf("serve help omitted %s", variable)
+		}
+	}
+}
+
+func TestServeHelpProcess(*testing.T) {
+	if os.Getenv("PROXY_TEST_SERVE_HELP") != "1" {
+		return
+	}
+	os.Args = []string{"proxy", "serve", "-help"}
+	main()
+}

--- a/config.example.yaml
+++ b/config.example.yaml
@@ -82,16 +82,16 @@ log:
 access_log:
   path: ""
 
-# Upstream registry URLs and authentication
+# Upstream URLs for built-in routes and authentication
 upstream:
+  # Hosts allowed to resolve to private, ULA, or CGNAT addresses
+  allow_private_hosts: []
+
+  # Permit upstream requests and redirects to loopback addresses
+  allow_loopback: false
+
   # npm registry URL
   npm: "https://registry.npmjs.org"
-
-  # Maven repository URL (used by /maven endpoint)
-  maven: "https://repo1.maven.org/maven2"
-
-  # Gradle Plugin Portal Maven URL (fallback for plugin marker artifacts)
-  gradle_plugin_portal: "https://plugins.gradle.org/m2"
 
   # Cargo sparse index URL
   cargo: "https://index.crates.io"
@@ -99,8 +99,65 @@ upstream:
   # Cargo crate download URL
   cargo_download: "https://static.crates.io/crates"
 
+  # RubyGems registry URL
+  gem: "https://rubygems.org"
+
+  # Go module proxy URL
+  go: "https://proxy.golang.org"
+
+  # Hex repository URL
+  hex: "https://repo.hex.pm"
+
+  # Hex API URL used for package timestamps
+  hex_api: "https://hex.pm"
+
+  # pub registry URL
+  pub: "https://pub.dev"
+
+  # PyPI index and API URL
+  pypi: "https://pypi.org"
+
+  # PyPI package download URL
+  pypi_download: "https://files.pythonhosted.org"
+
+  # Maven repository URL (used by /maven endpoint)
+  maven: "https://repo1.maven.org/maven2"
+
+  # Gradle Plugin Portal Maven URL (fallback for plugin marker artifacts)
+  gradle_plugin_portal: "https://plugins.gradle.org/m2"
+
+  # NuGet API URL
+  nuget: "https://api.nuget.org"
+
+  # NuGet search API URL
+  nuget_search: "https://azuresearch-usnc.nuget.org"
+
+  # Packagist API URL
+  composer: "https://packagist.org"
+
+  # Packagist repository URL
+  composer_repository: "https://repo.packagist.org"
+
+  # Conan registry URL
+  conan: "https://center.conan.io"
+
+  # Conda channel base URL
+  conda: "https://conda.anaconda.org"
+
+  # CRAN mirror URL
+  cran: "https://cloud.r-project.org"
+
+  # Julia package server URL
+  julia: "https://pkg.julialang.org"
+
+  # Default OCI registry URL for unprefixed /v2 requests
+  oci_default: "https://registry-1.docker.io"
+
   # Debian/APT repository URL (used by /debian endpoint)
   debian: "http://deb.debian.org/debian"
+
+  # RPM repository URL (used by /rpm endpoint)
+  rpm: "https://dl.fedoraproject.org/pub/fedora/linux"
 
   # Named HTTP Helm chart repositories (used by /helm/{name}/)
   # helm:

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -134,16 +134,64 @@ Upstream retries and OCI authentication calls are separate `upstream` records, s
 
 ## Upstream Registries
 
-Override default upstream registry URLs:
+Each upstream used by a built-in package route can be set in YAML or JSON under `upstream`, or with its matching environment variable. Existing installations keep the same public upstreams by default. Trailing slashes are ignored.
+
+| Config | Environment | Default |
+|--------|-------------|---------|
+| `upstream.allow_private_hosts` | `PROXY_UPSTREAM_ALLOW_PRIVATE_HOSTS` | `[]` |
+| `upstream.allow_loopback` | `PROXY_UPSTREAM_ALLOW_LOOPBACK` | `false` |
+| `upstream.npm` | `PROXY_UPSTREAM_NPM` | `https://registry.npmjs.org` |
+| `upstream.cargo` | `PROXY_UPSTREAM_CARGO` | `https://index.crates.io` |
+| `upstream.cargo_download` | `PROXY_UPSTREAM_CARGO_DOWNLOAD` | `https://static.crates.io/crates` |
+| `upstream.gem` | `PROXY_UPSTREAM_GEM` | `https://rubygems.org` |
+| `upstream.go` | `PROXY_UPSTREAM_GO` | `https://proxy.golang.org` |
+| `upstream.hex` | `PROXY_UPSTREAM_HEX` | `https://repo.hex.pm` |
+| `upstream.hex_api` | `PROXY_UPSTREAM_HEX_API` | `https://hex.pm` |
+| `upstream.pub` | `PROXY_UPSTREAM_PUB` | `https://pub.dev` |
+| `upstream.pypi` | `PROXY_UPSTREAM_PYPI` | `https://pypi.org` |
+| `upstream.pypi_download` | `PROXY_UPSTREAM_PYPI_DOWNLOAD` | `https://files.pythonhosted.org` |
+| `upstream.maven` | `PROXY_UPSTREAM_MAVEN` | `https://repo1.maven.org/maven2` |
+| `upstream.gradle_plugin_portal` | `PROXY_UPSTREAM_GRADLE_PLUGIN_PORTAL` | `https://plugins.gradle.org/m2` |
+| `upstream.nuget` | `PROXY_UPSTREAM_NUGET` | `https://api.nuget.org` |
+| `upstream.nuget_search` | `PROXY_UPSTREAM_NUGET_SEARCH` | `https://azuresearch-usnc.nuget.org` |
+| `upstream.composer` | `PROXY_UPSTREAM_COMPOSER` | `https://packagist.org` |
+| `upstream.composer_repository` | `PROXY_UPSTREAM_COMPOSER_REPOSITORY` | `https://repo.packagist.org` |
+| `upstream.conan` | `PROXY_UPSTREAM_CONAN` | `https://center.conan.io` |
+| `upstream.conda` | `PROXY_UPSTREAM_CONDA` | `https://conda.anaconda.org` |
+| `upstream.cran` | `PROXY_UPSTREAM_CRAN` | `https://cloud.r-project.org` |
+| `upstream.julia` | `PROXY_UPSTREAM_JULIA` | `https://pkg.julialang.org` |
+| `upstream.oci_default` | `PROXY_UPSTREAM_OCI_DEFAULT` | `https://registry-1.docker.io` |
+| `upstream.debian` | `PROXY_UPSTREAM_DEBIAN` | `http://deb.debian.org/debian` |
+| `upstream.rpm` | `PROXY_UPSTREAM_RPM` | `https://dl.fedoraproject.org/pub/fedora/linux` |
+
+Private, ULA, CGNAT, and loopback addresses are rejected by default. Add each private upstream hostname or IP address to `upstream.allow_private_hosts`. The matching environment variable accepts a comma-separated list. Loopback upstreams also require `upstream.allow_loopback: true`. That setting permits upstream requests and redirects to reach any loopback address.
 
 ```yaml
 upstream:
-  npm: "https://registry.npmjs.org"
-  maven: "https://repo1.maven.org/maven2"
-  gradle_plugin_portal: "https://plugins.gradle.org/m2"
-  cargo: "https://index.crates.io"
-  cargo_download: "https://static.crates.io/crates"
+  allow_private_hosts:
+    - "upstream-proxy.internal"
+  pypi: "http://upstream-proxy.internal/pypi"
+  pypi_download: "http://upstream-proxy.internal/pypi"
+```
 
+For protocols that use separate metadata and download services, configure both values. They may point to the same endpoint when chaining proxies:
+
+```yaml
+upstream:
+  pypi: "https://upstream-proxy.example.com/pypi"
+  pypi_download: "https://upstream-proxy.example.com/pypi"
+  nuget: "https://upstream-proxy.example.com/nuget"
+  nuget_search: "https://upstream-proxy.example.com/nuget"
+  composer: "https://upstream-proxy.example.com/composer"
+  composer_repository: "https://upstream-proxy.example.com/composer"
+```
+
+`upstream.hex_api` is used for cooldown timestamps and must expose Hex's `/api/packages/{name}` JSON endpoint.
+
+Helm HTTP repositories and additional OCI registries are configured as named maps:
+
+```yaml
+upstream:
   # Named HTTP Helm chart repositories, served at /helm/{name}/.
   helm:
     bitnami: "https://charts.bitnami.com/bitnami"
@@ -159,9 +207,10 @@ repository's `index.yaml` so chart archives are downloaded through the proxy.
 Chart archives are retained only when their SHA-256 digest matches the digest
 listed in the index. Relative and absolute chart URLs are both supported.
 
-Named OCI registries preserve the existing unprefixed Docker Hub mirror. A
-reference such as `oci://proxy.example.com/upstream/ghcr/owner/chart` is sent
-to the registry configured as `ghcr` with `owner/chart` as its repository.
+`upstream.oci_default` sets the registry used by unprefixed `/v2` requests,
+while `upstream.oci` selects named registries through the `upstream/{name}/`
+repository prefix. For example, `oci://proxy.example.com/upstream/ghcr/owner/chart`
+uses the `ghcr` registry with `owner/chart` as its repository.
 When the proxy uses plain HTTP (for example `localhost:8080`), pass
 `--plain-http` to Helm OCI commands.
 

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -289,12 +289,54 @@ type AccessLogConfig struct {
 	Path string `json:"path" yaml:"path"`
 }
 
-// UpstreamConfig configures upstream registry URLs and authentication.
+// UpstreamConfig configures upstream URLs for built-in routes and authentication.
 // Leave empty to use defaults.
 type UpstreamConfig struct {
+	// AllowPrivateHosts permits listed upstream hosts to resolve to private addresses.
+	AllowPrivateHosts []string `json:"allow_private_hosts" yaml:"allow_private_hosts"`
+
+	// AllowLoopback permits upstream requests and redirects to loopback addresses.
+	AllowLoopback bool `json:"allow_loopback" yaml:"allow_loopback"`
+
 	// NPM is the upstream npm registry URL.
 	// Default: https://registry.npmjs.org
 	NPM string `json:"npm" yaml:"npm"`
+
+	// Cargo is the upstream cargo index URL.
+	// Default: https://index.crates.io
+	Cargo string `json:"cargo" yaml:"cargo"`
+
+	// CargoDownload is the upstream cargo download URL.
+	// Default: https://static.crates.io/crates
+	CargoDownload string `json:"cargo_download" yaml:"cargo_download"`
+
+	// Gem is the upstream RubyGems registry URL.
+	// Default: https://rubygems.org
+	Gem string `json:"gem" yaml:"gem"`
+
+	// Go is the upstream Go module proxy URL.
+	// Default: https://proxy.golang.org
+	Go string `json:"go" yaml:"go"`
+
+	// Hex is the upstream Hex repository URL.
+	// Default: https://repo.hex.pm
+	Hex string `json:"hex" yaml:"hex"`
+
+	// HexAPI is the upstream Hex API URL used for package timestamps.
+	// Default: https://hex.pm
+	HexAPI string `json:"hex_api" yaml:"hex_api"`
+
+	// Pub is the upstream pub registry URL.
+	// Default: https://pub.dev
+	Pub string `json:"pub" yaml:"pub"`
+
+	// PyPI is the upstream PyPI index and API URL.
+	// Default: https://pypi.org
+	PyPI string `json:"pypi" yaml:"pypi"`
+
+	// PyPIDownload is the upstream PyPI package download URL.
+	// Default: https://files.pythonhosted.org
+	PyPIDownload string `json:"pypi_download" yaml:"pypi_download"`
 
 	// Maven is the upstream Maven repository URL.
 	// Default: https://repo1.maven.org/maven2
@@ -305,18 +347,50 @@ type UpstreamConfig struct {
 	// Default: https://plugins.gradle.org/m2
 	GradlePluginPortal string `json:"gradle_plugin_portal" yaml:"gradle_plugin_portal"`
 
-	// Cargo is the upstream cargo index URL.
-	// Default: https://index.crates.io
-	Cargo string `json:"cargo" yaml:"cargo"`
+	// NuGet is the upstream NuGet API URL.
+	// Default: https://api.nuget.org
+	NuGet string `json:"nuget" yaml:"nuget"`
 
-	// CargoDownload is the upstream cargo download URL.
-	// Default: https://static.crates.io/crates
-	CargoDownload string `json:"cargo_download" yaml:"cargo_download"`
+	// NuGetSearch is the upstream NuGet search API URL.
+	// Default: https://azuresearch-usnc.nuget.org
+	NuGetSearch string `json:"nuget_search" yaml:"nuget_search"`
+
+	// Composer is the upstream Packagist API URL.
+	// Default: https://packagist.org
+	Composer string `json:"composer" yaml:"composer"`
+
+	// ComposerRepository is the upstream Packagist repository URL.
+	// Default: https://repo.packagist.org
+	ComposerRepository string `json:"composer_repository" yaml:"composer_repository"`
+
+	// Conan is the upstream Conan registry URL.
+	// Default: https://center.conan.io
+	Conan string `json:"conan" yaml:"conan"`
+
+	// Conda is the upstream Conda channel base URL.
+	// Default: https://conda.anaconda.org
+	Conda string `json:"conda" yaml:"conda"`
+
+	// CRAN is the upstream CRAN mirror URL.
+	// Default: https://cloud.r-project.org
+	CRAN string `json:"cran" yaml:"cran"`
+
+	// Julia is the upstream Julia package server URL.
+	// Default: https://pkg.julialang.org
+	Julia string `json:"julia" yaml:"julia"`
+
+	// OCIDefault is the default upstream OCI registry URL.
+	// Default: https://registry-1.docker.io
+	OCIDefault string `json:"oci_default" yaml:"oci_default"`
 
 	// Debian is the upstream APT repository base URL.
 	// Example: http://archive.ubuntu.com/ubuntu would get Ubuntu.
 	// Default: http://deb.debian.org/debian
 	Debian string `json:"debian" yaml:"debian"`
+
+	// RPM is the upstream RPM repository base URL.
+	// Default: https://dl.fedoraproject.org/pub/fedora/linux
+	RPM string `json:"rpm" yaml:"rpm"`
 
 	// Helm maps repository names to HTTP Helm chart repository URLs.
 	// Requests use /helm/{name}/index.yaml and chart URLs in the index are
@@ -471,11 +545,28 @@ func Default() *Config {
 		},
 		Upstream: UpstreamConfig{
 			NPM:                "https://registry.npmjs.org",
-			Maven:              "https://repo1.maven.org/maven2",
-			GradlePluginPortal: "https://plugins.gradle.org/m2",
 			Cargo:              "https://index.crates.io",
 			CargoDownload:      "https://static.crates.io/crates",
+			Gem:                "https://rubygems.org",
+			Go:                 "https://proxy.golang.org",
+			Hex:                "https://repo.hex.pm",
+			HexAPI:             "https://hex.pm",
+			Pub:                "https://pub.dev",
+			PyPI:               "https://pypi.org",
+			PyPIDownload:       "https://files.pythonhosted.org",
+			Maven:              "https://repo1.maven.org/maven2",
+			GradlePluginPortal: "https://plugins.gradle.org/m2",
+			NuGet:              "https://api.nuget.org",
+			NuGetSearch:        "https://azuresearch-usnc.nuget.org",
+			Composer:           "https://packagist.org",
+			ComposerRepository: "https://repo.packagist.org",
+			Conan:              "https://center.conan.io",
+			Conda:              "https://conda.anaconda.org",
+			CRAN:               "https://cloud.r-project.org",
+			Julia:              "https://pkg.julialang.org",
+			OCIDefault:         "https://registry-1.docker.io",
 			Debian:             "http://deb.debian.org/debian",
+			RPM:                "https://dl.fedoraproject.org/pub/fedora/linux",
 		},
 		Gradle: GradleConfig{
 			BuildCache: GradleBuildCacheConfig{
@@ -535,6 +626,22 @@ func setEnvBool(dst *bool, key string) {
 	}
 }
 
+func setEnvStringSlice(dst *[]string, key string) {
+	value := os.Getenv(key)
+	if value == "" {
+		return
+	}
+	var items []string
+	for item := range strings.SplitSeq(value, ",") {
+		if item = strings.TrimSpace(item); item != "" {
+			items = append(items, item)
+		}
+	}
+	if len(items) > 0 {
+		*dst = items
+	}
+}
+
 // LoadFromEnv applies environment variable overrides to a Config.
 // Environment variables use the PROXY_ prefix:
 //   - PROXY_LISTEN
@@ -563,9 +670,31 @@ func (c *Config) LoadFromEnv() {
 	setEnvString(&c.Log.Level, "PROXY_LOG_LEVEL")
 	setEnvString(&c.Log.Format, "PROXY_LOG_FORMAT")
 	setEnvString(&c.AccessLog.Path, "PROXY_ACCESS_LOG_PATH")
+	setEnvStringSlice(&c.Upstream.AllowPrivateHosts, "PROXY_UPSTREAM_ALLOW_PRIVATE_HOSTS")
+	setEnvBool(&c.Upstream.AllowLoopback, "PROXY_UPSTREAM_ALLOW_LOOPBACK")
+	setEnvString(&c.Upstream.NPM, "PROXY_UPSTREAM_NPM")
+	setEnvString(&c.Upstream.Cargo, "PROXY_UPSTREAM_CARGO")
+	setEnvString(&c.Upstream.CargoDownload, "PROXY_UPSTREAM_CARGO_DOWNLOAD")
+	setEnvString(&c.Upstream.Gem, "PROXY_UPSTREAM_GEM")
+	setEnvString(&c.Upstream.Go, "PROXY_UPSTREAM_GO")
+	setEnvString(&c.Upstream.Hex, "PROXY_UPSTREAM_HEX")
+	setEnvString(&c.Upstream.HexAPI, "PROXY_UPSTREAM_HEX_API")
+	setEnvString(&c.Upstream.Pub, "PROXY_UPSTREAM_PUB")
+	setEnvString(&c.Upstream.PyPI, "PROXY_UPSTREAM_PYPI")
+	setEnvString(&c.Upstream.PyPIDownload, "PROXY_UPSTREAM_PYPI_DOWNLOAD")
 	setEnvString(&c.Upstream.Maven, "PROXY_UPSTREAM_MAVEN")
 	setEnvString(&c.Upstream.GradlePluginPortal, "PROXY_UPSTREAM_GRADLE_PLUGIN_PORTAL")
+	setEnvString(&c.Upstream.NuGet, "PROXY_UPSTREAM_NUGET")
+	setEnvString(&c.Upstream.NuGetSearch, "PROXY_UPSTREAM_NUGET_SEARCH")
+	setEnvString(&c.Upstream.Composer, "PROXY_UPSTREAM_COMPOSER")
+	setEnvString(&c.Upstream.ComposerRepository, "PROXY_UPSTREAM_COMPOSER_REPOSITORY")
+	setEnvString(&c.Upstream.Conan, "PROXY_UPSTREAM_CONAN")
+	setEnvString(&c.Upstream.Conda, "PROXY_UPSTREAM_CONDA")
+	setEnvString(&c.Upstream.CRAN, "PROXY_UPSTREAM_CRAN")
+	setEnvString(&c.Upstream.Julia, "PROXY_UPSTREAM_JULIA")
+	setEnvString(&c.Upstream.OCIDefault, "PROXY_UPSTREAM_OCI_DEFAULT")
 	setEnvString(&c.Upstream.Debian, "PROXY_UPSTREAM_DEBIAN")
+	setEnvString(&c.Upstream.RPM, "PROXY_UPSTREAM_RPM")
 	setEnvString(&c.Cooldown.Default, "PROXY_COOLDOWN_DEFAULT")
 	setEnvBool(&c.CacheMetadata, "PROXY_CACHE_METADATA")
 	setEnvBool(&c.MirrorAPI, "PROXY_MIRROR_API")

--- a/internal/config/config_test.go
+++ b/internal/config/config_test.go
@@ -14,6 +14,100 @@ const (
 	testLevelDebug     = "debug"
 )
 
+func upstreamConfigValues(upstream UpstreamConfig) map[string]string {
+	return map[string]string{
+		"npm":                  upstream.NPM,
+		"cargo":                upstream.Cargo,
+		"cargo_download":       upstream.CargoDownload,
+		"gem":                  upstream.Gem,
+		"go":                   upstream.Go,
+		"hex":                  upstream.Hex,
+		"hex_api":              upstream.HexAPI,
+		"pub":                  upstream.Pub,
+		"pypi":                 upstream.PyPI,
+		"pypi_download":        upstream.PyPIDownload,
+		"maven":                upstream.Maven,
+		"gradle_plugin_portal": upstream.GradlePluginPortal,
+		"nuget":                upstream.NuGet,
+		"nuget_search":         upstream.NuGetSearch,
+		"composer":             upstream.Composer,
+		"composer_repository":  upstream.ComposerRepository,
+		"conan":                upstream.Conan,
+		"conda":                upstream.Conda,
+		"cran":                 upstream.CRAN,
+		"julia":                upstream.Julia,
+		"oci_default":          upstream.OCIDefault,
+		"debian":               upstream.Debian,
+		"rpm":                  upstream.RPM,
+	}
+}
+
+func defaultUpstreamValues() map[string]string {
+	return map[string]string{
+		"npm":                  "https://registry.npmjs.org",
+		"cargo":                "https://index.crates.io",
+		"cargo_download":       "https://static.crates.io/crates",
+		"gem":                  "https://rubygems.org",
+		"go":                   "https://proxy.golang.org",
+		"hex":                  "https://repo.hex.pm",
+		"hex_api":              "https://hex.pm",
+		"pub":                  "https://pub.dev",
+		"pypi":                 "https://pypi.org",
+		"pypi_download":        "https://files.pythonhosted.org",
+		"maven":                "https://repo1.maven.org/maven2",
+		"gradle_plugin_portal": "https://plugins.gradle.org/m2",
+		"nuget":                "https://api.nuget.org",
+		"nuget_search":         "https://azuresearch-usnc.nuget.org",
+		"composer":             "https://packagist.org",
+		"composer_repository":  "https://repo.packagist.org",
+		"conan":                "https://center.conan.io",
+		"conda":                "https://conda.anaconda.org",
+		"cran":                 "https://cloud.r-project.org",
+		"julia":                "https://pkg.julialang.org",
+		"oci_default":          "https://registry-1.docker.io",
+		"debian":               "http://deb.debian.org/debian",
+		"rpm":                  "https://dl.fedoraproject.org/pub/fedora/linux",
+	}
+}
+
+func upstreamEnvironmentVariables() map[string]string {
+	return map[string]string{
+		"npm":                  "PROXY_UPSTREAM_NPM",
+		"cargo":                "PROXY_UPSTREAM_CARGO",
+		"cargo_download":       "PROXY_UPSTREAM_CARGO_DOWNLOAD",
+		"gem":                  "PROXY_UPSTREAM_GEM",
+		"go":                   "PROXY_UPSTREAM_GO",
+		"hex":                  "PROXY_UPSTREAM_HEX",
+		"hex_api":              "PROXY_UPSTREAM_HEX_API",
+		"pub":                  "PROXY_UPSTREAM_PUB",
+		"pypi":                 "PROXY_UPSTREAM_PYPI",
+		"pypi_download":        "PROXY_UPSTREAM_PYPI_DOWNLOAD",
+		"maven":                "PROXY_UPSTREAM_MAVEN",
+		"gradle_plugin_portal": "PROXY_UPSTREAM_GRADLE_PLUGIN_PORTAL",
+		"nuget":                "PROXY_UPSTREAM_NUGET",
+		"nuget_search":         "PROXY_UPSTREAM_NUGET_SEARCH",
+		"composer":             "PROXY_UPSTREAM_COMPOSER",
+		"composer_repository":  "PROXY_UPSTREAM_COMPOSER_REPOSITORY",
+		"conan":                "PROXY_UPSTREAM_CONAN",
+		"conda":                "PROXY_UPSTREAM_CONDA",
+		"cran":                 "PROXY_UPSTREAM_CRAN",
+		"julia":                "PROXY_UPSTREAM_JULIA",
+		"oci_default":          "PROXY_UPSTREAM_OCI_DEFAULT",
+		"debian":               "PROXY_UPSTREAM_DEBIAN",
+		"rpm":                  "PROXY_UPSTREAM_RPM",
+	}
+}
+
+func assertUpstreamValues(t *testing.T, cfg *Config, want map[string]string) {
+	t.Helper()
+	got := upstreamConfigValues(cfg.Upstream)
+	for name, wantValue := range want {
+		if gotValue := got[name]; gotValue != wantValue {
+			t.Errorf("Upstream %s = %q, want %q", name, gotValue, wantValue)
+		}
+	}
+}
+
 func TestDefault(t *testing.T) {
 	cfg := Default()
 
@@ -35,15 +129,13 @@ func TestDefault(t *testing.T) {
 	if cfg.Gradle.BuildCache.MaxAge != "168h" {
 		t.Errorf("Gradle.BuildCache.MaxAge = %q, want %q", cfg.Gradle.BuildCache.MaxAge, "168h")
 	}
-	if cfg.Upstream.Maven != "https://repo1.maven.org/maven2" {
-		t.Errorf("Upstream.Maven = %q, want %q", cfg.Upstream.Maven, "https://repo1.maven.org/maven2")
+	if len(cfg.Upstream.AllowPrivateHosts) != 0 {
+		t.Errorf("Upstream.AllowPrivateHosts = %v, want empty", cfg.Upstream.AllowPrivateHosts)
 	}
-	if cfg.Upstream.GradlePluginPortal != "https://plugins.gradle.org/m2" {
-		t.Errorf("Upstream.GradlePluginPortal = %q, want %q", cfg.Upstream.GradlePluginPortal, "https://plugins.gradle.org/m2")
+	if cfg.Upstream.AllowLoopback {
+		t.Error("Upstream.AllowLoopback = true, want false")
 	}
-	if cfg.Upstream.Debian != "http://deb.debian.org/debian" {
-		t.Errorf("Upstream.Debian = %q, want %q", cfg.Upstream.Debian, "http://deb.debian.org/debian")
-	}
+	assertUpstreamValues(t, cfg, defaultUpstreamValues())
 }
 
 func TestValidate(t *testing.T) {
@@ -250,13 +342,71 @@ access_log:
 	}
 }
 
+func TestLoadYAMLUpstreams(t *testing.T) {
+	path := filepath.Join(t.TempDir(), "config.yaml")
+	content := `
+upstream:
+  allow_private_hosts:
+    - "registry.internal"
+    - "10.0.0.12"
+  allow_loopback: true
+  npm: "https://upstream.example.com/npm"
+  cargo: "https://upstream.example.com/cargo"
+  cargo_download: "https://upstream.example.com/cargo_download"
+  gem: "https://upstream.example.com/gem"
+  go: "https://upstream.example.com/go"
+  hex: "https://upstream.example.com/hex"
+  hex_api: "https://upstream.example.com/hex_api"
+  pub: "https://upstream.example.com/pub"
+  pypi: "https://upstream.example.com/pypi"
+  pypi_download: "https://upstream.example.com/pypi_download"
+  maven: "https://upstream.example.com/maven"
+  gradle_plugin_portal: "https://upstream.example.com/gradle_plugin_portal"
+  nuget: "https://upstream.example.com/nuget"
+  nuget_search: "https://upstream.example.com/nuget_search"
+  composer: "https://upstream.example.com/composer"
+  composer_repository: "https://upstream.example.com/composer_repository"
+  conan: "https://upstream.example.com/conan"
+  conda: "https://upstream.example.com/conda"
+  cran: "https://upstream.example.com/cran"
+  julia: "https://upstream.example.com/julia"
+  oci_default: "https://upstream.example.com/oci_default"
+  debian: "https://upstream.example.com/debian"
+  rpm: "https://upstream.example.com/rpm"
+`
+	if err := os.WriteFile(path, []byte(content), 0644); err != nil {
+		t.Fatalf("writing config file: %v", err)
+	}
+
+	cfg, err := Load(path)
+	if err != nil {
+		t.Fatalf("Load failed: %v", err)
+	}
+
+	want := make(map[string]string)
+	for name := range defaultUpstreamValues() {
+		want[name] = "https://upstream.example.com/" + name
+	}
+	assertUpstreamValues(t, cfg, want)
+	if got := strings.Join(cfg.Upstream.AllowPrivateHosts, ","); got != "registry.internal,10.0.0.12" {
+		t.Errorf("Upstream.AllowPrivateHosts = %q, want %q", got, "registry.internal,10.0.0.12")
+	}
+	if !cfg.Upstream.AllowLoopback {
+		t.Error("Upstream.AllowLoopback = false, want true")
+	}
+}
+
 func TestLoadJSON(t *testing.T) {
 	dir := t.TempDir()
 	path := filepath.Join(dir, "config.json")
 
 	content := `{
 		"listen": ":4000",
-		"base_url": "https://json.example.com"
+		"base_url": "https://json.example.com",
+		"upstream": {
+			"gem": "https://json.example.com/gem",
+			"rpm": "https://json.example.com/rpm"
+		}
 	}`
 	if err := os.WriteFile(path, []byte(content), 0644); err != nil {
 		t.Fatalf("writing config file: %v", err)
@@ -273,6 +423,12 @@ func TestLoadJSON(t *testing.T) {
 	if cfg.BaseURL != "https://json.example.com" {
 		t.Errorf("BaseURL = %q, want %q", cfg.BaseURL, "https://json.example.com")
 	}
+	if cfg.Upstream.Gem != "https://json.example.com/gem" {
+		t.Errorf("Upstream.Gem = %q, want %q", cfg.Upstream.Gem, "https://json.example.com/gem")
+	}
+	if cfg.Upstream.RPM != "https://json.example.com/rpm" {
+		t.Errorf("Upstream.RPM = %q, want %q", cfg.Upstream.RPM, "https://json.example.com/rpm")
+	}
 }
 
 func TestLoadFromEnv(t *testing.T) {
@@ -284,9 +440,8 @@ func TestLoadFromEnv(t *testing.T) {
 	t.Setenv("PROXY_STORAGE_PATH", "/env/cache")
 	t.Setenv("PROXY_LOG_LEVEL", testLevelDebug)
 	t.Setenv("PROXY_ACCESS_LOG_PATH", "/tmp/proxy-access.jsonl")
-	t.Setenv("PROXY_UPSTREAM_MAVEN", "https://maven.example.com/repository/maven-public")
-	t.Setenv("PROXY_UPSTREAM_GRADLE_PLUGIN_PORTAL", "https://plugins.example.com/m2")
-	t.Setenv("PROXY_UPSTREAM_DEBIAN", "http://archive.ubuntu.com/ubuntu")
+	t.Setenv("PROXY_UPSTREAM_ALLOW_PRIVATE_HOSTS", "registry.internal, 10.0.0.12")
+	t.Setenv("PROXY_UPSTREAM_ALLOW_LOOPBACK", "true")
 	t.Setenv("PROXY_GRADLE_BUILD_CACHE_READ_ONLY", "true")
 	t.Setenv("PROXY_GRADLE_BUILD_CACHE_MAX_UPLOAD_SIZE", "32MB")
 	t.Setenv("PROXY_GRADLE_BUILD_CACHE_MAX_AGE", "12h")
@@ -313,15 +468,19 @@ func TestLoadFromEnv(t *testing.T) {
 	if cfg.AccessLog.Path != "/tmp/proxy-access.jsonl" {
 		t.Errorf("AccessLog.Path = %q, want %q", cfg.AccessLog.Path, "/tmp/proxy-access.jsonl")
 	}
-	if cfg.Upstream.Maven != "https://maven.example.com/repository/maven-public" {
-		t.Errorf("Upstream.Maven = %q, want %q", cfg.Upstream.Maven, "https://maven.example.com/repository/maven-public")
+	if got := strings.Join(cfg.Upstream.AllowPrivateHosts, ","); got != "registry.internal,10.0.0.12" {
+		t.Errorf("Upstream.AllowPrivateHosts = %q, want %q", got, "registry.internal,10.0.0.12")
 	}
-	if cfg.Upstream.GradlePluginPortal != "https://plugins.example.com/m2" {
-		t.Errorf("Upstream.GradlePluginPortal = %q, want %q", cfg.Upstream.GradlePluginPortal, "https://plugins.example.com/m2")
+	if !cfg.Upstream.AllowLoopback {
+		t.Error("Upstream.AllowLoopback = false, want true")
 	}
-	if cfg.Upstream.Debian != "http://archive.ubuntu.com/ubuntu" {
-		t.Errorf("Upstream.Debian = %q, want %q", cfg.Upstream.Debian, "http://archive.ubuntu.com/ubuntu")
+
+	t.Setenv("PROXY_UPSTREAM_ALLOW_PRIVATE_HOSTS", " , ")
+	cfg.LoadFromEnv()
+	if got := strings.Join(cfg.Upstream.AllowPrivateHosts, ","); got != "registry.internal,10.0.0.12" {
+		t.Errorf("Upstream.AllowPrivateHosts after empty env = %q, want unchanged", got)
 	}
+
 	if !cfg.Gradle.BuildCache.ReadOnly {
 		t.Error("Gradle.BuildCache.ReadOnly = false, want true")
 	}
@@ -337,6 +496,19 @@ func TestLoadFromEnv(t *testing.T) {
 	if cfg.Gradle.BuildCache.SweepInterval != "15m" {
 		t.Errorf("Gradle.BuildCache.SweepInterval = %q, want %q", cfg.Gradle.BuildCache.SweepInterval, "15m")
 	}
+}
+
+func TestLoadFromEnvUpstreams(t *testing.T) {
+	cfg := Default()
+	want := make(map[string]string)
+	for name, envName := range upstreamEnvironmentVariables() {
+		value := "https://env.example.com/" + name
+		t.Setenv(envName, value)
+		want[name] = value
+	}
+
+	cfg.LoadFromEnv()
+	assertUpstreamValues(t, cfg, want)
 }
 
 func TestLoadCooldownConfig(t *testing.T) {

--- a/internal/handler/composer.go
+++ b/internal/handler/composer.go
@@ -37,6 +37,15 @@ func NewComposerHandler(proxy *Proxy, proxyURL string) *ComposerHandler {
 	}
 }
 
+// NewComposerHandlerWithUpstreams creates a Composer handler with custom API
+// and repository upstreams.
+func NewComposerHandlerWithUpstreams(proxy *Proxy, proxyURL, upstreamURL, repoURL string) *ComposerHandler {
+	h := NewComposerHandler(proxy, proxyURL)
+	h.upstreamURL = configuredUpstreamURL(upstreamURL, composerUpstream)
+	h.repoURL = configuredUpstreamURL(repoURL, composerRepo)
+	return h
+}
+
 // Routes returns the HTTP handler for Composer requests.
 func (h *ComposerHandler) Routes() http.Handler {
 	mux := http.NewServeMux()

--- a/internal/handler/conan.go
+++ b/internal/handler/conan.go
@@ -27,6 +27,13 @@ func NewConanHandler(proxy *Proxy, proxyURL string) *ConanHandler {
 	}
 }
 
+// NewConanHandlerWithUpstream creates a Conan handler with a custom upstream.
+func NewConanHandlerWithUpstream(proxy *Proxy, proxyURL, upstreamURL string) *ConanHandler {
+	h := NewConanHandler(proxy, proxyURL)
+	h.upstreamURL = configuredUpstreamURL(upstreamURL, conanUpstream)
+	return h
+}
+
 // Routes returns the HTTP handler for Conan requests.
 func (h *ConanHandler) Routes() http.Handler {
 	mux := http.NewServeMux()

--- a/internal/handler/conda.go
+++ b/internal/handler/conda.go
@@ -29,6 +29,13 @@ func NewCondaHandler(proxy *Proxy, proxyURL string) *CondaHandler {
 	}
 }
 
+// NewCondaHandlerWithUpstream creates a Conda handler with a custom upstream.
+func NewCondaHandlerWithUpstream(proxy *Proxy, proxyURL, upstreamURL string) *CondaHandler {
+	h := NewCondaHandler(proxy, proxyURL)
+	h.upstreamURL = configuredUpstreamURL(upstreamURL, condaUpstream)
+	return h
+}
+
 // Routes returns the HTTP handler for Conda requests.
 func (h *CondaHandler) Routes() http.Handler {
 	mux := http.NewServeMux()

--- a/internal/handler/container.go
+++ b/internal/handler/container.go
@@ -47,6 +47,18 @@ func NewContainerHandler(proxy *Proxy, proxyURL string, namedRegistries ...map[s
 	return h
 }
 
+// NewContainerHandlerWithRegistry creates a container handler with a custom
+// default registry and optional named registries.
+func NewContainerHandlerWithRegistry(
+	proxy *Proxy,
+	proxyURL, registryURL string,
+	namedRegistries ...map[string]string,
+) *ContainerHandler {
+	h := NewContainerHandler(proxy, proxyURL, namedRegistries...)
+	h.registryURL = configuredUpstreamURL(registryURL, dockerHubRegistry)
+	return h
+}
+
 // Routes returns the HTTP handler for container registry requests.
 // Mount this at /v2 on your router.
 func (h *ContainerHandler) Routes() http.Handler {

--- a/internal/handler/cran.go
+++ b/internal/handler/cran.go
@@ -25,6 +25,13 @@ func NewCRANHandler(proxy *Proxy, proxyURL string) *CRANHandler {
 	}
 }
 
+// NewCRANHandlerWithUpstream creates a CRAN handler with a custom upstream.
+func NewCRANHandlerWithUpstream(proxy *Proxy, proxyURL, upstreamURL string) *CRANHandler {
+	h := NewCRANHandler(proxy, proxyURL)
+	h.upstreamURL = configuredUpstreamURL(upstreamURL, cranUpstream)
+	return h
+}
+
 // Routes returns the HTTP handler for CRAN requests.
 func (h *CRANHandler) Routes() http.Handler {
 	mux := http.NewServeMux()

--- a/internal/handler/download_test.go
+++ b/internal/handler/download_test.go
@@ -11,6 +11,7 @@ import (
 	"time"
 
 	"github.com/git-pkgs/proxy/internal/database"
+	"github.com/git-pkgs/proxy/internal/metrics"
 	"github.com/git-pkgs/proxy/internal/storage"
 	"github.com/git-pkgs/purl"
 	"github.com/git-pkgs/registries/fetch"
@@ -203,16 +204,19 @@ func TestGemHandler_UpstreamProxy(t *testing.T) {
 
 func TestGemHandler_CacheMiss(t *testing.T) {
 	proxy, _, _, fetcher := setupTestProxy(t)
+	fetchesBefore := histogramSampleCount(t, metrics.UpstreamFetchDuration.WithLabelValues("gem"))
 	fetcher.artifact = &fetch.Artifact{
 		Body:        io.NopCloser(strings.NewReader("fetched gem")),
 		ContentType: "application/octet-stream",
 	}
 
-	h := NewGemHandler(proxy, "http://localhost")
+	upstreamURL := "https://packages.example.com/gem"
+	h := NewGemHandlerWithUpstream(proxy, "http://localhost", upstreamURL)
 	srv := httptest.NewServer(h.Routes())
 	defer srv.Close()
 
-	resp, err := http.Get(srv.URL + "/gems/sinatra-3.0.0.gem")
+	path := "/gems/sinatra-3.0.0.gem"
+	resp, err := http.Get(srv.URL + path)
 	if err != nil {
 		t.Fatalf("request failed: %v", err)
 	}
@@ -220,6 +224,12 @@ func TestGemHandler_CacheMiss(t *testing.T) {
 
 	if !fetcher.fetchCalled {
 		t.Error("expected fetcher to be called on cache miss")
+	}
+	if want := upstreamURL + path; fetcher.fetchedURL != want {
+		t.Errorf("upstream URL = %q, want %q", fetcher.fetchedURL, want)
+	}
+	if diff := histogramSampleCount(t, metrics.UpstreamFetchDuration.WithLabelValues("gem")) - fetchesBefore; diff != 1 {
+		t.Errorf("upstream fetch observations delta = %d, want 1", diff)
 	}
 }
 
@@ -342,11 +352,13 @@ func TestGoHandler_CacheMiss(t *testing.T) {
 		ContentType: "application/zip",
 	}
 
-	h := NewGoHandler(proxy, "http://localhost")
+	upstreamURL := "https://packages.example.com/go"
+	h := NewGoHandlerWithUpstream(proxy, "http://localhost", upstreamURL)
 	srv := httptest.NewServer(h.Routes())
 	defer srv.Close()
 
-	resp, err := http.Get(srv.URL + "/example.com/mod/@v/v1.0.0.zip")
+	path := "/example.com/mod/@v/v1.0.0.zip"
+	resp, err := http.Get(srv.URL + path)
 	if err != nil {
 		t.Fatalf("request failed: %v", err)
 	}
@@ -354,6 +366,9 @@ func TestGoHandler_CacheMiss(t *testing.T) {
 
 	if !fetcher.fetchCalled {
 		t.Error("expected fetcher to be called on cache miss")
+	}
+	if want := upstreamURL + path; fetcher.fetchedURL != want {
+		t.Errorf("upstream URL = %q, want %q", fetcher.fetchedURL, want)
 	}
 }
 
@@ -423,11 +438,13 @@ func TestHexHandler_CacheMiss(t *testing.T) {
 		ContentType: "application/x-tar",
 	}
 
-	h := NewHexHandler(proxy, "http://localhost")
+	upstreamURL := "https://packages.example.com/hex"
+	h := NewHexHandlerWithUpstreams(proxy, "http://localhost", upstreamURL, "https://packages.example.com/hex-api")
 	srv := httptest.NewServer(h.Routes())
 	defer srv.Close()
 
-	resp, err := http.Get(srv.URL + "/tarballs/plug-1.15.0.tar")
+	path := "/tarballs/plug-1.15.0.tar"
+	resp, err := http.Get(srv.URL + path)
 	if err != nil {
 		t.Fatalf("request failed: %v", err)
 	}
@@ -435,6 +452,36 @@ func TestHexHandler_CacheMiss(t *testing.T) {
 
 	if !fetcher.fetchCalled {
 		t.Error("expected fetcher to be called on cache miss")
+	}
+	if want := upstreamURL + path; fetcher.fetchedURL != want {
+		t.Errorf("upstream URL = %q, want %q", fetcher.fetchedURL, want)
+	}
+}
+
+func TestPubHandler_CacheMiss(t *testing.T) {
+	proxy, _, _, fetcher := setupTestProxy(t)
+	fetcher.artifact = &fetch.Artifact{
+		Body:        io.NopCloser(strings.NewReader("fetched pub package")),
+		ContentType: "application/gzip",
+	}
+
+	upstreamURL := "https://packages.example.com/pub"
+	h := NewPubHandlerWithUpstream(proxy, "http://localhost", upstreamURL)
+	srv := httptest.NewServer(h.Routes())
+	defer srv.Close()
+
+	path := "/packages/flutter_bloc/versions/8.1.6.tar.gz"
+	resp, err := http.Get(srv.URL + path)
+	if err != nil {
+		t.Fatalf("request failed: %v", err)
+	}
+	defer func() { _ = resp.Body.Close() }()
+
+	if !fetcher.fetchCalled {
+		t.Error("expected fetcher to be called on cache miss")
+	}
+	if want := upstreamURL + path; fetcher.fetchedURL != want {
+		t.Errorf("upstream URL = %q, want %q", fetcher.fetchedURL, want)
 	}
 }
 

--- a/internal/handler/filename_download.go
+++ b/internal/handler/filename_download.go
@@ -6,11 +6,12 @@ import (
 )
 
 type filenameDownload struct {
-	ecosystem string
-	suffix    string
-	parseErr  string
-	fetchErr  string
-	parse     func(string) (name, version string)
+	ecosystem   string
+	upstreamURL string
+	suffix      string
+	parseErr    string
+	fetchErr    string
+	parse       func(string) (name, version string)
 }
 
 func (p *Proxy) handleFilenameDownload(w http.ResponseWriter, r *http.Request, d filenameDownload) {
@@ -29,7 +30,10 @@ func (p *Proxy) handleFilenameDownload(w http.ResponseWriter, r *http.Request, d
 	p.Logger.Info(d.ecosystem+" download request",
 		"name", name, "version", version, "filename", filename)
 
-	result, err := p.GetOrFetchArtifact(r.Context(), d.ecosystem, name, version, filename)
+	downloadURL := d.upstreamURL + r.URL.Path
+	result, err := p.GetOrFetchArtifactFromURL(
+		r.Context(), d.ecosystem, name, version, filename, downloadURL,
+	)
 	if err != nil {
 		p.serveArtifactError(w, err, d.fetchErr)
 		return

--- a/internal/handler/gem.go
+++ b/internal/handler/gem.go
@@ -30,6 +30,13 @@ func NewGemHandler(proxy *Proxy, proxyURL string) *GemHandler {
 	}
 }
 
+// NewGemHandlerWithUpstream creates a RubyGems handler with a custom upstream.
+func NewGemHandlerWithUpstream(proxy *Proxy, proxyURL, upstreamURL string) *GemHandler {
+	h := NewGemHandler(proxy, proxyURL)
+	h.upstreamURL = configuredUpstreamURL(upstreamURL, gemUpstream)
+	return h
+}
+
 // Routes returns the HTTP handler for RubyGems requests.
 func (h *GemHandler) Routes() http.Handler {
 	mux := http.NewServeMux()
@@ -59,11 +66,12 @@ func (h *GemHandler) Routes() http.Handler {
 // handleDownload serves a gem file, fetching and caching from upstream if needed.
 func (h *GemHandler) handleDownload(w http.ResponseWriter, r *http.Request) {
 	h.proxy.handleFilenameDownload(w, r, filenameDownload{
-		ecosystem: "gem",
-		suffix:    ".gem",
-		parseErr:  "could not parse gem filename",
-		fetchErr:  "failed to fetch gem",
-		parse:     h.parseGemFilename,
+		ecosystem:   "gem",
+		upstreamURL: h.upstreamURL,
+		suffix:      ".gem",
+		parseErr:    "could not parse gem filename",
+		fetchErr:    "failed to fetch gem",
+		parse:       h.parseGemFilename,
 	})
 }
 

--- a/internal/handler/go.go
+++ b/internal/handler/go.go
@@ -30,6 +30,13 @@ func NewGoHandler(proxy *Proxy, proxyURL string) *GoHandler {
 	}
 }
 
+// NewGoHandlerWithUpstream creates a Go module handler with a custom upstream.
+func NewGoHandlerWithUpstream(proxy *Proxy, proxyURL, upstreamURL string) *GoHandler {
+	h := NewGoHandler(proxy, proxyURL)
+	h.upstreamURL = configuredUpstreamURL(upstreamURL, goUpstream)
+	return h
+}
+
 // Routes returns the HTTP handler for Go proxy requests.
 func (h *GoHandler) Routes() http.Handler {
 	// Go module paths can contain slashes, so just use the handler directly
@@ -101,7 +108,10 @@ func (h *GoHandler) handleDownload(w http.ResponseWriter, r *http.Request, modul
 	h.proxy.Logger.Info("go module download request",
 		"module", decodedModule, "version", version)
 
-	result, err := h.proxy.GetOrFetchArtifact(r.Context(), "golang", decodedModule, version, filename)
+	downloadURL := h.upstreamURL + r.URL.Path
+	result, err := h.proxy.GetOrFetchArtifactFromURL(
+		r.Context(), "golang", decodedModule, version, filename, downloadURL,
+	)
 	if err != nil {
 		if errors.Is(err, fetch.ErrNotFound) {
 			http.Error(w, "not found", http.StatusNotFound)

--- a/internal/handler/handler.go
+++ b/internal/handler/handler.go
@@ -47,6 +47,13 @@ func hasDotDotSegment(path string) bool {
 	return false
 }
 
+func configuredUpstreamURL(value, defaultValue string) string {
+	if value == "" {
+		value = defaultValue
+	}
+	return strings.TrimRight(value, "/")
+}
+
 const defaultHTTPTimeout = 30 * time.Second
 
 const artifactCopyBufferSize = 32 << 10
@@ -880,8 +887,11 @@ func (p *Proxy) fetchAndCacheFromURL(ctx context.Context, ecosystem, name, versi
 	p.Logger.Info("fetching from upstream",
 		"ecosystem", ecosystem, "name", name, "version", version, "url", downloadURL)
 
+	fetchStart := time.Now()
 	artifact, err := p.Fetcher.FetchWithHeaders(ctx, downloadURL, headers)
+	metrics.RecordUpstreamFetch(ecosystem, time.Since(fetchStart))
 	if err != nil {
+		metrics.RecordUpstreamError(ecosystem, "fetch_failed")
 		if errors.Is(err, fetch.ErrNotFound) {
 			return nil, ErrUpstreamNotFound
 		}
@@ -889,9 +899,12 @@ func (p *Proxy) fetchAndCacheFromURL(ctx context.Context, ecosystem, name, versi
 	}
 
 	storagePath := storage.ArtifactPath(ecosystem, "", name, version, filename)
+	storeStart := time.Now()
 	size, hash, err := p.Storage.Store(ctx, storagePath, artifact.Body)
 	_ = artifact.Body.Close()
+	metrics.RecordStorageOperation("write", time.Since(storeStart))
 	if err != nil {
+		metrics.RecordStorageError("write")
 		return nil, fmt.Errorf("storing artifact: %w", err)
 	}
 
@@ -899,8 +912,11 @@ func (p *Proxy) fetchAndCacheFromURL(ctx context.Context, ecosystem, name, versi
 		p.Logger.Warn("failed to update cache database", "error", err)
 	}
 
+	readStart := time.Now()
 	reader, err := p.Storage.Open(ctx, storagePath)
+	metrics.RecordStorageOperation("read", time.Since(readStart))
 	if err != nil {
+		metrics.RecordStorageError("read")
 		return nil, fmt.Errorf("opening cached artifact: %w", err)
 	}
 

--- a/internal/handler/handler_test.go
+++ b/internal/handler/handler_test.go
@@ -19,7 +19,9 @@ import (
 	"github.com/git-pkgs/proxy/internal/storage"
 	"github.com/git-pkgs/purl"
 	"github.com/git-pkgs/registries/fetch"
+	"github.com/prometheus/client_golang/prometheus"
 	"github.com/prometheus/client_golang/prometheus/testutil"
+	dto "github.com/prometheus/client_model/go"
 )
 
 // mockStorage implements storage.Storage for testing.
@@ -147,6 +149,19 @@ func setupTestProxy(t testing.TB) (*Proxy, *database.DB, *mockStorage, *mockFetc
 
 	proxy := NewProxy(db, store, fetcher, resolver, logger)
 	return proxy, db, store, fetcher
+}
+
+func histogramSampleCount(t testing.TB, observer prometheus.Observer) uint64 {
+	t.Helper()
+	metric, ok := observer.(prometheus.Metric)
+	if !ok {
+		t.Fatal("observer does not implement prometheus.Metric")
+	}
+	value := &dto.Metric{}
+	if err := metric.Write(value); err != nil {
+		t.Fatalf("writing Prometheus metric: %v", err)
+	}
+	return value.GetHistogram().GetSampleCount()
 }
 
 // seedPackage creates a package, version, and cached artifact in the test DB and storage.
@@ -636,6 +651,9 @@ func TestGetOrFetchArtifactFromURL_CacheHit(t *testing.T) {
 func TestGetOrFetchArtifactFromURL_CacheMiss(t *testing.T) {
 	proxy, _, store, fetcher := setupTestProxy(t)
 	missesBefore := testutil.ToFloat64(metrics.CacheMisses.WithLabelValues("pypi"))
+	fetchesBefore := histogramSampleCount(t, metrics.UpstreamFetchDuration.WithLabelValues("pypi"))
+	writesBefore := histogramSampleCount(t, metrics.StorageOperationDuration.WithLabelValues("write"))
+	readsBefore := histogramSampleCount(t, metrics.StorageOperationDuration.WithLabelValues("read"))
 
 	fetcher.artifact = &fetch.Artifact{
 		Body:        io.NopCloser(strings.NewReader("fetched content")),
@@ -672,11 +690,21 @@ func TestGetOrFetchArtifactFromURL_CacheMiss(t *testing.T) {
 	if diff := missesAfter - missesBefore; diff != 1 {
 		t.Errorf("cache misses delta = %.0f, want 1", diff)
 	}
+	if diff := histogramSampleCount(t, metrics.UpstreamFetchDuration.WithLabelValues("pypi")) - fetchesBefore; diff != 1 {
+		t.Errorf("upstream fetch observations delta = %d, want 1", diff)
+	}
+	if diff := histogramSampleCount(t, metrics.StorageOperationDuration.WithLabelValues("write")) - writesBefore; diff != 1 {
+		t.Errorf("storage write observations delta = %d, want 1", diff)
+	}
+	if diff := histogramSampleCount(t, metrics.StorageOperationDuration.WithLabelValues("read")) - readsBefore; diff != 1 {
+		t.Errorf("storage read observations delta = %d, want 1", diff)
+	}
 }
 
 func TestGetOrFetchArtifactFromURL_FetchError(t *testing.T) {
 	proxy, _, _, fetcher := setupTestProxy(t)
 	fetcher.fetchErr = errors.New("connection refused")
+	errorsBefore := testutil.ToFloat64(metrics.UpstreamErrors.WithLabelValues("pypi", "fetch_failed"))
 
 	_, err := proxy.GetOrFetchArtifactFromURL(context.Background(), "pypi", "fail", "1.0.0", "fail-1.0.0.tar.gz", "https://pypi.org/files/fail-1.0.0.tar.gz")
 	if err == nil {
@@ -685,11 +713,15 @@ func TestGetOrFetchArtifactFromURL_FetchError(t *testing.T) {
 	if !strings.Contains(err.Error(), "fetching from upstream") {
 		t.Errorf("expected upstream error, got: %v", err)
 	}
+	if diff := testutil.ToFloat64(metrics.UpstreamErrors.WithLabelValues("pypi", "fetch_failed")) - errorsBefore; diff != 1 {
+		t.Errorf("upstream errors delta = %.0f, want 1", diff)
+	}
 }
 
 func TestGetOrFetchArtifactFromURL_StoreError(t *testing.T) {
 	proxy, _, store, fetcher := setupTestProxy(t)
 	store.storeErr = errors.New("disk full")
+	errorsBefore := testutil.ToFloat64(metrics.StorageErrors.WithLabelValues("write"))
 	fetcher.artifact = &fetch.Artifact{
 		Body:        io.NopCloser(strings.NewReader("data")),
 		ContentType: "application/gzip",
@@ -701,6 +733,9 @@ func TestGetOrFetchArtifactFromURL_StoreError(t *testing.T) {
 	}
 	if !strings.Contains(err.Error(), "storing artifact") {
 		t.Errorf("expected storage error, got: %v", err)
+	}
+	if diff := testutil.ToFloat64(metrics.StorageErrors.WithLabelValues("write")) - errorsBefore; diff != 1 {
+		t.Errorf("storage errors delta = %.0f, want 1", diff)
 	}
 }
 

--- a/internal/handler/hex.go
+++ b/internal/handler/hex.go
@@ -21,6 +21,7 @@ const (
 type HexHandler struct {
 	proxy       *Proxy
 	upstreamURL string
+	apiURL      string
 	proxyURL    string
 }
 
@@ -29,8 +30,18 @@ func NewHexHandler(proxy *Proxy, proxyURL string) *HexHandler {
 	return &HexHandler{
 		proxy:       proxy,
 		upstreamURL: hexUpstream,
+		apiURL:      hexAPIURL,
 		proxyURL:    strings.TrimSuffix(proxyURL, "/"),
 	}
+}
+
+// NewHexHandlerWithUpstreams creates a Hex handler with custom repository and
+// API upstreams.
+func NewHexHandlerWithUpstreams(proxy *Proxy, proxyURL, upstreamURL, apiURL string) *HexHandler {
+	h := NewHexHandler(proxy, proxyURL)
+	h.upstreamURL = configuredUpstreamURL(upstreamURL, hexUpstream)
+	h.apiURL = configuredUpstreamURL(apiURL, hexAPIURL)
+	return h
 }
 
 // Routes returns the HTTP handler for Hex requests.
@@ -54,11 +65,12 @@ func (h *HexHandler) Routes() http.Handler {
 // handleDownload serves a package tarball, fetching and caching from upstream if needed.
 func (h *HexHandler) handleDownload(w http.ResponseWriter, r *http.Request) {
 	h.proxy.handleFilenameDownload(w, r, filenameDownload{
-		ecosystem: "hex",
-		suffix:    ".tar",
-		parseErr:  "could not parse tarball filename",
-		fetchErr:  "failed to fetch package",
-		parse:     h.parseTarballFilename,
+		ecosystem:   "hex",
+		upstreamURL: h.upstreamURL,
+		suffix:      ".tar",
+		parseErr:    "could not parse tarball filename",
+		fetchErr:    "failed to fetch package",
+		parse:       h.parseTarballFilename,
 	})
 }
 
@@ -197,7 +209,7 @@ type hexPackageAPI struct {
 // fetchFilteredVersions fetches the Hex API and returns a set of version
 // strings that should be filtered out by cooldown.
 func (h *HexHandler) fetchFilteredVersions(r *http.Request, name string) (map[string]bool, error) {
-	apiURL := fmt.Sprintf("%s/api/packages/%s", hexAPIURL, name)
+	apiURL := fmt.Sprintf("%s/api/packages/%s", h.apiURL, name)
 	req, err := http.NewRequestWithContext(r.Context(), http.MethodGet, apiURL, nil)
 	if err != nil {
 		return nil, err

--- a/internal/handler/julia.go
+++ b/internal/handler/julia.go
@@ -53,6 +53,13 @@ func NewJuliaHandler(proxy *Proxy, _ string) *JuliaHandler {
 	}
 }
 
+// NewJuliaHandlerWithUpstream creates a Julia handler with a custom upstream.
+func NewJuliaHandlerWithUpstream(proxy *Proxy, upstreamURL string) *JuliaHandler {
+	h := NewJuliaHandler(proxy, "")
+	h.upstreamURL = configuredUpstreamURL(upstreamURL, juliaUpstream)
+	return h
+}
+
 // Routes returns the HTTP handler for Julia requests.
 func (h *JuliaHandler) Routes() http.Handler {
 	mux := http.NewServeMux()

--- a/internal/handler/notfound_ecosystems_test.go
+++ b/internal/handler/notfound_ecosystems_test.go
@@ -22,7 +22,9 @@ func TestArtifactDownloadUpstreamNotFoundReturns404(t *testing.T) {
 		{"nuget", "/v3-flatcontainer/newtonsoft.json/13.0.3/newtonsoft.json.13.0.3.nupkg",
 			func(p *Proxy) http.Handler { return NewNuGetHandler(p, "http://localhost").Routes() }},
 		{"pypi", "/packages/packages/ab/cd/ef0123456789/requests-2.31.0-py3-none-any.whl",
-			func(p *Proxy) http.Handler { return NewPyPIHandler(p, "http://localhost").Routes() }},
+			func(p *Proxy) http.Handler {
+				return NewPyPIHandlerWithUpstreams(p, "http://localhost", "", "").Routes()
+			}},
 		{"cran", "/src/contrib/ggplot2_3.4.4.tar.gz",
 			func(p *Proxy) http.Handler { return NewCRANHandler(p, "http://localhost").Routes() }},
 		{"conda", "/conda-forge/linux-64/numpy-1.26.0-py311_0.tar.bz2",

--- a/internal/handler/nuget.go
+++ b/internal/handler/nuget.go
@@ -11,13 +11,15 @@ import (
 )
 
 const (
-	nugetUpstream = "https://api.nuget.org"
+	nugetUpstream       = "https://api.nuget.org"
+	nugetSearchUpstream = "https://azuresearch-usnc.nuget.org"
 )
 
 // NuGetHandler handles NuGet V3 API protocol requests.
 type NuGetHandler struct {
 	proxy       *Proxy
 	upstreamURL string
+	searchURL   string
 	proxyURL    string
 }
 
@@ -26,8 +28,18 @@ func NewNuGetHandler(proxy *Proxy, proxyURL string) *NuGetHandler {
 	return &NuGetHandler{
 		proxy:       proxy,
 		upstreamURL: nugetUpstream,
+		searchURL:   nugetSearchUpstream,
 		proxyURL:    strings.TrimSuffix(proxyURL, "/"),
 	}
+}
+
+// NewNuGetHandlerWithUpstreams creates a NuGet handler with custom API and
+// search upstreams.
+func NewNuGetHandlerWithUpstreams(proxy *Proxy, proxyURL, upstreamURL, searchURL string) *NuGetHandler {
+	h := NewNuGetHandler(proxy, proxyURL)
+	h.upstreamURL = configuredUpstreamURL(upstreamURL, nugetUpstream)
+	h.searchURL = configuredUpstreamURL(searchURL, nugetSearchUpstream)
+	return h
 }
 
 // Routes returns the HTTP handler for NuGet requests.
@@ -103,55 +115,31 @@ func (h *NuGetHandler) rewriteServiceIndex(body []byte) ([]byte, error) {
 		id, _ := rmap["@id"].(string)
 		rtype, _ := rmap["@type"].(string)
 
-		// Rewrite URLs for services we proxy
-		if id != "" && h.shouldRewriteService(rtype) {
-			newURL := h.rewriteNuGetURL(id)
-			rmap["@id"] = newURL
+		// Rewrite URLs for services we proxy. The service type determines the
+		// local route because an upstream index may advertise a different host.
+		if id != "" {
+			rmap["@id"] = h.rewriteNuGetURL(id, rtype)
 		}
 	}
 
 	return json.Marshal(index)
 }
 
-// shouldRewriteService returns true if the service type should be rewritten.
-func (h *NuGetHandler) shouldRewriteService(serviceType string) bool {
-	// Rewrite package content and registration services
-	rewriteTypes := []string{
-		"PackageBaseAddress/3.0.0",
-		"RegistrationsBaseUrl/3.6.0",
-		"RegistrationsBaseUrl/Versioned",
-		"SearchQueryService",
-		"SearchQueryService/3.0.0-rc",
-		"SearchQueryService/3.5.0",
-		"SearchAutocompleteService",
-		"SearchAutocompleteService/3.5.0",
+// rewriteNuGetURL rewrites a NuGet service URL based on its advertised type.
+// Service types the proxy does not handle are returned unchanged.
+func (h *NuGetHandler) rewriteNuGetURL(origURL, serviceType string) string {
+	switch serviceType {
+	case "PackageBaseAddress/3.0.0":
+		return h.proxyURL + "/nuget/v3-flatcontainer/"
+	case "RegistrationsBaseUrl/3.6.0", "RegistrationsBaseUrl/Versioned":
+		return h.proxyURL + "/nuget/v3/registration5-gz-semver2/"
+	case "SearchQueryService", "SearchQueryService/3.0.0-rc", "SearchQueryService/3.5.0":
+		return h.proxyURL + "/nuget/query"
+	case "SearchAutocompleteService", "SearchAutocompleteService/3.5.0":
+		return h.proxyURL + "/nuget/autocomplete"
+	default:
+		return origURL
 	}
-
-	for _, t := range rewriteTypes {
-		if serviceType == t {
-			return true
-		}
-	}
-	return false
-}
-
-// rewriteNuGetURL rewrites a NuGet API URL to point at this proxy.
-func (h *NuGetHandler) rewriteNuGetURL(origURL string) string {
-	// Map known NuGet API endpoints to our proxy paths
-	replacements := map[string]string{
-		"https://api.nuget.org/v3-flatcontainer/":            h.proxyURL + "/nuget/v3-flatcontainer/",
-		"https://api.nuget.org/v3/registration5-gz-semver2/": h.proxyURL + "/nuget/v3/registration5-gz-semver2/",
-		"https://azuresearch-usnc.nuget.org/query":           h.proxyURL + "/nuget/query",
-		"https://azuresearch-usnc.nuget.org/autocomplete":    h.proxyURL + "/nuget/autocomplete",
-	}
-
-	for old, new := range replacements {
-		if strings.HasPrefix(origURL, old) {
-			return strings.Replace(origURL, old, new, 1)
-		}
-	}
-
-	return origURL
 }
 
 // handleRegistration proxies NuGet registration pages, applying cooldown filtering.
@@ -363,7 +351,7 @@ func (h *NuGetHandler) buildUpstreamURL(r *http.Request) string {
 
 	// Handle query and autocomplete which go to azuresearch
 	if strings.HasPrefix(path, "/query") || strings.HasPrefix(path, "/autocomplete") {
-		return "https://azuresearch-usnc.nuget.org" + path + "?" + r.URL.RawQuery
+		return h.searchURL + path + "?" + r.URL.RawQuery
 	}
 
 	return h.upstreamURL + path

--- a/internal/handler/nuget_test.go
+++ b/internal/handler/nuget_test.go
@@ -91,75 +91,82 @@ func TestNuGetRewriteServiceIndex(t *testing.T) {
 	}
 }
 
-func TestNuGetShouldRewriteService(t *testing.T) {
-	h := &NuGetHandler{}
-
-	rewriteTypes := []string{
-		"PackageBaseAddress/3.0.0",
-		"RegistrationsBaseUrl/3.6.0",
-		"RegistrationsBaseUrl/Versioned",
-		"SearchQueryService",
-		"SearchQueryService/3.0.0-rc",
-		"SearchQueryService/3.5.0",
-		"SearchAutocompleteService",
-		"SearchAutocompleteService/3.5.0",
-	}
-
-	for _, stype := range rewriteTypes {
-		if !h.shouldRewriteService(stype) {
-			t.Errorf("shouldRewriteService(%q) = false, want true", stype)
-		}
-	}
-
-	noRewriteTypes := []string{
-		"SomeOtherService/1.0.0",
-		"PackagePublish/2.0.0",
-		"",
-		"SearchQueryService/99.0.0",
-	}
-
-	for _, stype := range noRewriteTypes {
-		if h.shouldRewriteService(stype) {
-			t.Errorf("shouldRewriteService(%q) = true, want false", stype)
-		}
-	}
-}
-
 func TestNuGetRewriteURL(t *testing.T) {
 	h := &NuGetHandler{
 		proxyURL: "http://localhost:8080",
 	}
 
 	tests := []struct {
-		input string
-		want  string
+		input       string
+		serviceType string
+		want        string
 	}{
 		{
 			"https://api.nuget.org/v3-flatcontainer/",
+			"PackageBaseAddress/3.0.0",
 			"http://localhost:8080/nuget/v3-flatcontainer/",
 		},
 		{
 			"https://api.nuget.org/v3/registration5-gz-semver2/",
+			"RegistrationsBaseUrl/3.6.0",
+			"http://localhost:8080/nuget/v3/registration5-gz-semver2/",
+		},
+		{
+			"https://api.nuget.org/v3/registration5-gz-semver2/",
+			"RegistrationsBaseUrl/Versioned",
 			"http://localhost:8080/nuget/v3/registration5-gz-semver2/",
 		},
 		{
 			"https://azuresearch-usnc.nuget.org/query",
+			"SearchQueryService",
+			"http://localhost:8080/nuget/query",
+		},
+		{
+			"https://azuresearch-usnc.nuget.org/query",
+			"SearchQueryService/3.0.0-rc",
+			"http://localhost:8080/nuget/query",
+		},
+		{
+			"https://azuresearch-usnc.nuget.org/query",
+			"SearchQueryService/3.5.0",
 			"http://localhost:8080/nuget/query",
 		},
 		{
 			"https://azuresearch-usnc.nuget.org/autocomplete",
+			"SearchAutocompleteService",
+			"http://localhost:8080/nuget/autocomplete",
+		},
+		{
+			"https://azuresearch-usnc.nuget.org/autocomplete",
+			"SearchAutocompleteService/3.5.0",
 			"http://localhost:8080/nuget/autocomplete",
 		},
 		{
 			"https://example.com/unknown",
+			"SomeOtherService/1.0.0",
 			"https://example.com/unknown",
+		},
+		{
+			"https://api.nuget.org/v2/package",
+			"PackagePublish/2.0.0",
+			"https://api.nuget.org/v2/package",
+		},
+		{
+			"https://azuresearch-usnc.nuget.org/query",
+			"SearchQueryService/99.0.0",
+			"https://azuresearch-usnc.nuget.org/query",
+		},
+		{
+			"https://example.com/resource",
+			"",
+			"https://example.com/resource",
 		},
 	}
 
 	for _, tt := range tests {
-		got := h.rewriteNuGetURL(tt.input)
+		got := h.rewriteNuGetURL(tt.input, tt.serviceType)
 		if got != tt.want {
-			t.Errorf("rewriteNuGetURL(%q) = %q, want %q", tt.input, got, tt.want)
+			t.Errorf("rewriteNuGetURL(%q, %q) = %q, want %q", tt.input, tt.serviceType, got, tt.want)
 		}
 	}
 }
@@ -458,6 +465,7 @@ func TestNuGetProxyUpstreamForwardsAcceptEncoding(t *testing.T) {
 func TestNuGetBuildUpstreamURL(t *testing.T) {
 	h := &NuGetHandler{
 		upstreamURL: "https://api.nuget.org",
+		searchURL:   "https://azuresearch-usnc.nuget.org",
 	}
 
 	tests := []struct {
@@ -736,6 +744,7 @@ func TestNuGetHandleDownloadMissingFilename(t *testing.T) {
 func TestNuGetBuildUpstreamURLQueryPath(t *testing.T) {
 	h := &NuGetHandler{
 		upstreamURL: "https://api.nuget.org",
+		searchURL:   "https://azuresearch-usnc.nuget.org",
 	}
 
 	// Query endpoint should go to azuresearch
@@ -750,6 +759,7 @@ func TestNuGetBuildUpstreamURLQueryPath(t *testing.T) {
 func TestNuGetBuildUpstreamURLAutocompletePath(t *testing.T) {
 	h := &NuGetHandler{
 		upstreamURL: "https://api.nuget.org",
+		searchURL:   "https://azuresearch-usnc.nuget.org",
 	}
 
 	req := httptest.NewRequest(http.MethodGet, "/autocomplete?q=new&take=10", nil)

--- a/internal/handler/pub.go
+++ b/internal/handler/pub.go
@@ -30,6 +30,13 @@ func NewPubHandler(proxy *Proxy, proxyURL string) *PubHandler {
 	}
 }
 
+// NewPubHandlerWithUpstream creates a pub handler with a custom upstream.
+func NewPubHandlerWithUpstream(proxy *Proxy, proxyURL, upstreamURL string) *PubHandler {
+	h := NewPubHandler(proxy, proxyURL)
+	h.upstreamURL = configuredUpstreamURL(upstreamURL, pubUpstream)
+	return h
+}
+
 // Routes returns the HTTP handler for pub requests.
 func (h *PubHandler) Routes() http.Handler {
 	mux := http.NewServeMux()
@@ -65,7 +72,10 @@ func (h *PubHandler) handleDownload(w http.ResponseWriter, r *http.Request) {
 	h.proxy.Logger.Info("pub download request",
 		"name", name, "version", version)
 
-	result, err := h.proxy.GetOrFetchArtifact(r.Context(), "pub", name, version, filename)
+	downloadURL := h.upstreamURL + r.URL.Path
+	result, err := h.proxy.GetOrFetchArtifactFromURL(
+		r.Context(), "pub", name, version, filename, downloadURL,
+	)
 	if err != nil {
 		h.proxy.serveArtifactError(w, err, "failed to fetch package")
 		return

--- a/internal/handler/pypi.go
+++ b/internal/handler/pypi.go
@@ -9,7 +9,6 @@ import (
 	"io"
 	"mime"
 	"net/http"
-	"net/url"
 	"regexp"
 	"strconv"
 	"strings"
@@ -18,6 +17,7 @@ import (
 
 const (
 	pypiUpstream         = "https://pypi.org"
+	pypiDownloadUpstream = "https://files.pythonhosted.org"
 	pypiSimpleJSON       = "application/vnd.pypi.simple.v1+json"
 	pypiSimpleHTML       = "application/vnd.pypi.simple.v1+html"
 	pypiSimpleLatestJSON = "application/vnd.pypi.simple.latest+json"
@@ -39,18 +39,29 @@ const (
 
 // PyPIHandler handles PyPI registry protocol requests.
 type PyPIHandler struct {
-	proxy       *Proxy
-	upstreamURL string
-	proxyURL    string
+	proxy          *Proxy
+	upstreamURL    string
+	downloadURL    string
+	downloadHrefRe *regexp.Regexp
+	proxyURL       string
 }
 
 // NewPyPIHandler creates a new PyPI protocol handler.
 func NewPyPIHandler(proxy *Proxy, proxyURL string) *PyPIHandler {
-	return &PyPIHandler{
+	return NewPyPIHandlerWithUpstreams(proxy, proxyURL, "", "")
+}
+
+// NewPyPIHandlerWithUpstreams creates a PyPI handler with custom API and
+// package download upstreams.
+func NewPyPIHandlerWithUpstreams(proxy *Proxy, proxyURL, upstreamURL, downloadURL string) *PyPIHandler {
+	h := &PyPIHandler{
 		proxy:       proxy,
-		upstreamURL: pypiUpstream,
+		upstreamURL: configuredUpstreamURL(upstreamURL, pypiUpstream),
+		downloadURL: configuredUpstreamURL(downloadURL, pypiDownloadUpstream),
 		proxyURL:    strings.TrimSuffix(proxyURL, "/"),
 	}
+	h.downloadHrefRe = regexp.MustCompile(`href="(` + regexp.QuoteMeta(h.downloadURL) + `/packages/[^"]+)"`)
+	return h
 }
 
 // Routes returns the HTTP handler for PyPI requests.
@@ -296,24 +307,16 @@ func (h *PyPIHandler) rewriteSimpleHTML(body []byte, filteredVersions map[string
 		})
 	}
 
-	// Match href attributes pointing to packages
-	// PyPI URLs look like: https://files.pythonhosted.org/packages/...
-	re := regexp.MustCompile(`href="(https://files\.pythonhosted\.org/packages/[^"]+)"`)
-
-	return re.ReplaceAllFunc(body, func(match []byte) []byte {
-		submatch := re.FindSubmatch(match)
+	// Match href attributes pointing to packages on the configured download host.
+	return h.downloadHrefRe.ReplaceAllFunc(body, func(match []byte) []byte {
+		submatch := h.downloadHrefRe.FindSubmatch(match)
 		if len(submatch) < minSubmatchParts {
 			return match
 		}
 
 		origURL := string(submatch[1])
 
-		u, err := url.Parse(origURL)
-		if err != nil {
-			return match
-		}
-
-		newURL := fmt.Sprintf("%s/pypi/packages%s", h.proxyURL, u.Path)
+		newURL := h.proxyURL + "/pypi/packages" + strings.TrimPrefix(origURL, h.downloadURL)
 		return []byte(fmt.Sprintf(`href="%s"`, newURL))
 	})
 }
@@ -552,15 +555,8 @@ func (h *PyPIHandler) rewriteURLEntry(entry map[string]any) {
 		return
 	}
 
-	u, err := url.Parse(urlStr)
-	if err != nil {
-		return
-	}
-
-	// Only rewrite pythonhosted.org URLs
-	if u.Host == "files.pythonhosted.org" {
-		newURL := fmt.Sprintf("%s/pypi/packages%s", h.proxyURL, u.Path)
-		entry["url"] = newURL
+	if strings.HasPrefix(urlStr, h.downloadURL+"/packages/") {
+		entry["url"] = h.proxyURL + "/pypi/packages" + strings.TrimPrefix(urlStr, h.downloadURL)
 	}
 }
 
@@ -599,10 +595,9 @@ func (h *PyPIHandler) handleDownload(w http.ResponseWriter, r *http.Request) {
 	h.proxy.Logger.Info("pypi download request",
 		"name", name, "version", version, "filename", filename)
 
-	// Construct upstream URL; the incoming path starts with
-	// '/packages' so there is no need to include it in the format
-	// string
-	upstreamURL := fmt.Sprintf("https://files.pythonhosted.org/%s", path)
+	// The path value starts with 'packages/' (no leading slash), so add
+	// the separator here.
+	upstreamURL := fmt.Sprintf("%s/%s", h.downloadURL, path)
 
 	result, err := h.proxy.GetOrFetchArtifactFromURL(r.Context(), "pypi", name, version, filename, upstreamURL)
 	if err != nil {

--- a/internal/handler/pypi_test.go
+++ b/internal/handler/pypi_test.go
@@ -39,7 +39,7 @@ func setupPyPIHandler(t testing.TB, transport pypiRoundTripFunc) (*PyPIHandler, 
 
 	proxy, _, _, _ := setupTestProxy(t)
 	proxy.HTTPClient = &http.Client{Transport: transport}
-	h := NewPyPIHandler(proxy, "http://proxy.test")
+	h := NewPyPIHandlerWithUpstreams(proxy, "http://proxy.test", "", "")
 	h.upstreamURL = "https://pypi.test"
 	return h, proxy
 }
@@ -430,7 +430,7 @@ func TestPyPIHandler_DownloadUpstreamURL(t *testing.T) {
 		ContentType: "application/octet-stream",
 	}
 
-	h := NewPyPIHandler(proxy, "http://localhost")
+	h := NewPyPIHandlerWithUpstreams(proxy, "http://localhost", "", "")
 	srv := httptest.NewServer(h.Routes())
 	defer srv.Close()
 
@@ -458,7 +458,7 @@ func TestPyPIHandler_DownloadCacheHit(t *testing.T) {
 	seedPackage(t, db, store, "pypi", "requests", "2.31.0",
 		"requests-2.31.0-py3-none-any.whl", "wheel binary data")
 
-	h := NewPyPIHandler(proxy, "http://localhost")
+	h := NewPyPIHandlerWithUpstreams(proxy, "http://localhost", "", "")
 	srv := httptest.NewServer(h.Routes())
 	defer srv.Close()
 
@@ -484,7 +484,7 @@ func TestPyPIHandler_DownloadCacheMiss(t *testing.T) {
 		ContentType: "application/octet-stream",
 	}
 
-	h := NewPyPIHandler(proxy, "http://localhost")
+	h := NewPyPIHandlerWithUpstreams(proxy, "http://localhost", "", "")
 	srv := httptest.NewServer(h.Routes())
 	defer srv.Close()
 

--- a/internal/handler/rpm.go
+++ b/internal/handler/rpm.go
@@ -30,6 +30,13 @@ func NewRPMHandler(proxy *Proxy, proxyURL string) *RPMHandler {
 	}
 }
 
+// NewRPMHandlerWithUpstream creates an RPM handler with a custom upstream.
+func NewRPMHandlerWithUpstream(proxy *Proxy, proxyURL, upstreamURL string) *RPMHandler {
+	h := NewRPMHandler(proxy, proxyURL)
+	h.upstreamURL = configuredUpstreamURL(upstreamURL, defaultRPMUpstream)
+	return h
+}
+
 // Routes returns the HTTP handler for RPM requests.
 // Mount this at /rpm on your router.
 func (h *RPMHandler) Routes() http.Handler {

--- a/internal/handler/upstream_test.go
+++ b/internal/handler/upstream_test.go
@@ -1,0 +1,130 @@
+package handler
+
+import (
+	"io"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+)
+
+func TestHandlerUpstreamConfiguration(t *testing.T) {
+	const (
+		proxyURL = "https://proxy.example.com/"
+		baseURL  = "https://upstream.example.com"
+	)
+	hex := NewHexHandlerWithUpstreams(nil, proxyURL, baseURL+"/hex/", baseURL+"/hex-api/")
+	pypi := NewPyPIHandlerWithUpstreams(nil, proxyURL, baseURL+"/pypi/", baseURL+"/pypi-download/")
+	nuget := NewNuGetHandlerWithUpstreams(nil, proxyURL, baseURL+"/nuget/", baseURL+"/nuget-search/")
+	composer := NewComposerHandlerWithUpstreams(
+		nil, proxyURL, baseURL+"/composer/", baseURL+"/composer-repository/",
+	)
+
+	got := map[string]string{
+		"gem":                 NewGemHandlerWithUpstream(nil, proxyURL, baseURL+"/gem/").upstreamURL,
+		"go":                  NewGoHandlerWithUpstream(nil, proxyURL, baseURL+"/go/").upstreamURL,
+		"hex":                 hex.upstreamURL,
+		"hex_api":             hex.apiURL,
+		"pub":                 NewPubHandlerWithUpstream(nil, proxyURL, baseURL+"/pub/").upstreamURL,
+		"pypi":                pypi.upstreamURL,
+		"pypi_download":       pypi.downloadURL,
+		"nuget":               nuget.upstreamURL,
+		"nuget_search":        nuget.searchURL,
+		"composer":            composer.upstreamURL,
+		"composer_repository": composer.repoURL,
+		"conan":               NewConanHandlerWithUpstream(nil, proxyURL, baseURL+"/conan/").upstreamURL,
+		"conda":               NewCondaHandlerWithUpstream(nil, proxyURL, baseURL+"/conda/").upstreamURL,
+		"cran":                NewCRANHandlerWithUpstream(nil, proxyURL, baseURL+"/cran/").upstreamURL,
+		"julia":               NewJuliaHandlerWithUpstream(nil, baseURL+"/julia/").upstreamURL,
+		"oci_default":         NewContainerHandlerWithRegistry(nil, proxyURL, baseURL+"/oci/").registryURL,
+		"rpm":                 NewRPMHandlerWithUpstream(nil, proxyURL, baseURL+"/rpm/").upstreamURL,
+	}
+
+	want := map[string]string{
+		"gem":                 baseURL + "/gem",
+		"go":                  baseURL + "/go",
+		"hex":                 baseURL + "/hex",
+		"hex_api":             baseURL + "/hex-api",
+		"pub":                 baseURL + "/pub",
+		"pypi":                baseURL + "/pypi",
+		"pypi_download":       baseURL + "/pypi-download",
+		"nuget":               baseURL + "/nuget",
+		"nuget_search":        baseURL + "/nuget-search",
+		"composer":            baseURL + "/composer",
+		"composer_repository": baseURL + "/composer-repository",
+		"conan":               baseURL + "/conan",
+		"conda":               baseURL + "/conda",
+		"cran":                baseURL + "/cran",
+		"julia":               baseURL + "/julia",
+		"oci_default":         baseURL + "/oci",
+		"rpm":                 baseURL + "/rpm",
+	}
+
+	for name, wantURL := range want {
+		if gotURL := got[name]; gotURL != wantURL {
+			t.Errorf("%s upstream = %q, want %q", name, gotURL, wantURL)
+		}
+	}
+}
+
+func TestConfiguredUpstreamURL(t *testing.T) {
+	if got := configuredUpstreamURL("", "https://default.example.com/"); got != "https://default.example.com" {
+		t.Errorf("empty configured URL = %q, want default", got)
+	}
+	if got := configuredUpstreamURL("https://custom.example.com/", "https://default.example.com"); got != "https://custom.example.com" {
+		t.Errorf("configured URL = %q, want trimmed custom URL", got)
+	}
+	if got := configuredUpstreamURL("https://custom.example.com///", "https://default.example.com"); got != "https://custom.example.com" {
+		t.Errorf("configured URL with trailing slashes = %q, want trimmed custom URL", got)
+	}
+}
+
+func TestHexHandlerUsesConfiguredAPIUpstream(t *testing.T) {
+	var requestedPath string
+	upstream := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		requestedPath = r.URL.Path
+		_, _ = io.WriteString(w, `{"releases":[]}`)
+	}))
+	defer upstream.Close()
+
+	h := NewHexHandlerWithUpstreams(
+		&Proxy{HTTPClient: upstream.Client()},
+		"https://proxy.example.com",
+		upstream.URL+"/hex",
+		upstream.URL+"/hex-api",
+	)
+	_, err := h.fetchFilteredVersions(httptest.NewRequest(http.MethodGet, "/", nil), "demo")
+	if err != nil {
+		t.Fatalf("fetchFilteredVersions failed: %v", err)
+	}
+	if requestedPath != "/hex-api/api/packages/demo" {
+		t.Errorf("API path = %q, want %q", requestedPath, "/hex-api/api/packages/demo")
+	}
+}
+
+func TestPyPIHandlerRewritesConfiguredDownloadUpstream(t *testing.T) {
+	h := NewPyPIHandlerWithUpstreams(
+		nil,
+		"https://proxy.example.com",
+		"https://upstream.example.com/pypi",
+		"https://upstream.example.com/pypi",
+	)
+	body := []byte(`<a href="https://upstream.example.com/pypi/packages/packages/ab/demo.whl#sha256=abc">demo</a>`)
+	want := `<a href="https://proxy.example.com/pypi/packages/packages/packages/ab/demo.whl#sha256=abc">demo</a>`
+	if got := string(h.rewriteSimpleHTML(body, nil)); got != want {
+		t.Errorf("rewritten HTML = %q, want %q", got, want)
+	}
+}
+
+func TestNuGetHandlerUsesConfiguredSearchUpstream(t *testing.T) {
+	h := NewNuGetHandlerWithUpstreams(
+		nil,
+		"https://proxy.example.com",
+		"https://upstream.example.com/nuget",
+		"https://upstream.example.com/nuget-search",
+	)
+	req := httptest.NewRequest(http.MethodGet, "/query?q=demo", nil)
+	want := "https://upstream.example.com/nuget-search/query?q=demo"
+	if got := h.buildUpstreamURL(req); got != want {
+		t.Errorf("search URL = %q, want %q", got, want)
+	}
+}

--- a/internal/server/server.go
+++ b/internal/server/server.go
@@ -53,6 +53,7 @@ import (
 	"errors"
 	"fmt"
 	"log/slog"
+	"net"
 	"net/http"
 	"net/url"
 	"strconv"
@@ -180,10 +181,24 @@ func New(cfg *config.Config, logger *slog.Logger, buildInfo BuildInfo) (*Server,
 }
 
 // Start starts the HTTP server.
-func (s *Server) Start() error {
+func (s *Server) Start(listeners ...net.Listener) error {
+	if len(listeners) > 1 {
+		return errors.New("only one listener is supported")
+	}
+	var listener net.Listener
+	if len(listeners) == 1 {
+		listener = listeners[0]
+		if listener == nil {
+			return errors.New("listener is required")
+		}
+	}
+	return s.serve(listener)
+}
+
+func (s *Server) serve(listener net.Listener) error {
 	// Use one authentication-aware transport for metadata and artifacts so
 	// configured credentials and cached OCI challenges apply consistently.
-	safeClient := safehttp.New(nil, safehttp.Options{})
+	safeClient := safehttp.New(nil, upstreamSafeHTTPOptions(s.cfg.Upstream))
 	baseTransport := safeClient.Transport
 	if s.accessLog != nil {
 		baseTransport = upstreamhttp.NewAccessLogTransport(baseTransport, s.accessLog, s.logger)
@@ -243,11 +258,21 @@ func (s *Server) Start() error {
 		s.cfg.Upstream.Cargo,
 		s.cfg.Upstream.CargoDownload,
 	)
-	gemHandler := handler.NewGemHandler(proxy, s.cfg.BaseURL)
-	goHandler := handler.NewGoHandler(proxy, s.cfg.BaseURL)
-	hexHandler := handler.NewHexHandler(proxy, s.cfg.BaseURL)
-	pubHandler := handler.NewPubHandler(proxy, s.cfg.BaseURL)
-	pypiHandler := handler.NewPyPIHandler(proxy, s.cfg.BaseURL)
+	gemHandler := handler.NewGemHandlerWithUpstream(proxy, s.cfg.BaseURL, s.cfg.Upstream.Gem)
+	goHandler := handler.NewGoHandlerWithUpstream(proxy, s.cfg.BaseURL, s.cfg.Upstream.Go)
+	hexHandler := handler.NewHexHandlerWithUpstreams(
+		proxy,
+		s.cfg.BaseURL,
+		s.cfg.Upstream.Hex,
+		s.cfg.Upstream.HexAPI,
+	)
+	pubHandler := handler.NewPubHandlerWithUpstream(proxy, s.cfg.BaseURL, s.cfg.Upstream.Pub)
+	pypiHandler := handler.NewPyPIHandlerWithUpstreams(
+		proxy,
+		s.cfg.BaseURL,
+		s.cfg.Upstream.PyPI,
+		s.cfg.Upstream.PyPIDownload,
+	)
 	mavenHandler := handler.NewMavenHandler(
 		proxy,
 		s.cfg.BaseURL,
@@ -255,16 +280,31 @@ func (s *Server) Start() error {
 		s.cfg.Upstream.GradlePluginPortal,
 	)
 	gradleHandler := handler.NewGradleBuildCacheHandler(proxy)
-	nugetHandler := handler.NewNuGetHandler(proxy, s.cfg.BaseURL)
-	composerHandler := handler.NewComposerHandler(proxy, s.cfg.BaseURL)
-	conanHandler := handler.NewConanHandler(proxy, s.cfg.BaseURL)
-	condaHandler := handler.NewCondaHandler(proxy, s.cfg.BaseURL)
-	cranHandler := handler.NewCRANHandler(proxy, s.cfg.BaseURL)
-	juliaHandler := handler.NewJuliaHandler(proxy, s.cfg.BaseURL)
-	containerHandler := handler.NewContainerHandler(proxy, s.cfg.BaseURL, s.cfg.Upstream.OCI)
+	nugetHandler := handler.NewNuGetHandlerWithUpstreams(
+		proxy,
+		s.cfg.BaseURL,
+		s.cfg.Upstream.NuGet,
+		s.cfg.Upstream.NuGetSearch,
+	)
+	composerHandler := handler.NewComposerHandlerWithUpstreams(
+		proxy,
+		s.cfg.BaseURL,
+		s.cfg.Upstream.Composer,
+		s.cfg.Upstream.ComposerRepository,
+	)
+	conanHandler := handler.NewConanHandlerWithUpstream(proxy, s.cfg.BaseURL, s.cfg.Upstream.Conan)
+	condaHandler := handler.NewCondaHandlerWithUpstream(proxy, s.cfg.BaseURL, s.cfg.Upstream.Conda)
+	cranHandler := handler.NewCRANHandlerWithUpstream(proxy, s.cfg.BaseURL, s.cfg.Upstream.CRAN)
+	juliaHandler := handler.NewJuliaHandlerWithUpstream(proxy, s.cfg.Upstream.Julia)
+	containerHandler := handler.NewContainerHandlerWithRegistry(
+		proxy,
+		s.cfg.BaseURL,
+		s.cfg.Upstream.OCIDefault,
+		s.cfg.Upstream.OCI,
+	)
 	helmHandler := handler.NewHelmHandler(proxy, s.cfg.BaseURL, s.cfg.Upstream.Helm)
 	debianHandler := handler.NewDebianHandler(proxy, s.cfg.BaseURL, s.cfg.Upstream.Debian)
-	rpmHandler := handler.NewRPMHandler(proxy, s.cfg.BaseURL)
+	rpmHandler := handler.NewRPMHandlerWithUpstream(proxy, s.cfg.BaseURL, s.cfg.Upstream.RPM)
 
 	r.Mount("/npm", http.StripPrefix("/npm", npmHandler.Routes()))
 	r.Mount("/cargo", http.StripPrefix("/cargo", cargoHandler.Routes()))
@@ -354,7 +394,17 @@ func (s *Server) Start() error {
 	go s.updateCacheStatsMetrics()
 	go s.startEvictionLoop(bgCtx)
 
+	if listener != nil {
+		return s.http.Serve(listener)
+	}
 	return s.http.ListenAndServe()
+}
+
+func upstreamSafeHTTPOptions(upstream config.UpstreamConfig) safehttp.Options {
+	return safehttp.Options{
+		AllowLoopback:     upstream.AllowLoopback,
+		AllowPrivateHosts: upstream.AllowPrivateHosts,
+	}
 }
 
 // updateCacheStatsMetrics periodically updates cache statistics in Prometheus metrics.

--- a/internal/server/server_test.go
+++ b/internal/server/server_test.go
@@ -4,14 +4,17 @@ import (
 	"context"
 	"database/sql"
 	"encoding/json"
+	"errors"
 	"fmt"
 	"html"
 	"io"
 	"log/slog"
+	"net"
 	"net/http"
 	"net/http/httptest"
 	"net/url"
 	"os"
+	"os/exec"
 	"path/filepath"
 	"regexp"
 	"strconv"
@@ -25,6 +28,7 @@ import (
 	"github.com/git-pkgs/proxy/internal/storage"
 	"github.com/git-pkgs/purl"
 	"github.com/git-pkgs/registries/fetch"
+	"github.com/git-pkgs/registries/safehttp"
 	"github.com/go-chi/chi/v5"
 )
 
@@ -138,6 +142,142 @@ func newTestServer(t *testing.T) *testServer {
 func (ts *testServer) close() {
 	_ = ts.db.Close()
 	_ = os.RemoveAll(ts.tempDir)
+}
+
+func TestUpstreamSafeHTTPOptions(t *testing.T) {
+	opts := upstreamSafeHTTPOptions(config.UpstreamConfig{
+		AllowPrivateHosts: []string{"registry.internal"},
+		AllowLoopback:     true,
+	})
+
+	if !opts.AllowLoopback {
+		t.Fatal("AllowLoopback = false, want true")
+	}
+	privateIP := net.ParseIP("10.0.0.12")
+	if err := safehttp.CheckHostIP("registry.internal", privateIP, opts); err != nil {
+		t.Fatalf("listed private upstream rejected: %v", err)
+	}
+	if err := safehttp.CheckHostIP("other.internal", privateIP, opts); err == nil {
+		t.Fatal("unlisted private upstream was allowed")
+	}
+}
+
+func TestStartUsesConfiguredLoopbackUpstreams(t *testing.T) {
+	if os.Getenv("PROXY_TEST_LOOPBACK_UPSTREAM") == "1" {
+		testStartUsesConfiguredLoopbackUpstreams(t)
+		return
+	}
+
+	cmd := exec.Command(os.Args[0], "-test.run=^TestStartUsesConfiguredLoopbackUpstreams$")
+	cmd.Env = append(os.Environ(), "PROXY_TEST_LOOPBACK_UPSTREAM=1")
+	if output, err := cmd.CombinedOutput(); err != nil {
+		t.Fatalf("configured loopback upstream test failed: %v\n%s", err, output)
+	}
+}
+
+func testStartUsesConfiguredLoopbackUpstreams(t *testing.T) {
+	upstream := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		switch r.URL.Path {
+		case "/pypi/simple/ruff/":
+			w.Header().Set("Content-Type", "application/vnd.pypi.simple.v1+json")
+			_, _ = io.WriteString(w, `{"meta":{"api-version":"1.4"},"name":"ruff","files":[]}`)
+		case "/v2/library/demo/manifests/latest":
+			w.Header().Set("Content-Type", "application/vnd.oci.image.manifest.v1+json")
+			w.Header().Set("Docker-Content-Digest", "sha256:aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa")
+			_, _ = io.WriteString(w, `{"schemaVersion":2}`)
+		default:
+			t.Errorf("unexpected upstream path: %q", r.URL.Path)
+			http.NotFound(w, r)
+		}
+	}))
+	defer upstream.Close()
+
+	listener, err := net.Listen("tcp", "127.0.0.1:0")
+	if err != nil {
+		t.Fatalf("reserving proxy address: %v", err)
+	}
+	t.Cleanup(func() { _ = listener.Close() })
+	listenAddress := listener.Addr().String()
+
+	tempDir := t.TempDir()
+	cfg := config.Default()
+	cfg.Listen = listenAddress
+	cfg.BaseURL = "http://" + listenAddress
+	cfg.Database.Path = filepath.Join(tempDir, "proxy.db")
+	cfg.Storage.URL = "file://" + filepath.Join(tempDir, "artifacts")
+	cfg.Upstream.PyPI = upstream.URL + "/pypi"
+	cfg.Upstream.PyPIDownload = upstream.URL + "/pypi"
+	cfg.Upstream.OCIDefault = upstream.URL
+	cfg.Upstream.AllowLoopback = true
+	if err := cfg.Validate(); err != nil {
+		t.Fatalf("validating config: %v", err)
+	}
+
+	logger := slog.New(slog.NewTextHandler(io.Discard, nil))
+	proxyServer, err := New(cfg, logger, BuildInfo{Version: "test", Commit: "test"})
+	if err != nil {
+		t.Fatalf("creating server: %v", err)
+	}
+	startErr := make(chan error, 1)
+	go func() {
+		startErr <- proxyServer.Start(listener)
+	}()
+
+	defer func() {
+		ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
+		defer cancel()
+		if err := proxyServer.Shutdown(ctx); err != nil {
+			t.Errorf("shutting down server: %v", err)
+		}
+		if err := <-startErr; !errors.Is(err, http.ErrServerClosed) {
+			t.Errorf("Start() error = %v, want %v", err, http.ErrServerClosed)
+		}
+	}()
+
+	client := &http.Client{Timeout: 250 * time.Millisecond}
+	deadline := time.Now().Add(5 * time.Second)
+	for {
+		req, err := http.NewRequest(http.MethodGet, cfg.BaseURL+"/pypi/simple/ruff/", nil)
+		if err != nil {
+			t.Fatalf("creating request: %v", err)
+		}
+		req.Header.Set("Accept", "application/vnd.pypi.simple.v1+json")
+		resp, requestErr := client.Do(req)
+		if requestErr == nil {
+			body, readErr := io.ReadAll(resp.Body)
+			_ = resp.Body.Close()
+			if readErr != nil {
+				t.Fatalf("reading response: %v", readErr)
+			}
+			if resp.StatusCode != http.StatusOK {
+				t.Fatalf("status = %d, want %d; body: %s", resp.StatusCode, http.StatusOK, body)
+			}
+			if !strings.Contains(string(body), `"name":"ruff"`) {
+				t.Fatalf("response body = %s, want PyPI metadata", body)
+			}
+			break
+		}
+		if time.Now().After(deadline) {
+			t.Fatalf("proxy did not start: %v", requestErr)
+		}
+		time.Sleep(10 * time.Millisecond)
+	}
+
+	resp, err := client.Get(cfg.BaseURL + "/v2/library/demo/manifests/latest")
+	if err != nil {
+		t.Fatalf("OCI request failed: %v", err)
+	}
+	body, readErr := io.ReadAll(resp.Body)
+	_ = resp.Body.Close()
+	if readErr != nil {
+		t.Fatalf("reading OCI response: %v", readErr)
+	}
+	if resp.StatusCode != http.StatusOK {
+		t.Fatalf("OCI status = %d, want %d; body: %s", resp.StatusCode, http.StatusOK, body)
+	}
+	if !strings.Contains(string(body), `"schemaVersion":2`) {
+		t.Fatalf("OCI response body = %s, want manifest", body)
+	}
 }
 
 // seedTestPackage creates a package, version, and artifact in the database for testing


### PR DESCRIPTION
Makes every built-in package upstream configurable through the `upstream` YAML or JSON block and matching `PROXY_UPSTREAM_*` environment variables.

Existing defaults and constructor signatures remain unchanged. Protocols with separate services expose distinct settings, and PyPI and NuGet URL rewriting follows configured upstreams so one proxy can use another as its upstream.

The `upstream` block remains the configuration layer for built-in routes. A future route model such as #93 can use these resolved values for its default routes while keeping custom route topology separate.

The configuration example and reference list every key, environment variable, and default.
