### PR TITLE
Add Swift package registry support

### DIFF
--- a/README.md
+++ b/README.md
@@ -39,6 +39,7 @@ Resolution order: package override, then ecosystem override, then global default
 | Conda | Python/R | Yes | ✓ |
 | CRAN | R | | ✓ |
 | Julia | Julia | | ✓ |
+| Swift | Swift | | ✓ |
 | Container | Docker/OCI | | ✓ |
 | Debian | Debian/Ubuntu | | ✓ |
 | RPM | RHEL/Fedora | | ✓ |
@@ -47,7 +48,6 @@ Resolution order: package override, then ecosystem override, then global default
 | Chef | Chef | | ✗ |
 | Generic | Any | | ✗ |
 | Helm | Kubernetes | | ✗ |
-| Swift | Swift | | ✗ |
 | Vagrant | Vagrant | | ✗ |
 
 Cooldown requires publish timestamps in metadata. Registries without a "Yes" in the cooldown column either don't expose timestamps or haven't been wired up yet.
@@ -340,6 +340,25 @@ ENV["JULIA_PKG_SERVER"] = "http://localhost:8080/julia"
 using Pkg; Pkg.update()
 ```
 
+### Swift
+
+Configure the proxy as the default registry for the current Swift package:
+
+```bash
+swift package-registry set --allow-insecure-http http://localhost:8080/swift
+```
+
+Registry dependencies use their scoped package identifier in `Package.swift`:
+
+```swift
+dependencies: [
+    .package(id: "apple.swift-argument-parser", from: "1.2.0")
+]
+```
+
+The proxy supports dependency resolution and source downloads. Publishing with
+`swift package-registry publish` is not supported.
+
 ### Docker / Container Registry
 
 Configure Docker to use the proxy as a registry mirror in `/etc/docker/daemon.json`:
@@ -513,6 +532,7 @@ PROXY_DATABASE_URL=postgres://user:pass@localhost/proxy?sslmode=disable
 PROXY_LOG_LEVEL=info
 PROXY_LOG_FORMAT=text
 PROXY_ACCESS_LOG_PATH=/var/log/proxy/access.jsonl
+PROXY_UPSTREAM_SWIFT=https://tuist.dev/api/registry/swift
 ```
 
 ### Configuration File
@@ -540,6 +560,7 @@ access_log:
 upstream:
   npm: "https://registry.npmjs.org"
   cargo: "https://index.crates.io"
+  swift: "https://tuist.dev/api/registry/swift"
 
 # Optional: version cooldown (see above)
 cooldown:
@@ -767,6 +788,7 @@ Recently cached:
 | `GET /conda/*` | Conda/Anaconda protocol |
 | `GET /cran/*` | CRAN (R) protocol |
 | `GET /julia/*` | Julia Pkg server protocol |
+| `GET /swift/*` | Swift Package Registry v1 protocol |
 | `GET /helm/{repository}/*` | HTTP Helm chart repository protocol |
 | `GET /v2/*` | OCI/Docker registry protocol |
 | `GET /apk/{repository}/*` | Alpine APK repository protocol |

--- a/cmd/proxy/main.go
+++ b/cmd/proxy/main.go
@@ -227,6 +227,7 @@ func runServe() {
 		fmt.Fprintf(os.Stderr, "  PROXY_UPSTREAM_CONDA                Conda channel upstream URL\n")
 		fmt.Fprintf(os.Stderr, "  PROXY_UPSTREAM_CRAN                 CRAN mirror upstream URL\n")
 		fmt.Fprintf(os.Stderr, "  PROXY_UPSTREAM_JULIA                Julia package server upstream URL\n")
+		fmt.Fprintf(os.Stderr, "  PROXY_UPSTREAM_SWIFT                Swift Package Registry upstream URL\n")
 		fmt.Fprintf(os.Stderr, "  PROXY_UPSTREAM_OCI_DEFAULT          Default OCI registry upstream URL\n")
 		fmt.Fprintf(os.Stderr, "  PROXY_UPSTREAM_DEBIAN               Debian repository upstream URL\n")
 		fmt.Fprintf(os.Stderr, "  PROXY_UPSTREAM_RPM                  RPM repository upstream URL\n")

--- a/config.example.yaml
+++ b/config.example.yaml
@@ -165,6 +165,9 @@ upstream:
   # Julia package server URL
   julia: "https://pkg.julialang.org"
 
+  # Swift Package Registry URL (used by /swift endpoint)
+  swift: "https://tuist.dev/api/registry/swift"
+
   # Default OCI registry URL for unprefixed /v2 requests
   oci_default: "https://registry-1.docker.io"
 

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -269,6 +269,10 @@ HTTP protocol handlers for each registry type.
 - `handleIndex()` - Proxy sparse index
 - `handleDownload()` - Serve cached crate
 
+**SwiftHandler:**
+- Proxies the Swift Package Registry v1 read endpoints
+- Rewrites release URLs and caches source archives
+
 ### `internal/server`
 
 HTTP server setup, web UI, and API handlers.

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -161,6 +161,7 @@ Each upstream used by a built-in package route can be set in YAML or JSON under 
 | `upstream.conda` | `PROXY_UPSTREAM_CONDA` | `https://conda.anaconda.org` |
 | `upstream.cran` | `PROXY_UPSTREAM_CRAN` | `https://cloud.r-project.org` |
 | `upstream.julia` | `PROXY_UPSTREAM_JULIA` | `https://pkg.julialang.org` |
+| `upstream.swift` | `PROXY_UPSTREAM_SWIFT` | `https://tuist.dev/api/registry/swift` |
 | `upstream.oci_default` | `PROXY_UPSTREAM_OCI_DEFAULT` | `https://registry-1.docker.io` |
 | `upstream.debian` | `PROXY_UPSTREAM_DEBIAN` | `http://deb.debian.org/debian` |
 | `upstream.rpm` | `PROXY_UPSTREAM_RPM` | `https://dl.fedoraproject.org/pub/fedora/linux` |

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -404,6 +404,10 @@ type UpstreamConfig struct {
 	// Default: https://registry-1.docker.io
 	OCIDefault string `json:"oci_default" yaml:"oci_default"`
 
+	// Swift is the upstream Swift Package Registry URL.
+	// Default: https://tuist.dev/api/registry/swift
+	Swift string `json:"swift" yaml:"swift"`
+
 	// Debian is the upstream APT repository base URL.
 	// Example: http://archive.ubuntu.com/ubuntu would get Ubuntu.
 	// Default: http://deb.debian.org/debian
@@ -599,6 +603,7 @@ func Default() *Config {
 			Conda:              "https://conda.anaconda.org",
 			CRAN:               "https://cloud.r-project.org",
 			Julia:              "https://pkg.julialang.org",
+			Swift:              "https://tuist.dev/api/registry/swift",
 			OCIDefault:         "https://registry-1.docker.io",
 			Debian:             "http://deb.debian.org/debian",
 			RPM:                "https://dl.fedoraproject.org/pub/fedora/linux",
@@ -688,6 +693,7 @@ func setEnvStringSlice(dst *[]string, key string) {
 //   - PROXY_LOG_LEVEL
 //   - PROXY_LOG_FORMAT
 //   - PROXY_ACCESS_LOG_PATH
+//   - PROXY_UPSTREAM_SWIFT
 //   - PROXY_HEALTH_STORAGE_PROBE_INTERVAL
 func (c *Config) LoadFromEnv() {
 	setEnvString(&c.Listen, "PROXY_LISTEN")
@@ -728,6 +734,7 @@ func (c *Config) LoadFromEnv() {
 	setEnvString(&c.Upstream.Conda, "PROXY_UPSTREAM_CONDA")
 	setEnvString(&c.Upstream.CRAN, "PROXY_UPSTREAM_CRAN")
 	setEnvString(&c.Upstream.Julia, "PROXY_UPSTREAM_JULIA")
+	setEnvString(&c.Upstream.Swift, "PROXY_UPSTREAM_SWIFT")
 	setEnvString(&c.Upstream.OCIDefault, "PROXY_UPSTREAM_OCI_DEFAULT")
 	setEnvString(&c.Upstream.Debian, "PROXY_UPSTREAM_DEBIAN")
 	setEnvString(&c.Upstream.RPM, "PROXY_UPSTREAM_RPM")

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -75,6 +75,9 @@ import (
 	"gopkg.in/yaml.v3"
 )
 
+// DefaultSwiftUpstream is the Swift Package Registry used when none is configured.
+const DefaultSwiftUpstream = "https://tuist.dev/api/registry/swift"
+
 // Config holds all configuration for the proxy server.
 type Config struct {
 	// Listen is the address to listen on (e.g., ":8080", "127.0.0.1:8080").
@@ -603,7 +606,7 @@ func Default() *Config {
 			Conda:              "https://conda.anaconda.org",
 			CRAN:               "https://cloud.r-project.org",
 			Julia:              "https://pkg.julialang.org",
-			Swift:              "https://tuist.dev/api/registry/swift",
+			Swift:              DefaultSwiftUpstream,
 			OCIDefault:         "https://registry-1.docker.io",
 			Debian:             "http://deb.debian.org/debian",
 			RPM:                "https://dl.fedoraproject.org/pub/fedora/linux",

--- a/internal/config/config_test.go
+++ b/internal/config/config_test.go
@@ -36,6 +36,7 @@ func upstreamConfigValues(upstream UpstreamConfig) map[string]string {
 		"conda":                upstream.Conda,
 		"cran":                 upstream.CRAN,
 		"julia":                upstream.Julia,
+		"swift":                upstream.Swift,
 		"oci_default":          upstream.OCIDefault,
 		"debian":               upstream.Debian,
 		"rpm":                  upstream.RPM,
@@ -64,6 +65,7 @@ func defaultUpstreamValues() map[string]string {
 		"conda":                "https://conda.anaconda.org",
 		"cran":                 "https://cloud.r-project.org",
 		"julia":                "https://pkg.julialang.org",
+		"swift":                "https://tuist.dev/api/registry/swift",
 		"oci_default":          "https://registry-1.docker.io",
 		"debian":               "http://deb.debian.org/debian",
 		"rpm":                  "https://dl.fedoraproject.org/pub/fedora/linux",
@@ -92,6 +94,7 @@ func upstreamEnvironmentVariables() map[string]string {
 		"conda":                "PROXY_UPSTREAM_CONDA",
 		"cran":                 "PROXY_UPSTREAM_CRAN",
 		"julia":                "PROXY_UPSTREAM_JULIA",
+		"swift":                "PROXY_UPSTREAM_SWIFT",
 		"oci_default":          "PROXY_UPSTREAM_OCI_DEFAULT",
 		"debian":               "PROXY_UPSTREAM_DEBIAN",
 		"rpm":                  "PROXY_UPSTREAM_RPM",
@@ -370,6 +373,7 @@ upstream:
   conda: "https://upstream.example.com/conda"
   cran: "https://upstream.example.com/cran"
   julia: "https://upstream.example.com/julia"
+  swift: "https://upstream.example.com/swift"
   oci_default: "https://upstream.example.com/oci_default"
   debian: "https://upstream.example.com/debian"
   rpm: "https://upstream.example.com/rpm"

--- a/internal/enrichment/enrichment.go
+++ b/internal/enrichment/enrichment.go
@@ -69,6 +69,9 @@ type VulnInfo struct {
 // EnrichPackage fetches metadata for a package from registry APIs.
 func (s *Service) EnrichPackage(ctx context.Context, ecosystem, name string) (*PackageInfo, error) {
 	purlStr := packageurl.MakeString(ecosystem, name, "")
+	if purlStr == "" {
+		return nil, nil
+	}
 
 	pkg, err := registries.FetchPackageFromPURL(ctx, purlStr, s.regClient)
 	if err != nil {
@@ -104,6 +107,9 @@ func (s *Service) EnrichPackage(ctx context.Context, ecosystem, name string) (*P
 // EnrichVersion fetches metadata for a specific package version.
 func (s *Service) EnrichVersion(ctx context.Context, ecosystem, name, version string) (*VersionInfo, error) {
 	purlStr := packageurl.MakeString(ecosystem, name, version)
+	if purlStr == "" {
+		return nil, nil
+	}
 
 	ver, err := registries.FetchVersionFromPURL(ctx, purlStr, s.regClient)
 	if err != nil {
@@ -135,9 +141,14 @@ func (s *Service) EnrichVersion(ctx context.Context, ecosystem, name, version st
 
 // BulkEnrichPackages fetches metadata for multiple packages in parallel.
 func (s *Service) BulkEnrichPackages(ctx context.Context, packages []struct{ Ecosystem, Name string }) map[string]*PackageInfo {
-	purls := make([]string, len(packages))
-	for i, pkg := range packages {
-		purls[i] = packageurl.MakeString(pkg.Ecosystem, pkg.Name, "")
+	purls := make([]string, 0, len(packages))
+	for _, pkg := range packages {
+		if purlStr := packageurl.MakeString(pkg.Ecosystem, pkg.Name, ""); purlStr != "" {
+			purls = append(purls, purlStr)
+		}
+	}
+	if len(purls) == 0 {
+		return map[string]*PackageInfo{}
 	}
 
 	pkgData := registries.BulkFetchPackages(ctx, purls, s.regClient)
@@ -148,7 +159,10 @@ func (s *Service) BulkEnrichPackages(ctx context.Context, packages []struct{ Eco
 			continue
 		}
 
-		p, _ := purl.Parse(purlStr)
+		p, err := purl.Parse(purlStr)
+		if err != nil {
+			continue
+		}
 		info := &PackageInfo{
 			Ecosystem:     p.Type,
 			Name:          pkg.Name,
@@ -176,6 +190,9 @@ func (s *Service) BulkEnrichPackages(ctx context.Context, packages []struct{ Eco
 // CheckVulnerabilities queries for vulnerabilities affecting a package version.
 func (s *Service) CheckVulnerabilities(ctx context.Context, ecosystem, name, version string) ([]VulnInfo, error) {
 	p := packageurl.Make(ecosystem, name, version)
+	if p == nil {
+		return nil, nil
+	}
 
 	vulnList, err := s.vulnSource.Query(ctx, p)
 	if err != nil {
@@ -213,6 +230,9 @@ func (s *Service) IsOutdated(currentVersion, latestVersion string) bool {
 // GetLatestVersion fetches the latest version for a package.
 func (s *Service) GetLatestVersion(ctx context.Context, ecosystem, name string) (string, error) {
 	purlStr := packageurl.MakeString(ecosystem, name, "")
+	if purlStr == "" {
+		return "", nil
+	}
 
 	latest, err := registries.FetchLatestVersionFromPURL(ctx, purlStr, s.regClient)
 	if err != nil {

--- a/internal/enrichment/enrichment.go
+++ b/internal/enrichment/enrichment.go
@@ -9,6 +9,7 @@ import (
 	"sync"
 	"time"
 
+	"github.com/git-pkgs/proxy/internal/packageurl"
 	"github.com/git-pkgs/purl"
 	"github.com/git-pkgs/registries"
 	_ "github.com/git-pkgs/registries/all" // Import all registry implementations
@@ -67,7 +68,7 @@ type VulnInfo struct {
 
 // EnrichPackage fetches metadata for a package from registry APIs.
 func (s *Service) EnrichPackage(ctx context.Context, ecosystem, name string) (*PackageInfo, error) {
-	purlStr := purl.MakePURLString(ecosystem, name, "")
+	purlStr := packageurl.MakeString(ecosystem, name, "")
 
 	pkg, err := registries.FetchPackageFromPURL(ctx, purlStr, s.regClient)
 	if err != nil {
@@ -102,7 +103,7 @@ func (s *Service) EnrichPackage(ctx context.Context, ecosystem, name string) (*P
 
 // EnrichVersion fetches metadata for a specific package version.
 func (s *Service) EnrichVersion(ctx context.Context, ecosystem, name, version string) (*VersionInfo, error) {
-	purlStr := purl.MakePURLString(ecosystem, name, version)
+	purlStr := packageurl.MakeString(ecosystem, name, version)
 
 	ver, err := registries.FetchVersionFromPURL(ctx, purlStr, s.regClient)
 	if err != nil {
@@ -136,7 +137,7 @@ func (s *Service) EnrichVersion(ctx context.Context, ecosystem, name, version st
 func (s *Service) BulkEnrichPackages(ctx context.Context, packages []struct{ Ecosystem, Name string }) map[string]*PackageInfo {
 	purls := make([]string, len(packages))
 	for i, pkg := range packages {
-		purls[i] = purl.MakePURLString(pkg.Ecosystem, pkg.Name, "")
+		purls[i] = packageurl.MakeString(pkg.Ecosystem, pkg.Name, "")
 	}
 
 	pkgData := registries.BulkFetchPackages(ctx, purls, s.regClient)
@@ -174,7 +175,7 @@ func (s *Service) BulkEnrichPackages(ctx context.Context, packages []struct{ Eco
 
 // CheckVulnerabilities queries for vulnerabilities affecting a package version.
 func (s *Service) CheckVulnerabilities(ctx context.Context, ecosystem, name, version string) ([]VulnInfo, error) {
-	p := purl.MakePURL(ecosystem, name, version)
+	p := packageurl.Make(ecosystem, name, version)
 
 	vulnList, err := s.vulnSource.Query(ctx, p)
 	if err != nil {
@@ -211,7 +212,7 @@ func (s *Service) IsOutdated(currentVersion, latestVersion string) bool {
 
 // GetLatestVersion fetches the latest version for a package.
 func (s *Service) GetLatestVersion(ctx context.Context, ecosystem, name string) (string, error) {
-	purlStr := purl.MakePURLString(ecosystem, name, "")
+	purlStr := packageurl.MakeString(ecosystem, name, "")
 
 	latest, err := registries.FetchLatestVersionFromPURL(ctx, purlStr, s.regClient)
 	if err != nil {

--- a/internal/enrichment/enrichment_test.go
+++ b/internal/enrichment/enrichment_test.go
@@ -5,35 +5,7 @@ import (
 	"log/slog"
 	"os"
 	"testing"
-
-	"github.com/git-pkgs/purl"
-	"github.com/git-pkgs/vulns"
 )
-
-type recordingVulnerabilitySource struct {
-	purls []*purl.PURL
-}
-
-func (s *recordingVulnerabilitySource) Name() string {
-	return "recording"
-}
-
-func (s *recordingVulnerabilitySource) Query(context.Context, *purl.PURL) ([]vulns.Vulnerability, error) {
-	return nil, nil
-}
-
-func (s *recordingVulnerabilitySource) QueryBatch(_ context.Context, purls []*purl.PURL) ([][]vulns.Vulnerability, error) {
-	s.purls = purls
-	results := make([][]vulns.Vulnerability, len(purls))
-	for i := range results {
-		results[i] = []vulns.Vulnerability{{ID: "TEST-1"}}
-	}
-	return results, nil
-}
-
-func (s *recordingVulnerabilitySource) Get(context.Context, string) (*vulns.Vulnerability, error) {
-	return nil, nil
-}
 
 func TestNew(t *testing.T) {
 	logger := slog.New(slog.NewTextHandler(os.Stdout, nil))
@@ -79,38 +51,6 @@ func TestSwiftRegistryIdentitySkipsPURLDependentLookups(t *testing.T) {
 	packages := []struct{ Ecosystem, Name string }{{Ecosystem: "swift", Name: "apple/example"}}
 	if got := svc.BulkEnrichPackages(ctx, packages); len(got) != 0 {
 		t.Errorf("BulkEnrichPackages() = %#v, want empty result", got)
-	}
-
-	versions := []struct{ Ecosystem, Name, Version string }{
-		{Ecosystem: "swift", Name: "apple/example", Version: "1.2.3"},
-	}
-	got, err := svc.BulkCheckVulnerabilities(ctx, versions)
-	if err != nil || len(got) != 0 {
-		t.Errorf("BulkCheckVulnerabilities() = %#v, %v; want empty result, nil", got, err)
-	}
-}
-
-func TestBulkCheckVulnerabilitiesFiltersUnsupportedPackageIdentities(t *testing.T) {
-	source := &recordingVulnerabilitySource{}
-	svc := New(slog.New(slog.NewTextHandler(os.Stdout, nil)))
-	svc.vulnSource = source
-	packages := []struct{ Ecosystem, Name, Version string }{
-		{Ecosystem: "swift", Name: "apple/example", Version: "1.2.3"},
-		{Ecosystem: "npm", Name: "lodash", Version: "4.17.21"},
-	}
-
-	got, err := svc.BulkCheckVulnerabilities(context.Background(), packages)
-	if err != nil {
-		t.Fatalf("BulkCheckVulnerabilities() error = %v", err)
-	}
-	if len(source.purls) != 1 || source.purls[0].String() != "pkg:npm/lodash@4.17.21" {
-		t.Fatalf("queried PURLs = %#v, want only lodash", source.purls)
-	}
-	if len(got["pkg:npm/lodash@4.17.21"]) != 1 {
-		t.Errorf("result = %#v, want lodash vulnerability", got)
-	}
-	if _, exists := got[""]; exists {
-		t.Error("result contains an empty PURL key")
 	}
 }
 

--- a/internal/enrichment/enrichment_test.go
+++ b/internal/enrichment/enrichment_test.go
@@ -1,10 +1,39 @@
 package enrichment
 
 import (
+	"context"
 	"log/slog"
 	"os"
 	"testing"
+
+	"github.com/git-pkgs/purl"
+	"github.com/git-pkgs/vulns"
 )
+
+type recordingVulnerabilitySource struct {
+	purls []*purl.PURL
+}
+
+func (s *recordingVulnerabilitySource) Name() string {
+	return "recording"
+}
+
+func (s *recordingVulnerabilitySource) Query(context.Context, *purl.PURL) ([]vulns.Vulnerability, error) {
+	return nil, nil
+}
+
+func (s *recordingVulnerabilitySource) QueryBatch(_ context.Context, purls []*purl.PURL) ([][]vulns.Vulnerability, error) {
+	s.purls = purls
+	results := make([][]vulns.Vulnerability, len(purls))
+	for i := range results {
+		results[i] = []vulns.Vulnerability{{ID: "TEST-1"}}
+	}
+	return results, nil
+}
+
+func (s *recordingVulnerabilitySource) Get(context.Context, string) (*vulns.Vulnerability, error) {
+	return nil, nil
+}
 
 func TestNew(t *testing.T) {
 	logger := slog.New(slog.NewTextHandler(os.Stdout, nil))
@@ -20,6 +49,68 @@ func TestNew(t *testing.T) {
 
 	if svc.vulnSource == nil {
 		t.Error("vulnSource is nil")
+	}
+}
+
+func TestSwiftRegistryIdentitySkipsPURLDependentLookups(t *testing.T) {
+	svc := New(slog.New(slog.NewTextHandler(os.Stdout, nil)))
+	ctx := context.Background()
+
+	packageInfo, err := svc.EnrichPackage(ctx, "swift", "apple/example")
+	if err != nil || packageInfo != nil {
+		t.Errorf("EnrichPackage() = %#v, %v; want nil, nil", packageInfo, err)
+	}
+
+	versionInfo, err := svc.EnrichVersion(ctx, "swift", "apple/example", "1.2.3")
+	if err != nil || versionInfo != nil {
+		t.Errorf("EnrichVersion() = %#v, %v; want nil, nil", versionInfo, err)
+	}
+
+	vulnerabilities, err := svc.CheckVulnerabilities(ctx, "swift", "apple/example", "1.2.3")
+	if err != nil || vulnerabilities != nil {
+		t.Errorf("CheckVulnerabilities() = %#v, %v; want nil, nil", vulnerabilities, err)
+	}
+
+	latest, err := svc.GetLatestVersion(ctx, "swift", "apple/example")
+	if err != nil || latest != "" {
+		t.Errorf("GetLatestVersion() = %q, %v; want empty string, nil", latest, err)
+	}
+
+	packages := []struct{ Ecosystem, Name string }{{Ecosystem: "swift", Name: "apple/example"}}
+	if got := svc.BulkEnrichPackages(ctx, packages); len(got) != 0 {
+		t.Errorf("BulkEnrichPackages() = %#v, want empty result", got)
+	}
+
+	versions := []struct{ Ecosystem, Name, Version string }{
+		{Ecosystem: "swift", Name: "apple/example", Version: "1.2.3"},
+	}
+	got, err := svc.BulkCheckVulnerabilities(ctx, versions)
+	if err != nil || len(got) != 0 {
+		t.Errorf("BulkCheckVulnerabilities() = %#v, %v; want empty result, nil", got, err)
+	}
+}
+
+func TestBulkCheckVulnerabilitiesFiltersUnsupportedPackageIdentities(t *testing.T) {
+	source := &recordingVulnerabilitySource{}
+	svc := New(slog.New(slog.NewTextHandler(os.Stdout, nil)))
+	svc.vulnSource = source
+	packages := []struct{ Ecosystem, Name, Version string }{
+		{Ecosystem: "swift", Name: "apple/example", Version: "1.2.3"},
+		{Ecosystem: "npm", Name: "lodash", Version: "4.17.21"},
+	}
+
+	got, err := svc.BulkCheckVulnerabilities(context.Background(), packages)
+	if err != nil {
+		t.Fatalf("BulkCheckVulnerabilities() error = %v", err)
+	}
+	if len(source.purls) != 1 || source.purls[0].String() != "pkg:npm/lodash@4.17.21" {
+		t.Fatalf("queried PURLs = %#v, want only lodash", source.purls)
+	}
+	if len(got["pkg:npm/lodash@4.17.21"]) != 1 {
+		t.Errorf("result = %#v, want lodash vulnerability", got)
+	}
+	if _, exists := got[""]; exists {
+		t.Error("result contains an empty PURL key")
 	}
 }
 

--- a/internal/handler/handler.go
+++ b/internal/handler/handler.go
@@ -903,44 +903,52 @@ func (p *Proxy) GetOrFetchArtifactFromURLWithHeaders(ctx context.Context, ecosys
 	return p.getOrFetchArtifactFromURL(ctx, ecosystem, name, version, filename, downloadURL, headers, "")
 }
 
-func (p *Proxy) getOrFetchArtifactFromURL(ctx context.Context, ecosystem, name, version, filename, downloadURL string, headers http.Header, expectedHash string) (*CacheResult, error) {
+func (p *Proxy) getOrFetchArtifactFromURL(ctx context.Context, ecosystem, name, version, filename, downloadURL string, headers http.Header, upstreamHash string) (*CacheResult, error) {
 	pkgPURL, versionPURL, err := packagePURLStrings(ecosystem, name, version)
 	if err != nil {
 		return nil, err
 	}
 	return p.getOrFetchArtifactFromURLWithCachePURLs(
-		ctx, ecosystem, name, version, filename, pkgPURL, versionPURL, downloadURL, headers, expectedHash,
+		ctx, ecosystem, name, version, filename, pkgPURL, versionPURL, downloadURL, headers, upstreamHash,
 	)
 }
 
-func (p *Proxy) getOrFetchArtifactFromURLWithCachePURLs(ctx context.Context, ecosystem, name, version, filename, pkgPURL, versionPURL, downloadURL string, headers http.Header, expectedHash string) (*CacheResult, error) {
-	if cached, err := p.getCachedArtifactWithExpectedHash(ctx, pkgPURL, versionPURL, filename, expectedHash); err != nil {
+func (p *Proxy) getOrFetchArtifactFromURLWithCachePURLs(ctx context.Context, ecosystem, name, version, filename, pkgPURL, versionPURL, downloadURL string, headers http.Header, upstreamHash string) (*CacheResult, error) {
+	if cached, err := p.getCachedArtifactWithUpstreamHash(ctx, pkgPURL, versionPURL, filename, upstreamHash); err != nil {
 		return nil, err
 	} else if cached != nil {
 		return cached, nil
 	}
 	metrics.RecordCacheMiss(ecosystem)
 
-	return p.fetchAndCacheFromURL(ctx, ecosystem, name, version, filename, pkgPURL, versionPURL, downloadURL, headers, expectedHash)
+	return p.fetchAndCacheFromURL(ctx, ecosystem, name, version, filename, pkgPURL, versionPURL, downloadURL, headers, upstreamHash)
 }
 
-func (p *Proxy) getCachedArtifactWithExpectedHash(ctx context.Context, pkgPURL, versionPURL, filename, expectedHash string) (*CacheResult, error) {
+// getCachedArtifactWithUpstreamHash returns a cached artifact whose recorded
+// content hash matches the checksum the upstream currently declares for it.
+// This detects an upstream re-publishing under the same version, which the
+// stream integrity check in checkCache cannot: that check only verifies the
+// stored blob against the hash recorded when it was cached. On mismatch the
+// stale entry is discarded and nil is returned so the caller re-fetches.
+func (p *Proxy) getCachedArtifactWithUpstreamHash(ctx context.Context, pkgPURL, versionPURL, filename, upstreamHash string) (*CacheResult, error) {
 	cached, err := p.checkCache(ctx, pkgPURL, versionPURL, filename)
 	if err != nil || cached == nil {
 		return cached, err
 	}
-	if artifactHashMatches(cached.Hash, expectedHash) {
+	if artifactHashMatches(cached.Hash, upstreamHash) {
 		return cached, nil
 	}
 
 	if cached.Reader != nil {
 		_ = cached.Reader.Close()
 	}
+	p.Logger.Warn("cached artifact hash disagrees with upstream metadata, discarding",
+		"purl", versionPURL, "filename", filename, "cached", cached.Hash, "upstream", upstreamHash)
 	p.discardCachedArtifact(ctx, versionPURL, filename, cached.storagePath)
-	return nil, artifactHashMismatchError(expectedHash, cached.Hash)
+	return nil, nil
 }
 
-func (p *Proxy) fetchAndCacheFromURL(ctx context.Context, ecosystem, name, version, filename, pkgPURL, versionPURL, downloadURL string, headers http.Header, expectedHash string) (*CacheResult, error) {
+func (p *Proxy) fetchAndCacheFromURL(ctx context.Context, ecosystem, name, version, filename, pkgPURL, versionPURL, downloadURL string, headers http.Header, upstreamHash string) (*CacheResult, error) {
 	p.Logger.Info("fetching from upstream",
 		"ecosystem", ecosystem, "name", name, "version", version, "url", downloadURL)
 
@@ -964,11 +972,11 @@ func (p *Proxy) fetchAndCacheFromURL(ctx context.Context, ecosystem, name, versi
 		metrics.RecordStorageError("write")
 		return nil, fmt.Errorf("storing artifact: %w", err)
 	}
-	if !artifactHashMatches(hash, expectedHash) {
+	if !artifactHashMatches(hash, upstreamHash) {
 		if err := p.Storage.Delete(ctx, storagePath); err != nil {
 			p.Logger.Warn("failed to discard artifact with mismatched checksum", "path", storagePath, "error", err)
 		}
-		return nil, artifactHashMismatchError(expectedHash, hash)
+		return nil, fmt.Errorf("artifact checksum mismatch: upstream declared %s, got %s", upstreamHash, hash)
 	}
 
 	if err := p.updateCacheDB(ecosystem, name, filename, pkgPURL, versionPURL, downloadURL, storagePath, hash, size, artifact.ContentType); err != nil {
@@ -994,10 +1002,6 @@ func (p *Proxy) fetchAndCacheFromURL(ctx context.Context, ecosystem, name, versi
 
 func artifactHashMatches(got, expected string) bool {
 	return expected == "" || strings.EqualFold(got, expected)
-}
-
-func artifactHashMismatchError(expected, got string) error {
-	return fmt.Errorf("artifact checksum mismatch: expected %s, got %s", expected, got)
 }
 
 func (p *Proxy) discardCachedArtifact(ctx context.Context, versionPURL, filename, storagePath string) {

--- a/internal/handler/handler.go
+++ b/internal/handler/handler.go
@@ -157,6 +157,7 @@ type CacheResult struct {
 	ContentType string
 	Hash        string
 	Cached      bool
+	storagePath string
 }
 
 // GetOrFetchArtifact retrieves an artifact from cache or fetches from upstream.
@@ -222,6 +223,7 @@ func (p *Proxy) checkCache(ctx context.Context, pkgPURL, versionPURL, filename s
 		ContentType: artifact.ContentType.String,
 		Hash:        artifact.ContentHash.String,
 		Cached:      true,
+		storagePath: artifact.StoragePath,
 	}
 
 	if p.DirectServe {
@@ -881,19 +883,41 @@ func (p *Proxy) GetOrFetchArtifactFromURL(ctx context.Context, ecosystem, name, 
 // GetOrFetchArtifactFromURLWithHeaders retrieves an artifact from cache or fetches from a URL
 // with additional request-specific HTTP headers.
 func (p *Proxy) GetOrFetchArtifactFromURLWithHeaders(ctx context.Context, ecosystem, name, version, filename, downloadURL string, headers http.Header) (*CacheResult, error) {
-	if cached, err := p.GetCachedArtifact(ctx, ecosystem, name, version, filename); err != nil {
+	return p.getOrFetchArtifactFromURL(ctx, ecosystem, name, version, filename, downloadURL, headers, "")
+}
+
+func (p *Proxy) getOrFetchArtifactFromURL(ctx context.Context, ecosystem, name, version, filename, downloadURL string, headers http.Header, expectedHash string) (*CacheResult, error) {
+	pkgPURL := packageurl.MakeString(ecosystem, name, "")
+	versionPURL := packageurl.MakeString(ecosystem, name, version)
+
+	if cached, err := p.getCachedArtifactWithExpectedHash(ctx, ecosystem, name, version, filename, expectedHash); err != nil {
 		return nil, err
 	} else if cached != nil {
 		return cached, nil
 	}
 	metrics.RecordCacheMiss(ecosystem)
 
-	pkgPURL := packageurl.MakeString(ecosystem, name, "")
-	versionPURL := packageurl.MakeString(ecosystem, name, version)
-	return p.fetchAndCacheFromURL(ctx, ecosystem, name, version, filename, pkgPURL, versionPURL, downloadURL, headers)
+	return p.fetchAndCacheFromURL(ctx, ecosystem, name, version, filename, pkgPURL, versionPURL, downloadURL, headers, expectedHash)
 }
 
-func (p *Proxy) fetchAndCacheFromURL(ctx context.Context, ecosystem, name, version, filename, pkgPURL, versionPURL, downloadURL string, headers http.Header) (*CacheResult, error) {
+func (p *Proxy) getCachedArtifactWithExpectedHash(ctx context.Context, ecosystem, name, version, filename, expectedHash string) (*CacheResult, error) {
+	cached, err := p.GetCachedArtifact(ctx, ecosystem, name, version, filename)
+	if err != nil || cached == nil {
+		return cached, err
+	}
+	if artifactHashMatches(cached.Hash, expectedHash) {
+		return cached, nil
+	}
+
+	if cached.Reader != nil {
+		_ = cached.Reader.Close()
+	}
+	versionPURL := packageurl.MakeString(ecosystem, name, version)
+	p.discardCachedArtifact(ctx, versionPURL, filename, cached.storagePath)
+	return nil, artifactHashMismatchError(expectedHash, cached.Hash)
+}
+
+func (p *Proxy) fetchAndCacheFromURL(ctx context.Context, ecosystem, name, version, filename, pkgPURL, versionPURL, downloadURL string, headers http.Header, expectedHash string) (*CacheResult, error) {
 	p.Logger.Info("fetching from upstream",
 		"ecosystem", ecosystem, "name", name, "version", version, "url", downloadURL)
 
@@ -917,6 +941,12 @@ func (p *Proxy) fetchAndCacheFromURL(ctx context.Context, ecosystem, name, versi
 		metrics.RecordStorageError("write")
 		return nil, fmt.Errorf("storing artifact: %w", err)
 	}
+	if !artifactHashMatches(hash, expectedHash) {
+		if err := p.Storage.Delete(ctx, storagePath); err != nil {
+			p.Logger.Warn("failed to discard artifact with mismatched checksum", "path", storagePath, "error", err)
+		}
+		return nil, artifactHashMismatchError(expectedHash, hash)
+	}
 
 	if err := p.updateCacheDB(ecosystem, name, filename, pkgPURL, versionPURL, downloadURL, storagePath, hash, size, artifact.ContentType); err != nil {
 		p.Logger.Warn("failed to update cache database", "error", err)
@@ -937,4 +967,23 @@ func (p *Proxy) fetchAndCacheFromURL(ctx context.Context, ecosystem, name, versi
 		Hash:        hash,
 		Cached:      false,
 	}, nil
+}
+
+func artifactHashMatches(got, expected string) bool {
+	return expected == "" || strings.EqualFold(got, expected)
+}
+
+func artifactHashMismatchError(expected, got string) error {
+	return fmt.Errorf("artifact checksum mismatch: expected %s, got %s", expected, got)
+}
+
+func (p *Proxy) discardCachedArtifact(ctx context.Context, versionPURL, filename, storagePath string) {
+	if storagePath != "" {
+		if err := p.Storage.Delete(ctx, storagePath); err != nil {
+			p.Logger.Warn("failed to discard cached artifact", "path", storagePath, "error", err)
+		}
+	}
+	if err := p.DB.ClearArtifactCache(versionPURL, filename); err != nil {
+		p.Logger.Warn("failed to clear artifact cache record", "purl", versionPURL, "filename", filename, "error", err)
+	}
 }

--- a/internal/handler/handler.go
+++ b/internal/handler/handler.go
@@ -21,7 +21,6 @@ import (
 	"github.com/git-pkgs/proxy/internal/metrics"
 	"github.com/git-pkgs/proxy/internal/packageurl"
 	"github.com/git-pkgs/proxy/internal/storage"
-	"github.com/git-pkgs/purl"
 	"github.com/git-pkgs/registries/fetch"
 )
 
@@ -75,7 +74,18 @@ func canonicalPackagePURL(ecosystem, name string) string {
 // canonicalVersionPURL returns a versioned PURL in canonical form, matching
 // the keys the artifact cache writes to the versions table.
 func canonicalVersionPURL(ecosystem, name, version string) string {
-	return purl.MakePURLString(ecosystem, name, version)
+	return packageurl.MakeString(ecosystem, name, version)
+}
+
+var errUnsupportedPackageIdentity = errors.New("package identity cannot be represented as a PURL")
+
+func packagePURLStrings(ecosystem, name, version string) (string, string, error) {
+	packagePURL := packageurl.MakeString(ecosystem, name, "")
+	versionPURL := packageurl.MakeString(ecosystem, name, version)
+	if packagePURL == "" || versionPURL == "" {
+		return "", "", fmt.Errorf("%w: %s %q", errUnsupportedPackageIdentity, ecosystem, name)
+	}
+	return packagePURL, versionPURL, nil
 }
 
 const contentTypeJSON = "application/json"
@@ -162,23 +172,27 @@ type CacheResult struct {
 
 // GetOrFetchArtifact retrieves an artifact from cache or fetches from upstream.
 func (p *Proxy) GetOrFetchArtifact(ctx context.Context, ecosystem, name, version, filename string) (*CacheResult, error) {
-	if cached, err := p.GetCachedArtifact(ctx, ecosystem, name, version, filename); err != nil {
+	pkgPURL, versionPURL, err := packagePURLStrings(ecosystem, name, version)
+	if err != nil {
+		return nil, err
+	}
+	if cached, err := p.checkCache(ctx, pkgPURL, versionPURL, filename); err != nil {
 		return nil, err
 	} else if cached != nil {
 		return cached, nil
 	}
 	metrics.RecordCacheMiss(ecosystem)
 
-	pkgPURL := packageurl.MakeString(ecosystem, name, "")
-	versionPURL := packageurl.MakeString(ecosystem, name, version)
 	return p.fetchAndCache(ctx, ecosystem, name, version, filename, pkgPURL, versionPURL)
 }
 
 // GetCachedArtifact retrieves an artifact from cache without contacting an upstream.
 // It returns nil when no usable cache entry exists.
 func (p *Proxy) GetCachedArtifact(ctx context.Context, ecosystem, name, version, filename string) (*CacheResult, error) {
-	pkgPURL := packageurl.MakeString(ecosystem, name, "")
-	versionPURL := packageurl.MakeString(ecosystem, name, version)
+	pkgPURL, versionPURL, err := packagePURLStrings(ecosystem, name, version)
+	if err != nil {
+		return nil, err
+	}
 	return p.checkCache(ctx, pkgPURL, versionPURL, filename)
 }
 
@@ -188,8 +202,10 @@ func (p *Proxy) ClearCachedArtifact(ctx context.Context, ecosystem, name, versio
 	if p.DB == nil || p.Storage == nil {
 		return nil
 	}
-	pkgPURL := purl.MakePURLString(ecosystem, name, "")
-	versionPURL := purl.MakePURLString(ecosystem, name, version)
+	pkgPURL, versionPURL, err := packagePURLStrings(ecosystem, name, version)
+	if err != nil {
+		return err
+	}
 	cached, err := p.DB.GetCachedArtifact(pkgPURL, versionPURL, filename)
 	if err != nil {
 		return fmt.Errorf("looking up cached artifact: %w", err)
@@ -887,10 +903,17 @@ func (p *Proxy) GetOrFetchArtifactFromURLWithHeaders(ctx context.Context, ecosys
 }
 
 func (p *Proxy) getOrFetchArtifactFromURL(ctx context.Context, ecosystem, name, version, filename, downloadURL string, headers http.Header, expectedHash string) (*CacheResult, error) {
-	pkgPURL := packageurl.MakeString(ecosystem, name, "")
-	versionPURL := packageurl.MakeString(ecosystem, name, version)
+	pkgPURL, versionPURL, err := packagePURLStrings(ecosystem, name, version)
+	if err != nil {
+		return nil, err
+	}
+	return p.getOrFetchArtifactFromURLWithCachePURLs(
+		ctx, ecosystem, name, version, filename, pkgPURL, versionPURL, downloadURL, headers, expectedHash,
+	)
+}
 
-	if cached, err := p.getCachedArtifactWithExpectedHash(ctx, ecosystem, name, version, filename, expectedHash); err != nil {
+func (p *Proxy) getOrFetchArtifactFromURLWithCachePURLs(ctx context.Context, ecosystem, name, version, filename, pkgPURL, versionPURL, downloadURL string, headers http.Header, expectedHash string) (*CacheResult, error) {
+	if cached, err := p.getCachedArtifactWithExpectedHash(ctx, pkgPURL, versionPURL, filename, expectedHash); err != nil {
 		return nil, err
 	} else if cached != nil {
 		return cached, nil
@@ -900,8 +923,8 @@ func (p *Proxy) getOrFetchArtifactFromURL(ctx context.Context, ecosystem, name, 
 	return p.fetchAndCacheFromURL(ctx, ecosystem, name, version, filename, pkgPURL, versionPURL, downloadURL, headers, expectedHash)
 }
 
-func (p *Proxy) getCachedArtifactWithExpectedHash(ctx context.Context, ecosystem, name, version, filename, expectedHash string) (*CacheResult, error) {
-	cached, err := p.GetCachedArtifact(ctx, ecosystem, name, version, filename)
+func (p *Proxy) getCachedArtifactWithExpectedHash(ctx context.Context, pkgPURL, versionPURL, filename, expectedHash string) (*CacheResult, error) {
+	cached, err := p.checkCache(ctx, pkgPURL, versionPURL, filename)
 	if err != nil || cached == nil {
 		return cached, err
 	}
@@ -912,7 +935,6 @@ func (p *Proxy) getCachedArtifactWithExpectedHash(ctx context.Context, ecosystem
 	if cached.Reader != nil {
 		_ = cached.Reader.Close()
 	}
-	versionPURL := packageurl.MakeString(ecosystem, name, version)
 	p.discardCachedArtifact(ctx, versionPURL, filename, cached.storagePath)
 	return nil, artifactHashMismatchError(expectedHash, cached.Hash)
 }

--- a/internal/handler/handler.go
+++ b/internal/handler/handler.go
@@ -19,6 +19,7 @@ import (
 	"github.com/git-pkgs/cooldown"
 	"github.com/git-pkgs/proxy/internal/database"
 	"github.com/git-pkgs/proxy/internal/metrics"
+	"github.com/git-pkgs/proxy/internal/packageurl"
 	"github.com/git-pkgs/proxy/internal/storage"
 	"github.com/git-pkgs/purl"
 	"github.com/git-pkgs/registries/fetch"
@@ -68,7 +69,7 @@ var artifactCopyBufferPool = sync.Pool{ //nolint:gochecknoglobals // shared acro
 // canonicalPackagePURL returns a versionless PURL in canonical form so cooldown
 // lookups match keys produced by config.CooldownConfig.NormalizedPackages.
 func canonicalPackagePURL(ecosystem, name string) string {
-	return purl.MakePURLString(ecosystem, name, "")
+	return packageurl.MakeString(ecosystem, name, "")
 }
 
 // canonicalVersionPURL returns a versioned PURL in canonical form, matching
@@ -167,16 +168,16 @@ func (p *Proxy) GetOrFetchArtifact(ctx context.Context, ecosystem, name, version
 	}
 	metrics.RecordCacheMiss(ecosystem)
 
-	pkgPURL := purl.MakePURLString(ecosystem, name, "")
-	versionPURL := purl.MakePURLString(ecosystem, name, version)
+	pkgPURL := packageurl.MakeString(ecosystem, name, "")
+	versionPURL := packageurl.MakeString(ecosystem, name, version)
 	return p.fetchAndCache(ctx, ecosystem, name, version, filename, pkgPURL, versionPURL)
 }
 
 // GetCachedArtifact retrieves an artifact from cache without contacting an upstream.
 // It returns nil when no usable cache entry exists.
 func (p *Proxy) GetCachedArtifact(ctx context.Context, ecosystem, name, version, filename string) (*CacheResult, error) {
-	pkgPURL := purl.MakePURLString(ecosystem, name, "")
-	versionPURL := purl.MakePURLString(ecosystem, name, version)
+	pkgPURL := packageurl.MakeString(ecosystem, name, "")
+	versionPURL := packageurl.MakeString(ecosystem, name, version)
 	return p.checkCache(ctx, pkgPURL, versionPURL, filename)
 }
 
@@ -887,8 +888,8 @@ func (p *Proxy) GetOrFetchArtifactFromURLWithHeaders(ctx context.Context, ecosys
 	}
 	metrics.RecordCacheMiss(ecosystem)
 
-	pkgPURL := purl.MakePURLString(ecosystem, name, "")
-	versionPURL := purl.MakePURLString(ecosystem, name, version)
+	pkgPURL := packageurl.MakeString(ecosystem, name, "")
+	versionPURL := packageurl.MakeString(ecosystem, name, version)
 	return p.fetchAndCacheFromURL(ctx, ecosystem, name, version, filename, pkgPURL, versionPURL, downloadURL, headers)
 }
 

--- a/internal/handler/handler.go
+++ b/internal/handler/handler.go
@@ -21,6 +21,7 @@ import (
 	"github.com/git-pkgs/proxy/internal/metrics"
 	"github.com/git-pkgs/proxy/internal/packageurl"
 	"github.com/git-pkgs/proxy/internal/storage"
+	"github.com/git-pkgs/purl"
 	"github.com/git-pkgs/registries/fetch"
 )
 

--- a/internal/handler/handler_test.go
+++ b/internal/handler/handler_test.go
@@ -107,15 +107,17 @@ type mockFetcher struct {
 	fetchErrByURL map[string]error
 	fetchCalled   bool
 	fetchedURL    string
+	fetchedHeader http.Header
 }
 
 func (f *mockFetcher) Fetch(ctx context.Context, url string) (*fetch.Artifact, error) {
 	return f.FetchWithHeaders(ctx, url, nil)
 }
 
-func (f *mockFetcher) FetchWithHeaders(_ context.Context, url string, _ http.Header) (*fetch.Artifact, error) {
+func (f *mockFetcher) FetchWithHeaders(_ context.Context, url string, headers http.Header) (*fetch.Artifact, error) {
 	f.fetchCalled = true
 	f.fetchedURL = url
+	f.fetchedHeader = headers.Clone()
 	if f.fetchErrByURL != nil {
 		if err, ok := f.fetchErrByURL[url]; ok {
 			return nil, err

--- a/internal/handler/handler_test.go
+++ b/internal/handler/handler_test.go
@@ -420,6 +420,28 @@ func TestGetOrFetchArtifactFromURL_CacheMiss_StorageMissing(t *testing.T) {
 	}
 }
 
+func TestArtifactCacheRejectsUnsupportedPackageIdentity(t *testing.T) {
+	proxy, _, _, fetcher := setupTestProxy(t)
+
+	_, err := proxy.GetCachedArtifact(
+		context.Background(), "swift", "apple/example", "1.2.3", "example-1.2.3.zip",
+	)
+	if !errors.Is(err, errUnsupportedPackageIdentity) {
+		t.Fatalf("GetCachedArtifact() error = %v, want unsupported package identity", err)
+	}
+
+	_, err = proxy.GetOrFetchArtifactFromURL(
+		context.Background(), "swift", "apple/example", "1.2.3", "example-1.2.3.zip",
+		"https://registry.example/apple/example/1.2.3.zip",
+	)
+	if !errors.Is(err, errUnsupportedPackageIdentity) {
+		t.Fatalf("GetOrFetchArtifactFromURL() error = %v, want unsupported package identity", err)
+	}
+	if fetcher.fetchCalled {
+		t.Error("unsupported package identity reached the artifact fetcher")
+	}
+}
+
 func TestGetOrFetchArtifact_DirectServe_Redirect(t *testing.T) {
 	proxy, db, store, fetcher := setupTestProxy(t)
 	seedPackage(t, db, store, "npm", "lodash", "4.17.21", "lodash-4.17.21.tgz", "cached content")

--- a/internal/handler/swift.go
+++ b/internal/handler/swift.go
@@ -161,7 +161,7 @@ func (h *SwiftHandler) handleSourceArchive(w http.ResponseWriter, r *http.Reques
 	packageName := scope + "/" + name
 	filename := fmt.Sprintf("%s-%s.zip", name, version)
 	upstreamURL := h.buildUpstreamURL(scope, name, version+".zip", "", r.URL.RawQuery)
-	packagePURL, versionPURL := packageurl.MakeCacheStrings("swift", packageName, version, h.upstreamURL)
+	packagePURL, versionPURL := packageurl.MakeCacheStrings("swift", packageName, version)
 	if packagePURL == "" || versionPURL == "" {
 		h.writeArtifactError(w, fmt.Errorf("%w: swift %q", errUnsupportedPackageIdentity, packageName))
 		return
@@ -173,7 +173,7 @@ func (h *SwiftHandler) handleSourceArchive(w http.ResponseWriter, r *http.Reques
 	}
 
 	if r.Method == http.MethodHead {
-		h.handleSourceArchiveHead(w, r, packageName, version, filename, packagePURL, versionPURL, upstreamURL, archiveInfo)
+		h.handleSourceArchiveHead(w, r, name, version, filename, packagePURL, versionPURL, upstreamURL, archiveInfo)
 		return
 	}
 
@@ -196,10 +196,10 @@ func (h *SwiftHandler) handleSourceArchive(w http.ResponseWriter, r *http.Reques
 func (h *SwiftHandler) handleSourceArchiveHead(
 	w http.ResponseWriter,
 	r *http.Request,
-	packageName, version, filename, packagePURL, versionPURL, upstreamURL string,
+	name, version, filename, packagePURL, versionPURL, upstreamURL string,
 	archiveInfo swiftArchiveInfo,
 ) {
-	result, err := h.proxy.getCachedArtifactWithExpectedHash(
+	result, err := h.proxy.getCachedArtifactWithUpstreamHash(
 		r.Context(), packagePURL, versionPURL, filename, archiveInfo.checksum,
 	)
 	if err != nil {
@@ -208,7 +208,6 @@ func (h *SwiftHandler) handleSourceArchiveHead(
 	}
 	if result != nil {
 		result.ContentType = "application/zip"
-		_, name, _ := strings.Cut(packageName, "/")
 		setSwiftArchiveHeaders(w.Header(), name, version, result.Hash, archiveInfo)
 		serveArtifact(w, r.Method, result)
 		return
@@ -219,7 +218,6 @@ func (h *SwiftHandler) handleSourceArchiveHead(
 		h.writeArtifactError(w, err)
 		return
 	}
-	_, name, _ := strings.Cut(packageName, "/")
 	setSwiftArchiveHeaders(w.Header(), name, version, "", archiveInfo)
 	w.Header().Set("Content-Type", "application/zip")
 	if size >= 0 {

--- a/internal/handler/swift.go
+++ b/internal/handler/swift.go
@@ -155,7 +155,8 @@ func (h *SwiftHandler) handleSourceArchive(w http.ResponseWriter, r *http.Reques
 	upstreamURL := h.buildUpstreamURL(scope, name, version+".zip", "", r.URL.RawQuery)
 	archiveInfo, infoErr := h.fetchArchiveInfo(r.Context(), scope, name, version)
 	if infoErr != nil {
-		h.proxy.Logger.Debug("failed to fetch Swift archive metadata", "error", infoErr)
+		h.writeArtifactError(w, fmt.Errorf("fetching release metadata: %w", infoErr))
+		return
 	}
 
 	if r.Method == http.MethodHead {
@@ -165,8 +166,8 @@ func (h *SwiftHandler) handleSourceArchive(w http.ResponseWriter, r *http.Reques
 
 	headers := make(http.Header)
 	headers.Set("Accept", requestAccept(r, swiftAcceptArchive))
-	result, err := h.proxy.GetOrFetchArtifactFromURLWithHeaders(
-		r.Context(), "swift", packageName, version, filename, upstreamURL, headers,
+	result, err := h.proxy.getOrFetchArtifactFromURL(
+		r.Context(), "swift", packageName, version, filename, upstreamURL, headers, archiveInfo.checksum,
 	)
 	if err != nil {
 		h.writeArtifactError(w, err)
@@ -184,7 +185,9 @@ func (h *SwiftHandler) handleSourceArchiveHead(
 	packageName, version, filename, upstreamURL string,
 	archiveInfo swiftArchiveInfo,
 ) {
-	result, err := h.proxy.GetCachedArtifact(r.Context(), "swift", packageName, version, filename)
+	result, err := h.proxy.getCachedArtifactWithExpectedHash(
+		r.Context(), "swift", packageName, version, filename, archiveInfo.checksum,
+	)
 	if err != nil {
 		h.writeArtifactError(w, err)
 		return
@@ -197,7 +200,7 @@ func (h *SwiftHandler) handleSourceArchiveHead(
 		return
 	}
 
-	size, _, err := h.proxy.Fetcher.Head(r.Context(), upstreamURL)
+	size, err := h.headSourceArchive(r.Context(), upstreamURL, requestAccept(r, swiftAcceptArchive))
 	if err != nil {
 		h.writeArtifactError(w, err)
 		return
@@ -209,6 +212,36 @@ func (h *SwiftHandler) handleSourceArchiveHead(
 		w.Header().Set("Content-Length", strconv.FormatInt(size, 10))
 	}
 	w.WriteHeader(http.StatusOK)
+}
+
+func (h *SwiftHandler) headSourceArchive(ctx context.Context, upstreamURL, accept string) (int64, error) {
+	req, err := http.NewRequestWithContext(ctx, http.MethodHead, upstreamURL, nil)
+	if err != nil {
+		return 0, fmt.Errorf("creating upstream archive request: %w", err)
+	}
+	req.Header.Set("Accept", accept)
+	h.proxy.applyUpstreamAuth(req)
+
+	resp, err := h.proxy.HTTPClient.Do(req)
+	if err != nil {
+		return 0, fmt.Errorf("requesting upstream archive: %w", err)
+	}
+	defer func() { _ = resp.Body.Close() }()
+
+	if resp.StatusCode == http.StatusNotFound {
+		return 0, ErrUpstreamNotFound
+	}
+	if resp.StatusCode != http.StatusOK {
+		return 0, fmt.Errorf("upstream archive returned %d", resp.StatusCode)
+	}
+
+	size := int64(-1)
+	if contentLength := resp.Header.Get("Content-Length"); contentLength != "" {
+		if parsed, parseErr := strconv.ParseInt(contentLength, 10, 64); parseErr == nil {
+			size = parsed
+		}
+	}
+	return size, nil
 }
 
 type swiftReleaseMetadata struct {
@@ -246,15 +279,30 @@ func (h *SwiftHandler) fetchArchiveInfo(ctx context.Context, scope, name, versio
 		if resource.Name != "source-archive" || resource.Type != "application/zip" {
 			continue
 		}
-		info := swiftArchiveInfo{checksum: resource.Checksum}
+		checksum, err := normalizeSwiftChecksum(resource.Checksum)
+		if err != nil {
+			return swiftArchiveInfo{}, err
+		}
+		info := swiftArchiveInfo{checksum: checksum}
 		if resource.Signing != nil {
+			if resource.Signing.Signature == "" || resource.Signing.Format == "" {
+				return swiftArchiveInfo{}, errors.New("source archive signing metadata is incomplete")
+			}
 			info.signature = resource.Signing.Signature
 			info.signatureFormat = resource.Signing.Format
 		}
 		return info, nil
 	}
 
-	return swiftArchiveInfo{}, nil
+	return swiftArchiveInfo{}, errors.New("source archive is missing from release metadata")
+}
+
+func normalizeSwiftChecksum(checksum string) (string, error) {
+	digest, err := hex.DecodeString(checksum)
+	if err != nil || len(digest) != sha256.Size {
+		return "", errors.New("source archive checksum is not a SHA-256 digest")
+	}
+	return hex.EncodeToString(digest), nil
 }
 
 func setSwiftArchiveHeaders(header http.Header, name, version, contentHash string, info swiftArchiveInfo) {

--- a/internal/handler/swift.go
+++ b/internal/handler/swift.go
@@ -1,0 +1,534 @@
+package handler
+
+import (
+	"context"
+	"crypto/sha256"
+	"encoding/base64"
+	"encoding/hex"
+	"encoding/json"
+	"errors"
+	"fmt"
+	"io"
+	"net/http"
+	"net/url"
+	"strconv"
+	"strings"
+)
+
+const (
+	swiftDefaultUpstream = "https://tuist.dev/api/registry/swift"
+	swiftAcceptJSON      = "application/vnd.swift.registry.v1+json"
+	swiftAcceptManifest  = "application/vnd.swift.registry.v1+swift"
+	swiftAcceptArchive   = "application/vnd.swift.registry.v1+zip"
+	swiftContentVersion  = "1"
+	swiftMaxScopeLength  = 39
+	swiftMaxNameLength   = 100
+)
+
+// SwiftHandler handles the read-only Swift Package Registry v1 protocol.
+type SwiftHandler struct {
+	proxy       *Proxy
+	upstreamURL string
+	proxyURL    string
+}
+
+// NewSwiftHandler creates a Swift Package Registry protocol handler.
+func NewSwiftHandler(proxy *Proxy, proxyURL, upstreamURL string) *SwiftHandler {
+	if strings.TrimSpace(upstreamURL) == "" {
+		upstreamURL = swiftDefaultUpstream
+	}
+
+	return &SwiftHandler{
+		proxy:       proxy,
+		upstreamURL: strings.TrimSuffix(upstreamURL, "/"),
+		proxyURL:    strings.TrimSuffix(proxyURL, "/"),
+	}
+}
+
+// Routes returns the HTTP handler for Swift registry requests.
+func (h *SwiftHandler) Routes() http.Handler {
+	mux := http.NewServeMux()
+	mux.HandleFunc("GET /identifiers", h.handleIdentifiers)
+	mux.HandleFunc("GET /{scope}/{name}/{version}/Package.swift", h.handleManifest)
+	mux.HandleFunc("GET /{scope}/{name}/{version}", h.handleRelease)
+	mux.HandleFunc("PUT /{scope}/{name}/{version}", h.handlePublishingUnsupported)
+	mux.HandleFunc("GET /{scope}/{name}", h.handlePackageReleases)
+	return mux
+}
+
+func (h *SwiftHandler) handlePackageReleases(w http.ResponseWriter, r *http.Request) {
+	scope := r.PathValue("scope")
+	name := strings.TrimSuffix(r.PathValue("name"), ".json")
+	if !validSwiftScope(scope) || !validSwiftPackageName(name) {
+		writeSwiftProblem(w, http.StatusBadRequest, "invalid package identifier")
+		return
+	}
+
+	upstreamURL := h.buildUpstreamURL(scope, name, "", "", r.URL.RawQuery)
+	cacheKey := swiftMetadataCacheKey(scope, name, "releases", r.URL.RawQuery)
+	body, contentType, err := h.proxy.FetchOrCacheMetadata(
+		r.Context(), "swift", cacheKey, upstreamURL, requestAccept(r, swiftAcceptJSON),
+	)
+	if err != nil {
+		h.writeMetadataError(w, err)
+		return
+	}
+
+	rewritten, err := h.rewriteReleaseURLs(scope, name, body)
+	if err != nil {
+		h.proxy.Logger.Warn("failed to rewrite Swift release URLs", "error", err)
+		rewritten = body
+	}
+	writeSwiftMetadata(w, r, rewritten, contentType)
+}
+
+func (h *SwiftHandler) handleRelease(w http.ResponseWriter, r *http.Request) {
+	scope := r.PathValue("scope")
+	name := r.PathValue("name")
+	version := r.PathValue("version")
+	if strings.HasSuffix(version, ".zip") {
+		h.handleSourceArchive(w, r, scope, name, strings.TrimSuffix(version, ".zip"))
+		return
+	}
+
+	version = strings.TrimSuffix(version, ".json")
+	if !validSwiftPackageReference(scope, name, version) {
+		writeSwiftProblem(w, http.StatusBadRequest, "invalid package release")
+		return
+	}
+
+	upstreamURL := h.buildUpstreamURL(scope, name, version, "", r.URL.RawQuery)
+	body, contentType, err := h.proxy.FetchOrCacheMetadata(
+		r.Context(), "swift", swiftReleaseCacheKey(scope, name, version), upstreamURL, requestAccept(r, swiftAcceptJSON),
+	)
+	if err != nil {
+		h.writeMetadataError(w, err)
+		return
+	}
+	writeSwiftMetadata(w, r, body, contentType)
+}
+
+func (h *SwiftHandler) handleManifest(w http.ResponseWriter, r *http.Request) {
+	scope := r.PathValue("scope")
+	name := r.PathValue("name")
+	version := r.PathValue("version")
+	if !validSwiftPackageReference(scope, name, version) {
+		writeSwiftProblem(w, http.StatusBadRequest, "invalid package release")
+		return
+	}
+
+	upstreamURL := h.buildUpstreamURL(scope, name, version, "Package.swift", r.URL.RawQuery)
+	h.proxySwiftResource(w, r, upstreamURL, swiftAcceptManifest)
+}
+
+func (h *SwiftHandler) handleIdentifiers(w http.ResponseWriter, r *http.Request) {
+	if r.URL.Query().Get("url") == "" {
+		writeSwiftProblem(w, http.StatusBadRequest, "url query parameter is required")
+		return
+	}
+
+	upstreamURL := h.upstreamURL + "/identifiers?" + r.URL.RawQuery
+	cacheKey := swiftMetadataCacheKey("identifiers", r.URL.RawQuery)
+	body, contentType, err := h.proxy.FetchOrCacheMetadata(
+		r.Context(), "swift", cacheKey, upstreamURL, requestAccept(r, swiftAcceptJSON),
+	)
+	if err != nil {
+		h.writeMetadataError(w, err)
+		return
+	}
+	writeSwiftMetadata(w, r, body, contentType)
+}
+
+func (h *SwiftHandler) handlePublishingUnsupported(w http.ResponseWriter, _ *http.Request) {
+	w.Header().Set("Allow", "GET, HEAD")
+	writeSwiftProblem(w, http.StatusMethodNotAllowed, "publishing isn't supported")
+}
+
+func (h *SwiftHandler) handleSourceArchive(w http.ResponseWriter, r *http.Request, scope, name, version string) {
+	if !validSwiftPackageReference(scope, name, version) {
+		writeSwiftProblem(w, http.StatusBadRequest, "invalid package release")
+		return
+	}
+
+	packageName := scope + "/" + name
+	filename := fmt.Sprintf("%s-%s.zip", name, version)
+	upstreamURL := h.buildUpstreamURL(scope, name, version+".zip", "", r.URL.RawQuery)
+	archiveInfo, infoErr := h.fetchArchiveInfo(r.Context(), scope, name, version)
+	if infoErr != nil {
+		h.proxy.Logger.Debug("failed to fetch Swift archive metadata", "error", infoErr)
+	}
+
+	if r.Method == http.MethodHead {
+		h.handleSourceArchiveHead(w, r, packageName, version, filename, upstreamURL, archiveInfo)
+		return
+	}
+
+	headers := make(http.Header)
+	headers.Set("Accept", requestAccept(r, swiftAcceptArchive))
+	result, err := h.proxy.GetOrFetchArtifactFromURLWithHeaders(
+		r.Context(), "swift", packageName, version, filename, upstreamURL, headers,
+	)
+	if err != nil {
+		h.writeArtifactError(w, err)
+		return
+	}
+
+	result.ContentType = "application/zip"
+	setSwiftArchiveHeaders(w.Header(), name, version, result.Hash, archiveInfo)
+	serveArtifact(w, r.Method, result)
+}
+
+func (h *SwiftHandler) handleSourceArchiveHead(
+	w http.ResponseWriter,
+	r *http.Request,
+	packageName, version, filename, upstreamURL string,
+	archiveInfo swiftArchiveInfo,
+) {
+	result, err := h.proxy.GetCachedArtifact(r.Context(), "swift", packageName, version, filename)
+	if err != nil {
+		h.writeArtifactError(w, err)
+		return
+	}
+	if result != nil {
+		result.ContentType = "application/zip"
+		_, name, _ := strings.Cut(packageName, "/")
+		setSwiftArchiveHeaders(w.Header(), name, version, result.Hash, archiveInfo)
+		serveArtifact(w, r.Method, result)
+		return
+	}
+
+	size, _, err := h.proxy.Fetcher.Head(r.Context(), upstreamURL)
+	if err != nil {
+		h.writeArtifactError(w, err)
+		return
+	}
+	_, name, _ := strings.Cut(packageName, "/")
+	setSwiftArchiveHeaders(w.Header(), name, version, "", archiveInfo)
+	w.Header().Set("Content-Type", "application/zip")
+	if size >= 0 {
+		w.Header().Set("Content-Length", strconv.FormatInt(size, 10))
+	}
+	w.WriteHeader(http.StatusOK)
+}
+
+type swiftReleaseMetadata struct {
+	Resources []struct {
+		Name     string `json:"name"`
+		Type     string `json:"type"`
+		Checksum string `json:"checksum"`
+		Signing  *struct {
+			Signature string `json:"signatureBase64Encoded"`
+			Format    string `json:"signatureFormat"`
+		} `json:"signing"`
+	} `json:"resources"`
+}
+
+type swiftArchiveInfo struct {
+	checksum        string
+	signature       string
+	signatureFormat string
+}
+
+func (h *SwiftHandler) fetchArchiveInfo(ctx context.Context, scope, name, version string) (swiftArchiveInfo, error) {
+	upstreamURL := h.buildUpstreamURL(scope, name, version, "", "")
+	body, _, err := h.proxy.FetchOrCacheMetadata(
+		ctx, "swift", swiftReleaseCacheKey(scope, name, version), upstreamURL, swiftAcceptJSON,
+	)
+	if err != nil {
+		return swiftArchiveInfo{}, err
+	}
+
+	var metadata swiftReleaseMetadata
+	if err := json.Unmarshal(body, &metadata); err != nil {
+		return swiftArchiveInfo{}, fmt.Errorf("parsing release metadata: %w", err)
+	}
+	for _, resource := range metadata.Resources {
+		if resource.Name != "source-archive" || resource.Type != "application/zip" {
+			continue
+		}
+		info := swiftArchiveInfo{checksum: resource.Checksum}
+		if resource.Signing != nil {
+			info.signature = resource.Signing.Signature
+			info.signatureFormat = resource.Signing.Format
+		}
+		return info, nil
+	}
+
+	return swiftArchiveInfo{}, nil
+}
+
+func setSwiftArchiveHeaders(header http.Header, name, version, contentHash string, info swiftArchiveInfo) {
+	header.Set("Cache-Control", "public, immutable")
+	header.Set("Content-Disposition", fmt.Sprintf(`attachment; filename="%s-%s.zip"`, name, version))
+	header.Set("Content-Version", swiftContentVersion)
+
+	checksum := info.checksum
+	if checksum == "" {
+		checksum = contentHash
+	}
+	if digest := swiftDigestHeader(checksum); digest != "" {
+		header.Set("Digest", digest)
+	}
+	if info.signature != "" && info.signatureFormat != "" {
+		header.Set("X-Swift-Package-Signature", info.signature)
+		header.Set("X-Swift-Package-Signature-Format", info.signatureFormat)
+	}
+}
+
+func swiftDigestHeader(checksum string) string {
+	digest, err := hex.DecodeString(checksum)
+	if err != nil || len(digest) != sha256.Size {
+		return ""
+	}
+	return "sha-256=" + base64.StdEncoding.EncodeToString(digest)
+}
+
+func (h *SwiftHandler) proxySwiftResource(w http.ResponseWriter, r *http.Request, upstreamURL, defaultAccept string) {
+	req, err := http.NewRequestWithContext(r.Context(), r.Method, upstreamURL, nil)
+	if err != nil {
+		writeSwiftProblem(w, http.StatusInternalServerError, "failed to create upstream request")
+		return
+	}
+	req.Header.Set("Accept", requestAccept(r, defaultAccept))
+	for _, name := range []string{"If-Modified-Since", "If-None-Match"} {
+		if value := r.Header.Get(name); value != "" {
+			req.Header.Set(name, value)
+		}
+	}
+	h.proxy.applyUpstreamAuth(req)
+
+	resp, err := h.proxy.HTTPClient.Do(req)
+	if err != nil {
+		writeSwiftProblem(w, http.StatusBadGateway, "upstream request failed")
+		return
+	}
+	defer func() { _ = resp.Body.Close() }()
+
+	copySwiftResponseHeaders(w.Header(), resp.Header)
+	if location := resp.Header.Get("Location"); location != "" {
+		w.Header().Set("Location", h.rewriteRegistryURL(location, upstreamURL))
+	}
+	for _, link := range resp.Header.Values("Link") {
+		w.Header().Add("Link", h.rewriteLinkHeader(link, upstreamURL))
+	}
+	if w.Header().Get("Content-Version") == "" {
+		w.Header().Set("Content-Version", swiftContentVersion)
+	}
+
+	w.WriteHeader(resp.StatusCode)
+	if r.Method != http.MethodHead {
+		_, _ = io.Copy(w, resp.Body)
+	}
+}
+
+func copySwiftResponseHeaders(dst, src http.Header) {
+	for _, name := range []string{
+		"Cache-Control", "Content-Disposition", "Content-Language", "Content-Length",
+		"Content-Type", "Content-Version", "Digest", "ETag", "Last-Modified",
+		"Retry-After", "Vary", "Warning", "X-Swift-Package-Signature",
+		"X-Swift-Package-Signature-Format",
+	} {
+		for _, value := range src.Values(name) {
+			dst.Add(name, value)
+		}
+	}
+}
+
+func (h *SwiftHandler) rewriteLinkHeader(value, upstreamRequestURL string) string {
+	var result strings.Builder
+	for len(value) > 0 {
+		start := strings.IndexByte(value, '<')
+		if start < 0 {
+			result.WriteString(value)
+			break
+		}
+		endOffset := strings.IndexByte(value[start+1:], '>')
+		if endOffset < 0 {
+			result.WriteString(value)
+			break
+		}
+		end := start + 1 + endOffset
+		result.WriteString(value[:start+1])
+		result.WriteString(h.rewriteRegistryURL(value[start+1:end], upstreamRequestURL))
+		result.WriteByte('>')
+		value = value[end+1:]
+	}
+	return result.String()
+}
+
+func (h *SwiftHandler) rewriteRegistryURL(rawURL, upstreamRequestURL string) string {
+	base, err := url.Parse(h.upstreamURL)
+	if err != nil {
+		return rawURL
+	}
+	requestURL, err := url.Parse(upstreamRequestURL)
+	if err != nil {
+		return rawURL
+	}
+	reference, err := url.Parse(rawURL)
+	if err != nil {
+		return rawURL
+	}
+	absolute := requestURL.ResolveReference(reference)
+	if !strings.EqualFold(absolute.Scheme, base.Scheme) || !strings.EqualFold(absolute.Host, base.Host) {
+		return rawURL
+	}
+
+	basePath := strings.TrimSuffix(base.EscapedPath(), "/")
+	absolutePath := absolute.EscapedPath()
+	if absolutePath != basePath && !strings.HasPrefix(absolutePath, basePath+"/") {
+		return rawURL
+	}
+	suffix := strings.TrimPrefix(absolutePath, basePath)
+	rewritten := h.proxyURL + "/swift" + suffix
+	if absolute.RawQuery != "" {
+		rewritten += "?" + absolute.RawQuery
+	}
+	if absolute.Fragment != "" {
+		rewritten += "#" + absolute.Fragment
+	}
+	return rewritten
+}
+
+func (h *SwiftHandler) rewriteReleaseURLs(scope, name string, body []byte) ([]byte, error) {
+	var metadata map[string]any
+	if err := json.Unmarshal(body, &metadata); err != nil {
+		return nil, err
+	}
+	releases, ok := metadata["releases"].(map[string]any)
+	if !ok {
+		return body, nil
+	}
+
+	for version, value := range releases {
+		release, ok := value.(map[string]any)
+		if !ok {
+			continue
+		}
+		if _, hasURL := release["url"]; !hasURL {
+			continue
+		}
+		release["url"] = fmt.Sprintf(
+			"%s/swift/%s/%s/%s",
+			h.proxyURL,
+			url.PathEscape(scope),
+			url.PathEscape(name),
+			url.PathEscape(version),
+		)
+	}
+	return json.Marshal(metadata)
+}
+
+func (h *SwiftHandler) buildUpstreamURL(scope, name, version, resource, rawQuery string) string {
+	parts := []string{h.upstreamURL, url.PathEscape(scope), url.PathEscape(name)}
+	if version != "" {
+		parts = append(parts, url.PathEscape(version))
+	}
+	if resource != "" {
+		parts = append(parts, resource)
+	}
+	result := strings.Join(parts, "/")
+	if rawQuery != "" {
+		result += "?" + rawQuery
+	}
+	return result
+}
+
+func swiftMetadataCacheKey(parts ...string) string {
+	joined := strings.Join(parts, "\x00")
+	digest := sha256.Sum256([]byte(joined))
+	return hex.EncodeToString(digest[:])
+}
+
+func swiftReleaseCacheKey(scope, name, version string) string {
+	return swiftMetadataCacheKey("release", scope, name, version)
+}
+
+func requestAccept(r *http.Request, fallback string) string {
+	if accept := r.Header.Get("Accept"); accept != "" {
+		return accept
+	}
+	return fallback
+}
+
+func writeSwiftMetadata(w http.ResponseWriter, r *http.Request, body []byte, contentType string) {
+	if contentType == "" {
+		contentType = "application/json"
+	}
+	digest := sha256.Sum256(body)
+	etag := fmt.Sprintf(`"%x"`, digest)
+	w.Header().Set("Content-Type", contentType)
+	w.Header().Set("Content-Version", swiftContentVersion)
+	w.Header().Set("ETag", etag)
+	if r.Header.Get("If-None-Match") == etag {
+		w.WriteHeader(http.StatusNotModified)
+		return
+	}
+	w.Header().Set("Content-Length", strconv.Itoa(len(body)))
+	w.WriteHeader(http.StatusOK)
+	if r.Method != http.MethodHead {
+		_, _ = w.Write(body)
+	}
+}
+
+func (h *SwiftHandler) writeMetadataError(w http.ResponseWriter, err error) {
+	if errors.Is(err, ErrUpstreamNotFound) {
+		writeSwiftProblem(w, http.StatusNotFound, "not found")
+		return
+	}
+	h.proxy.Logger.Error("Swift metadata request failed", "error", err)
+	writeSwiftProblem(w, http.StatusBadGateway, "upstream request failed")
+}
+
+func (h *SwiftHandler) writeArtifactError(w http.ResponseWriter, err error) {
+	if errors.Is(err, ErrUpstreamNotFound) {
+		writeSwiftProblem(w, http.StatusNotFound, "release not found")
+		return
+	}
+	h.proxy.Logger.Error("Swift archive request failed", "error", err)
+	writeSwiftProblem(w, http.StatusBadGateway, "failed to fetch package")
+}
+
+func writeSwiftProblem(w http.ResponseWriter, status int, detail string) {
+	w.Header().Set("Content-Type", "application/problem+json")
+	w.Header().Set("Content-Version", swiftContentVersion)
+	w.WriteHeader(status)
+	_ = json.NewEncoder(w).Encode(map[string]string{"detail": detail})
+}
+
+func validSwiftPackageReference(scope, name, version string) bool {
+	return validSwiftScope(scope) && validSwiftPackageName(name) && version != "" && version != "." && version != ".." && !strings.ContainsAny(version, "/\\")
+}
+
+func validSwiftScope(scope string) bool {
+	return validSwiftIdentifier(scope, swiftMaxScopeLength, "-")
+}
+
+func validSwiftPackageName(name string) bool {
+	return validSwiftIdentifier(name, swiftMaxNameLength, "-_")
+}
+
+func validSwiftIdentifier(value string, maxLength int, separators string) bool {
+	if value == "" || len(value) > maxLength {
+		return false
+	}
+	previousSeparator := false
+	for i := 0; i < len(value); i++ {
+		character := value[i]
+		separator := strings.ContainsRune(separators, rune(character))
+		if separator {
+			if i == 0 || i == len(value)-1 || previousSeparator {
+				return false
+			}
+			previousSeparator = true
+			continue
+		}
+		if (character < 'a' || character > 'z') &&
+			(character < 'A' || character > 'Z') &&
+			(character < '0' || character > '9') {
+			return false
+		}
+		previousSeparator = false
+	}
+	return true
+}

--- a/internal/handler/swift.go
+++ b/internal/handler/swift.go
@@ -63,6 +63,7 @@ func (h *SwiftHandler) handlePackageReleases(w http.ResponseWriter, r *http.Requ
 		writeSwiftProblem(w, http.StatusBadRequest, "invalid package identifier")
 		return
 	}
+	scope, name = canonicalSwiftPackage(scope, name)
 
 	upstreamURL := h.buildUpstreamURL(scope, name, "", "", r.URL.RawQuery)
 	body, contentType, responseHeaders, err := h.fetchMetadataWithHeaders(
@@ -98,6 +99,7 @@ func (h *SwiftHandler) handleRelease(w http.ResponseWriter, r *http.Request) {
 		writeSwiftProblem(w, http.StatusBadRequest, "invalid package release")
 		return
 	}
+	scope, name = canonicalSwiftPackage(scope, name)
 
 	upstreamURL := h.buildUpstreamURL(scope, name, version, "", r.URL.RawQuery)
 	body, contentType, err := h.proxy.FetchOrCacheMetadata(
@@ -118,6 +120,7 @@ func (h *SwiftHandler) handleManifest(w http.ResponseWriter, r *http.Request) {
 		writeSwiftProblem(w, http.StatusBadRequest, "invalid package release")
 		return
 	}
+	scope, name = canonicalSwiftPackage(scope, name)
 
 	upstreamURL := h.buildUpstreamURL(scope, name, version, "Package.swift", r.URL.RawQuery)
 	h.proxySwiftResource(w, r, upstreamURL, swiftAcceptManifest)
@@ -151,6 +154,7 @@ func (h *SwiftHandler) handleSourceArchive(w http.ResponseWriter, r *http.Reques
 		writeSwiftProblem(w, http.StatusBadRequest, "invalid package release")
 		return
 	}
+	scope, name = canonicalSwiftPackage(scope, name)
 
 	packageName := scope + "/" + name
 	filename := fmt.Sprintf("%s-%s.zip", name, version)
@@ -595,6 +599,10 @@ func writeSwiftProblem(w http.ResponseWriter, status int, detail string) {
 
 func validSwiftPackageReference(scope, name, version string) bool {
 	return validSwiftScope(scope) && validSwiftPackageName(name) && version != "" && version != "." && version != ".." && !strings.ContainsAny(version, "/\\")
+}
+
+func canonicalSwiftPackage(scope, name string) (string, string) {
+	return strings.ToLower(scope), strings.ToLower(name)
 }
 
 func validSwiftScope(scope string) bool {

--- a/internal/handler/swift.go
+++ b/internal/handler/swift.go
@@ -65,9 +65,8 @@ func (h *SwiftHandler) handlePackageReleases(w http.ResponseWriter, r *http.Requ
 	}
 
 	upstreamURL := h.buildUpstreamURL(scope, name, "", "", r.URL.RawQuery)
-	cacheKey := swiftMetadataCacheKey(scope, name, "releases", r.URL.RawQuery)
-	body, contentType, err := h.proxy.FetchOrCacheMetadata(
-		r.Context(), "swift", cacheKey, upstreamURL, requestAccept(r, swiftAcceptJSON),
+	body, contentType, responseHeaders, err := h.fetchMetadataWithHeaders(
+		r.Context(), upstreamURL, requestAccept(r, swiftAcceptJSON),
 	)
 	if err != nil {
 		h.writeMetadataError(w, err)
@@ -78,6 +77,9 @@ func (h *SwiftHandler) handlePackageReleases(w http.ResponseWriter, r *http.Requ
 	if err != nil {
 		h.proxy.Logger.Warn("failed to rewrite Swift release URLs", "error", err)
 		rewritten = body
+	}
+	for _, link := range responseHeaders.Values("Link") {
+		w.Header().Add("Link", h.rewriteLinkHeader(link, upstreamURL))
 	}
 	writeSwiftMetadata(w, r, rewritten, contentType)
 }
@@ -200,7 +202,7 @@ func (h *SwiftHandler) handleSourceArchiveHead(
 		return
 	}
 
-	size, err := h.headSourceArchive(r.Context(), upstreamURL, requestAccept(r, swiftAcceptArchive))
+	size, err := h.probeSourceArchive(r.Context(), upstreamURL, requestAccept(r, swiftAcceptArchive))
 	if err != nil {
 		h.writeArtifactError(w, err)
 		return
@@ -214,12 +216,13 @@ func (h *SwiftHandler) handleSourceArchiveHead(
 	w.WriteHeader(http.StatusOK)
 }
 
-func (h *SwiftHandler) headSourceArchive(ctx context.Context, upstreamURL, accept string) (int64, error) {
-	req, err := http.NewRequestWithContext(ctx, http.MethodHead, upstreamURL, nil)
+func (h *SwiftHandler) probeSourceArchive(ctx context.Context, upstreamURL, accept string) (int64, error) {
+	req, err := http.NewRequestWithContext(ctx, http.MethodGet, upstreamURL, nil)
 	if err != nil {
 		return 0, fmt.Errorf("creating upstream archive request: %w", err)
 	}
 	req.Header.Set("Accept", accept)
+	req.Header.Set("Range", "bytes=0-0")
 	h.proxy.applyUpstreamAuth(req)
 
 	resp, err := h.proxy.HTTPClient.Do(req)
@@ -231,8 +234,19 @@ func (h *SwiftHandler) headSourceArchive(ctx context.Context, upstreamURL, accep
 	if resp.StatusCode == http.StatusNotFound {
 		return 0, ErrUpstreamNotFound
 	}
-	if resp.StatusCode != http.StatusOK {
+	if resp.StatusCode != http.StatusOK && resp.StatusCode != http.StatusPartialContent {
 		return 0, fmt.Errorf("upstream archive returned %d", resp.StatusCode)
+	}
+
+	if resp.StatusCode == http.StatusPartialContent {
+		_, total, found := strings.Cut(resp.Header.Get("Content-Range"), "/")
+		if !found || total == "*" {
+			return -1, nil
+		}
+		if parsed, parseErr := strconv.ParseInt(total, 10, 64); parseErr == nil {
+			return parsed, nil
+		}
+		return -1, nil
 	}
 
 	size := int64(-1)
@@ -242,6 +256,41 @@ func (h *SwiftHandler) headSourceArchive(ctx context.Context, upstreamURL, accep
 		}
 	}
 	return size, nil
+}
+
+func (h *SwiftHandler) fetchMetadataWithHeaders(
+	ctx context.Context,
+	upstreamURL, accept string,
+) ([]byte, string, http.Header, error) {
+	req, err := http.NewRequestWithContext(ctx, http.MethodGet, upstreamURL, nil)
+	if err != nil {
+		return nil, "", nil, fmt.Errorf("creating upstream metadata request: %w", err)
+	}
+	req.Header.Set("Accept", accept)
+	h.proxy.applyUpstreamAuth(req)
+
+	resp, err := h.proxy.HTTPClient.Do(req)
+	if err != nil {
+		return nil, "", nil, fmt.Errorf("requesting upstream metadata: %w", err)
+	}
+	defer func() { _ = resp.Body.Close() }()
+
+	if resp.StatusCode == http.StatusNotFound {
+		return nil, "", nil, ErrUpstreamNotFound
+	}
+	if resp.StatusCode != http.StatusOK {
+		return nil, "", nil, fmt.Errorf("upstream metadata returned %d", resp.StatusCode)
+	}
+
+	body, err := h.proxy.ReadMetadata(resp.Body)
+	if err != nil {
+		return nil, "", nil, fmt.Errorf("reading upstream metadata: %w", err)
+	}
+	contentType := resp.Header.Get("Content-Type")
+	if contentType == "" {
+		contentType = contentTypeJSON
+	}
+	return body, contentType, resp.Header.Clone(), nil
 }
 
 type swiftReleaseMetadata struct {

--- a/internal/handler/swift.go
+++ b/internal/handler/swift.go
@@ -13,16 +13,18 @@ import (
 	"net/url"
 	"strconv"
 	"strings"
+
+	"github.com/git-pkgs/proxy/internal/config"
+	"github.com/git-pkgs/proxy/internal/packageurl"
 )
 
 const (
-	swiftDefaultUpstream = "https://tuist.dev/api/registry/swift"
-	swiftAcceptJSON      = "application/vnd.swift.registry.v1+json"
-	swiftAcceptManifest  = "application/vnd.swift.registry.v1+swift"
-	swiftAcceptArchive   = "application/vnd.swift.registry.v1+zip"
-	swiftContentVersion  = "1"
-	swiftMaxScopeLength  = 39
-	swiftMaxNameLength   = 100
+	swiftAcceptJSON     = "application/vnd.swift.registry.v1+json"
+	swiftAcceptManifest = "application/vnd.swift.registry.v1+swift"
+	swiftAcceptArchive  = "application/vnd.swift.registry.v1+zip"
+	swiftContentVersion = "1"
+	swiftMaxScopeLength = 39
+	swiftMaxNameLength  = 100
 )
 
 // SwiftHandler handles the read-only Swift Package Registry v1 protocol.
@@ -35,7 +37,7 @@ type SwiftHandler struct {
 // NewSwiftHandler creates a Swift Package Registry protocol handler.
 func NewSwiftHandler(proxy *Proxy, proxyURL, upstreamURL string) *SwiftHandler {
 	if strings.TrimSpace(upstreamURL) == "" {
-		upstreamURL = swiftDefaultUpstream
+		upstreamURL = config.DefaultSwiftUpstream
 	}
 
 	return &SwiftHandler{
@@ -159,6 +161,11 @@ func (h *SwiftHandler) handleSourceArchive(w http.ResponseWriter, r *http.Reques
 	packageName := scope + "/" + name
 	filename := fmt.Sprintf("%s-%s.zip", name, version)
 	upstreamURL := h.buildUpstreamURL(scope, name, version+".zip", "", r.URL.RawQuery)
+	packagePURL, versionPURL := packageurl.MakeCacheStrings("swift", packageName, version, h.upstreamURL)
+	if packagePURL == "" || versionPURL == "" {
+		h.writeArtifactError(w, fmt.Errorf("%w: swift %q", errUnsupportedPackageIdentity, packageName))
+		return
+	}
 	archiveInfo, infoErr := h.fetchArchiveInfo(r.Context(), scope, name, version)
 	if infoErr != nil {
 		h.writeArtifactError(w, fmt.Errorf("fetching release metadata: %w", infoErr))
@@ -166,14 +173,15 @@ func (h *SwiftHandler) handleSourceArchive(w http.ResponseWriter, r *http.Reques
 	}
 
 	if r.Method == http.MethodHead {
-		h.handleSourceArchiveHead(w, r, packageName, version, filename, upstreamURL, archiveInfo)
+		h.handleSourceArchiveHead(w, r, packageName, version, filename, packagePURL, versionPURL, upstreamURL, archiveInfo)
 		return
 	}
 
 	headers := make(http.Header)
 	headers.Set("Accept", requestAccept(r, swiftAcceptArchive))
-	result, err := h.proxy.getOrFetchArtifactFromURL(
-		r.Context(), "swift", packageName, version, filename, upstreamURL, headers, archiveInfo.checksum,
+	result, err := h.proxy.getOrFetchArtifactFromURLWithCachePURLs(
+		r.Context(), "swift", packageName, version, filename, packagePURL, versionPURL,
+		upstreamURL, headers, archiveInfo.checksum,
 	)
 	if err != nil {
 		h.writeArtifactError(w, err)
@@ -188,11 +196,11 @@ func (h *SwiftHandler) handleSourceArchive(w http.ResponseWriter, r *http.Reques
 func (h *SwiftHandler) handleSourceArchiveHead(
 	w http.ResponseWriter,
 	r *http.Request,
-	packageName, version, filename, upstreamURL string,
+	packageName, version, filename, packagePURL, versionPURL, upstreamURL string,
 	archiveInfo swiftArchiveInfo,
 ) {
 	result, err := h.proxy.getCachedArtifactWithExpectedHash(
-		r.Context(), "swift", packageName, version, filename, archiveInfo.checksum,
+		r.Context(), packagePURL, versionPURL, filename, archiveInfo.checksum,
 	)
 	if err != nil {
 		h.writeArtifactError(w, err)

--- a/internal/handler/swift_test.go
+++ b/internal/handler/swift_test.go
@@ -204,9 +204,7 @@ func TestSwiftSourceArchiveCachesAndPreservesSecurityMetadata(t *testing.T) {
 		t.Errorf("Content-Disposition = %q", got)
 	}
 
-	packagePURL, versionPURL := packageurl.MakeCacheStrings(
-		"swift", "apple/example", "1.2.3", upstream.URL+"/registry",
-	)
+	packagePURL, versionPURL := packageurl.MakeCacheStrings("swift", "apple/example", "1.2.3")
 	if strings.HasPrefix(packagePURL, "pkg:swift/") {
 		t.Fatalf("registry identity produced source PURL %q", packagePURL)
 	}
@@ -269,7 +267,7 @@ func TestSwiftSourceArchiveRejectsChecksumMismatch(t *testing.T) {
 	if len(store.files) != 0 {
 		t.Errorf("mismatched archive remained in storage: %v", store.files)
 	}
-	packagePURL, versionPURL := packageurl.MakeCacheStrings("swift", "apple/example", "1.2.3", upstream.URL)
+	packagePURL, versionPURL := packageurl.MakeCacheStrings("swift", "apple/example", "1.2.3")
 	cached, err := db.GetCachedArtifact(packagePURL, versionPURL, "example-1.2.3.zip")
 	if err != nil {
 		t.Fatalf("checking cache: %v", err)
@@ -319,7 +317,7 @@ func TestSwiftSourceArchiveCanonicalizesPackageIdentity(t *testing.T) {
 		}
 	}
 
-	canonicalPURL, _ := packageurl.MakeCacheStrings("swift", "apple/example", "1.2.3", upstream.URL)
+	canonicalPURL, _ := packageurl.MakeCacheStrings("swift", "apple/example", "1.2.3")
 	canonical, err := db.GetPackageByPURL(canonicalPURL)
 	if err != nil {
 		t.Fatalf("getting canonical package: %v", err)
@@ -328,29 +326,37 @@ func TestSwiftSourceArchiveCanonicalizesPackageIdentity(t *testing.T) {
 		t.Fatalf("canonical package %q not found", canonicalPURL)
 	}
 
-	nonCanonicalPURL, _ := packageurl.MakeCacheStrings("swift", "APPLE/EXAMPLE", "1.2.3", upstream.URL)
+	nonCanonicalPURL, _ := packageurl.MakeCacheStrings("swift", "APPLE/EXAMPLE", "1.2.3")
 	if nonCanonicalPURL != canonicalPURL {
 		t.Errorf("uppercase cache PURL = %q, want %q", nonCanonicalPURL, canonicalPURL)
 	}
 }
 
-func TestSwiftSourceArchiveHeadRejectsCachedChecksumMismatch(t *testing.T) {
+func TestSwiftSourceArchiveHeadDiscardsCachedChecksumMismatch(t *testing.T) {
 	archive := []byte("cached archive")
-	expectedChecksum := sha256.Sum256([]byte("expected archive"))
+	upstreamChecksum := sha256.Sum256([]byte("upstream archive"))
 
-	upstream := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+	var probed bool
+	upstream := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if strings.HasSuffix(r.URL.Path, ".zip") {
+			probed = true
+			w.Header().Set("Content-Range", "bytes 0-0/456")
+			w.WriteHeader(http.StatusPartialContent)
+			_, _ = w.Write([]byte("x"))
+			return
+		}
 		w.Header().Set("Content-Type", "application/json")
-		_, _ = fmt.Fprintf(w, `{"id":"apple.example","version":"1.2.3","resources":[{"name":"source-archive","type":"application/zip","checksum":%q}]}`, hex.EncodeToString(expectedChecksum[:]))
+		_, _ = fmt.Fprintf(w, `{"id":"apple.example","version":"1.2.3","resources":[{"name":"source-archive","type":"application/zip","checksum":%q}]}`, hex.EncodeToString(upstreamChecksum[:]))
 	}))
 	defer upstream.Close()
 
-	proxy, _, store, fetcher := setupTestProxy(t)
+	proxy, db, store, fetcher := setupTestProxy(t)
 	fetcher.artifact = &fetch.Artifact{
 		Body:        io.NopCloser(strings.NewReader(string(archive))),
 		Size:        int64(len(archive)),
 		ContentType: "application/zip",
 	}
-	packagePURL, versionPURL := packageurl.MakeCacheStrings("swift", "apple/example", "1.2.3", upstream.URL)
+	packagePURL, versionPURL := packageurl.MakeCacheStrings("swift", "apple/example", "1.2.3")
 	cached, err := proxy.getOrFetchArtifactFromURLWithCachePURLs(
 		context.Background(), "swift", "apple/example", "1.2.3", "example-1.2.3.zip",
 		packagePURL, versionPURL, upstream.URL+"/apple/example/1.2.3.zip", nil, "",
@@ -364,11 +370,20 @@ func TestSwiftSourceArchiveHeadRejectsCachedChecksumMismatch(t *testing.T) {
 	w := httptest.NewRecorder()
 	handler.ServeHTTP(w, httptest.NewRequest(http.MethodHead, "/apple/example/1.2.3.zip", nil))
 
-	if w.Code != http.StatusBadGateway {
-		t.Fatalf("status = %d, want 502; body: %s", w.Code, w.Body.String())
+	if w.Code != http.StatusOK {
+		t.Fatalf("status = %d, want 200; body: %s", w.Code, w.Body.String())
+	}
+	if !probed {
+		t.Error("stale cache entry was not replaced by an upstream probe")
+	}
+	if got := w.Header().Get("Content-Length"); got != "456" {
+		t.Errorf("Content-Length = %q, want 456 from upstream probe", got)
 	}
 	if len(store.files) != 0 {
-		t.Errorf("cached mismatched archive remained in storage: %v", store.files)
+		t.Errorf("mismatched cached archive remained in storage: %v", store.files)
+	}
+	if rec, _ := db.GetCachedArtifact(packagePURL, versionPURL, "example-1.2.3.zip"); rec != nil {
+		t.Error("mismatched cache record was not cleared")
 	}
 }
 

--- a/internal/handler/swift_test.go
+++ b/internal/handler/swift_test.go
@@ -26,6 +26,7 @@ func TestSwiftPackageReleasesRewritesRegistryURLs(t *testing.T) {
 		gotAccept = r.Header.Get("Accept")
 		w.Header().Set("Content-Type", "application/json; charset=utf-8")
 		w.Header().Set("Content-Version", "1")
+		w.Header().Add("Link", `</registry/apple/swift-argument-parser?page=2>; rel="next"`)
 		_, _ = io.WriteString(w, `{"releases":{"1.2.0":{"url":"/registry/apple/swift-argument-parser/1.2.0"},"1.1.0":{}}}`)
 	}))
 	defer upstream.Close()
@@ -45,6 +46,9 @@ func TestSwiftPackageReleasesRewritesRegistryURLs(t *testing.T) {
 	}
 	if got := w.Header().Get("Content-Version"); got != "1" {
 		t.Errorf("Content-Version = %q, want 1", got)
+	}
+	if got := w.Header().Get("Link"); got != `<https://proxy.example/swift/apple/swift-argument-parser?page=2>; rel="next"` {
+		t.Errorf("Link = %q", got)
 	}
 
 	var body struct {
@@ -330,19 +334,28 @@ func TestSwiftSourceArchiveRequiresReleaseMetadata(t *testing.T) {
 	}
 }
 
-func TestSwiftSourceArchiveColdHeadSendsArchiveAccept(t *testing.T) {
+func TestSwiftSourceArchiveColdHeadUsesRangeGetAcrossRedirect(t *testing.T) {
 	checksum := strings.Repeat("a", sha256.Size*2)
 	var archiveAccept string
 	var archiveMethod string
+	var archiveRange string
+	download := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		archiveMethod = r.Method
+		archiveRange = r.Header.Get("Range")
+		w.Header().Set("Content-Range", "bytes 0-0/123")
+		w.WriteHeader(http.StatusPartialContent)
+		_, _ = w.Write([]byte("x"))
+	}))
+	defer download.Close()
+
 	upstream := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		switch r.URL.Path {
 		case "/apple/example/1.2.3":
 			w.Header().Set("Content-Type", "application/json")
 			_, _ = fmt.Fprintf(w, `{"id":"apple.example","version":"1.2.3","resources":[{"name":"source-archive","type":"application/zip","checksum":%q}]}`, checksum)
 		case "/apple/example/1.2.3.zip":
-			archiveMethod = r.Method
 			archiveAccept = r.Header.Get("Accept")
-			w.Header().Set("Content-Length", "123")
+			http.Redirect(w, r, download.URL, http.StatusSeeOther)
 		default:
 			http.NotFound(w, r)
 		}
@@ -359,8 +372,11 @@ func TestSwiftSourceArchiveColdHeadSendsArchiveAccept(t *testing.T) {
 	if w.Code != http.StatusOK {
 		t.Fatalf("status = %d, want 200; body: %s", w.Code, w.Body.String())
 	}
-	if archiveMethod != http.MethodHead {
-		t.Errorf("upstream method = %q, want HEAD", archiveMethod)
+	if archiveMethod != http.MethodGet {
+		t.Errorf("download method = %q, want GET", archiveMethod)
+	}
+	if archiveRange != "bytes=0-0" {
+		t.Errorf("download Range = %q, want bytes=0-0", archiveRange)
 	}
 	if archiveAccept != swiftAcceptArchive {
 		t.Errorf("upstream Accept = %q, want %q", archiveAccept, swiftAcceptArchive)

--- a/internal/handler/swift_test.go
+++ b/internal/handler/swift_test.go
@@ -1,0 +1,297 @@
+package handler
+
+import (
+	"crypto/sha256"
+	"encoding/base64"
+	"encoding/hex"
+	"encoding/json"
+	"fmt"
+	"io"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"testing"
+
+	"github.com/git-pkgs/proxy/internal/packageurl"
+	"github.com/git-pkgs/registries/fetch"
+)
+
+func TestSwiftPackageReleasesRewritesRegistryURLs(t *testing.T) {
+	var gotAccept string
+	upstream := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.URL.Path != "/registry/apple/swift-argument-parser" {
+			t.Errorf("upstream path = %q", r.URL.Path)
+		}
+		gotAccept = r.Header.Get("Accept")
+		w.Header().Set("Content-Type", "application/json; charset=utf-8")
+		w.Header().Set("Content-Version", "1")
+		_, _ = io.WriteString(w, `{"releases":{"1.2.0":{"url":"/registry/apple/swift-argument-parser/1.2.0"},"1.1.0":{}}}`)
+	}))
+	defer upstream.Close()
+
+	proxy, _, _, _ := setupTestProxy(t)
+	handler := NewSwiftHandler(proxy, "https://proxy.example", upstream.URL+"/registry").Routes()
+	req := httptest.NewRequest(http.MethodGet, "/apple/swift-argument-parser", nil)
+	req.Header.Set("Accept", swiftAcceptJSON)
+	w := httptest.NewRecorder()
+	handler.ServeHTTP(w, req)
+
+	if w.Code != http.StatusOK {
+		t.Fatalf("status = %d, want 200; body: %s", w.Code, w.Body.String())
+	}
+	if gotAccept != swiftAcceptJSON {
+		t.Errorf("upstream Accept = %q, want %q", gotAccept, swiftAcceptJSON)
+	}
+	if got := w.Header().Get("Content-Version"); got != "1" {
+		t.Errorf("Content-Version = %q, want 1", got)
+	}
+
+	var body struct {
+		Releases map[string]struct {
+			URL string `json:"url"`
+		} `json:"releases"`
+	}
+	if err := json.NewDecoder(w.Body).Decode(&body); err != nil {
+		t.Fatalf("decoding response: %v", err)
+	}
+	if got := body.Releases["1.2.0"].URL; got != "https://proxy.example/swift/apple/swift-argument-parser/1.2.0" {
+		t.Errorf("release URL = %q", got)
+	}
+	if got := body.Releases["1.1.0"].URL; got != "" {
+		t.Errorf("release without upstream URL gained URL %q", got)
+	}
+}
+
+func TestSwiftReleaseMetadataSupportsJSONExtensionAndHead(t *testing.T) {
+	var requestMethods []string
+	upstream := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		requestMethods = append(requestMethods, r.Method)
+		if r.URL.Path != "/registry/apple/example/1.2.3" {
+			t.Errorf("upstream path = %q", r.URL.Path)
+		}
+		w.Header().Set("Content-Type", "application/json")
+		_, _ = io.WriteString(w, `{"id":"apple.example","version":"1.2.3","resources":[]}`)
+	}))
+	defer upstream.Close()
+
+	proxy, _, _, _ := setupTestProxy(t)
+	handler := NewSwiftHandler(proxy, "https://proxy.example", upstream.URL+"/registry").Routes()
+
+	for _, method := range []string{http.MethodGet, http.MethodHead} {
+		req := httptest.NewRequest(method, "/apple/example/1.2.3.json", nil)
+		w := httptest.NewRecorder()
+		handler.ServeHTTP(w, req)
+		if w.Code != http.StatusOK {
+			t.Fatalf("%s status = %d, want 200", method, w.Code)
+		}
+		if method == http.MethodHead && w.Body.Len() != 0 {
+			t.Errorf("HEAD response body length = %d, want 0", w.Body.Len())
+		}
+	}
+	if len(requestMethods) != 2 || requestMethods[0] != http.MethodGet || requestMethods[1] != http.MethodGet {
+		t.Errorf("upstream methods = %v, want metadata GETs", requestMethods)
+	}
+}
+
+func TestSwiftManifestProxiesQueryAndRewritesLinks(t *testing.T) {
+	var upstream *httptest.Server
+	var gotAccept string
+	upstream = httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.Method != http.MethodGet {
+			t.Errorf("upstream method = %s, want GET", r.Method)
+		}
+		if r.URL.Path != "/registry/apple/example/1.2.3/Package.swift" {
+			t.Errorf("upstream path = %q", r.URL.Path)
+		}
+		if got := r.URL.Query().Get("swift-version"); got != "5.9" {
+			t.Errorf("swift-version = %q, want 5.9", got)
+		}
+		gotAccept = r.Header.Get("Accept")
+		w.Header().Set("Content-Type", "text/x-swift")
+		w.Header().Add("Link", fmt.Sprintf(`<%s/registry/apple/example/1.2.3/Package.swift?swift-version=5.8>; rel="alternate"; filename="Package@swift-5.8.swift"`, upstream.URL))
+		w.Header().Add("Link", `<https://github.com/apple/example>; rel="canonical"`)
+		_, _ = io.WriteString(w, "// swift-tools-version: 5.9\n")
+	}))
+	defer upstream.Close()
+
+	proxy, _, _, _ := setupTestProxy(t)
+	handler := NewSwiftHandler(proxy, "https://proxy.example", upstream.URL+"/registry").Routes()
+	req := httptest.NewRequest(http.MethodGet, "/apple/example/1.2.3/Package.swift?swift-version=5.9", nil)
+	req.Header.Set("Accept", swiftAcceptManifest)
+	w := httptest.NewRecorder()
+	handler.ServeHTTP(w, req)
+
+	if w.Code != http.StatusOK {
+		t.Fatalf("status = %d, want 200", w.Code)
+	}
+	if gotAccept != swiftAcceptManifest {
+		t.Errorf("upstream Accept = %q, want %q", gotAccept, swiftAcceptManifest)
+	}
+	links := strings.Join(w.Header().Values("Link"), ",")
+	if !strings.Contains(links, "https://proxy.example/swift/apple/example/1.2.3/Package.swift?swift-version=5.8") {
+		t.Errorf("internal manifest Link was not rewritten: %q", links)
+	}
+	if !strings.Contains(links, "https://github.com/apple/example") {
+		t.Errorf("external canonical Link was changed: %q", links)
+	}
+	if got := w.Header().Get("Content-Version"); got != "1" {
+		t.Errorf("Content-Version = %q, want 1", got)
+	}
+}
+
+func TestSwiftSourceArchiveCachesAndPreservesSecurityMetadata(t *testing.T) {
+	archive := []byte("swift source archive")
+	checksumBytes := sha256.Sum256(archive)
+	checksum := hex.EncodeToString(checksumBytes[:])
+	signature := base64.StdEncoding.EncodeToString([]byte("signature"))
+
+	upstream := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.URL.Path != "/registry/apple/example/1.2.3" {
+			t.Errorf("metadata path = %q", r.URL.Path)
+		}
+		w.Header().Set("Content-Type", "application/json")
+		_, _ = fmt.Fprintf(w, `{"id":"apple.example","version":"1.2.3","resources":[{"name":"source-archive","type":"application/zip","checksum":%q,"signing":{"signatureBase64Encoded":%q,"signatureFormat":"cms-1.0.0"}}]}`, checksum, signature)
+	}))
+	defer upstream.Close()
+
+	proxy, db, _, fetcher := setupTestProxy(t)
+	fetcher.artifact = &fetch.Artifact{
+		Body:        io.NopCloser(strings.NewReader(string(archive))),
+		Size:        int64(len(archive)),
+		ContentType: "application/zip",
+	}
+	handler := NewSwiftHandler(proxy, "https://proxy.example", upstream.URL+"/registry").Routes()
+
+	requestArchive := func(method string) *httptest.ResponseRecorder {
+		req := httptest.NewRequest(method, "/apple/example/1.2.3.zip", nil)
+		req.Header.Set("Accept", swiftAcceptArchive)
+		w := httptest.NewRecorder()
+		handler.ServeHTTP(w, req)
+		return w
+	}
+
+	w := requestArchive(http.MethodGet)
+	if w.Code != http.StatusOK {
+		t.Fatalf("status = %d, want 200; body: %s", w.Code, w.Body.String())
+	}
+	if got := w.Body.Bytes(); string(got) != string(archive) {
+		t.Errorf("archive body = %q", got)
+	}
+	if !fetcher.fetchCalled {
+		t.Fatal("archive fetcher was not called")
+	}
+	if got := fetcher.fetchedURL; got != upstream.URL+"/registry/apple/example/1.2.3.zip" {
+		t.Errorf("fetched URL = %q", got)
+	}
+	if got := fetcher.fetchedHeader.Get("Accept"); got != swiftAcceptArchive {
+		t.Errorf("archive Accept = %q, want %q", got, swiftAcceptArchive)
+	}
+	if got := w.Header().Get("Digest"); got != "sha-256="+base64.StdEncoding.EncodeToString(checksumBytes[:]) {
+		t.Errorf("Digest = %q", got)
+	}
+	if got := w.Header().Get("X-Swift-Package-Signature"); got != signature {
+		t.Errorf("signature = %q", got)
+	}
+	if got := w.Header().Get("X-Swift-Package-Signature-Format"); got != "cms-1.0.0" {
+		t.Errorf("signature format = %q", got)
+	}
+	if got := w.Header().Get("Content-Disposition"); got != `attachment; filename="example-1.2.3.zip"` {
+		t.Errorf("Content-Disposition = %q", got)
+	}
+
+	versionPURL := packageurl.MakeString("swift", "apple/example", "1.2.3")
+	versionRecord, err := db.GetVersionByPURL(versionPURL)
+	if err != nil {
+		t.Fatalf("cached Swift version %q not found: %v", versionPURL, err)
+	}
+	if versionRecord == nil {
+		t.Fatalf("cached Swift version %q not found", versionPURL)
+	}
+
+	fetcher.fetchCalled = false
+	w = requestArchive(http.MethodHead)
+	if w.Code != http.StatusOK {
+		t.Fatalf("HEAD status = %d, want 200", w.Code)
+	}
+	if w.Body.Len() != 0 {
+		t.Errorf("HEAD body length = %d, want 0", w.Body.Len())
+	}
+	if got := w.Header().Get("Content-Length"); got != fmt.Sprint(len(archive)) {
+		t.Errorf("HEAD Content-Length = %q", got)
+	}
+
+	w = requestArchive(http.MethodGet)
+	if w.Code != http.StatusOK || w.Body.String() != string(archive) {
+		t.Fatalf("cached response = %d %q", w.Code, w.Body.Bytes())
+	}
+	if fetcher.fetchCalled {
+		t.Error("cached archive contacted artifact upstream")
+	}
+}
+
+func TestSwiftIdentifiersAndPublishingUnsupported(t *testing.T) {
+	upstream := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.URL.Path != "/registry/identifiers" {
+			t.Errorf("upstream path = %q", r.URL.Path)
+		}
+		if got := r.URL.Query().Get("url"); got != "https://github.com/apple/example" {
+			t.Errorf("lookup URL = %q", got)
+		}
+		w.Header().Set("Content-Type", "application/json")
+		_, _ = io.WriteString(w, `{"identifiers":["apple.example"]}`)
+	}))
+	defer upstream.Close()
+
+	proxy, _, _, _ := setupTestProxy(t)
+	handler := NewSwiftHandler(proxy, "https://proxy.example", upstream.URL+"/registry").Routes()
+
+	req := httptest.NewRequest(http.MethodGet, "/identifiers?url=https%3A%2F%2Fgithub.com%2Fapple%2Fexample", nil)
+	w := httptest.NewRecorder()
+	handler.ServeHTTP(w, req)
+	if w.Code != http.StatusOK || !strings.Contains(w.Body.String(), "apple.example") {
+		t.Fatalf("identifier response = %d %q", w.Code, w.Body.String())
+	}
+
+	req = httptest.NewRequest(http.MethodGet, "/identifiers", nil)
+	w = httptest.NewRecorder()
+	handler.ServeHTTP(w, req)
+	if w.Code != http.StatusBadRequest {
+		t.Errorf("missing URL status = %d, want 400", w.Code)
+	}
+
+	req = httptest.NewRequest(http.MethodPut, "/apple/example/1.2.3", strings.NewReader("ignored"))
+	w = httptest.NewRecorder()
+	handler.ServeHTTP(w, req)
+	if w.Code != http.StatusMethodNotAllowed {
+		t.Errorf("publish status = %d, want 405", w.Code)
+	}
+	if got := w.Header().Get("Allow"); got != "GET, HEAD" {
+		t.Errorf("Allow = %q", got)
+	}
+}
+
+func TestSwiftIdentifierValidation(t *testing.T) {
+	tests := []struct {
+		name  string
+		value string
+		valid func(string) bool
+		want  bool
+	}{
+		{"scope", "apple", validSwiftScope, true},
+		{"scope hyphen", "swift-server", validSwiftScope, true},
+		{"scope underscore", "swift_server", validSwiftScope, false},
+		{"scope repeated separator", "swift--server", validSwiftScope, false},
+		{"package", "swift-argument_parser", validSwiftPackageName, true},
+		{"package repeated separators", "swift-_argument", validSwiftPackageName, false},
+		{"package trailing separator", "example-", validSwiftPackageName, false},
+		{"package non-ASCII", "café", validSwiftPackageName, false},
+	}
+
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			if got := test.valid(test.value); got != test.want {
+				t.Errorf("validation of %q = %v, want %v", test.value, got, test.want)
+			}
+		})
+	}
+}

--- a/internal/handler/swift_test.go
+++ b/internal/handler/swift_test.go
@@ -204,13 +204,21 @@ func TestSwiftSourceArchiveCachesAndPreservesSecurityMetadata(t *testing.T) {
 		t.Errorf("Content-Disposition = %q", got)
 	}
 
-	versionPURL := packageurl.MakeString("swift", "apple/example", "1.2.3")
+	packagePURL, versionPURL := packageurl.MakeCacheStrings(
+		"swift", "apple/example", "1.2.3", upstream.URL+"/registry",
+	)
+	if strings.HasPrefix(packagePURL, "pkg:swift/") {
+		t.Fatalf("registry identity produced source PURL %q", packagePURL)
+	}
 	versionRecord, err := db.GetVersionByPURL(versionPURL)
 	if err != nil {
 		t.Fatalf("cached Swift version %q not found: %v", versionPURL, err)
 	}
 	if versionRecord == nil {
 		t.Fatalf("cached Swift version %q not found", versionPURL)
+	}
+	if versionRecord.PackagePURL != packagePURL {
+		t.Errorf("cached package PURL = %q, want %q", versionRecord.PackagePURL, packagePURL)
 	}
 
 	fetcher.fetchCalled = false
@@ -261,8 +269,8 @@ func TestSwiftSourceArchiveRejectsChecksumMismatch(t *testing.T) {
 	if len(store.files) != 0 {
 		t.Errorf("mismatched archive remained in storage: %v", store.files)
 	}
-	versionPURL := packageurl.MakeString("swift", "apple/example", "1.2.3")
-	cached, err := db.GetCachedArtifact(packageurl.MakeString("swift", "apple/example", ""), versionPURL, "example-1.2.3.zip")
+	packagePURL, versionPURL := packageurl.MakeCacheStrings("swift", "apple/example", "1.2.3", upstream.URL)
+	cached, err := db.GetCachedArtifact(packagePURL, versionPURL, "example-1.2.3.zip")
 	if err != nil {
 		t.Fatalf("checking cache: %v", err)
 	}
@@ -311,7 +319,7 @@ func TestSwiftSourceArchiveCanonicalizesPackageIdentity(t *testing.T) {
 		}
 	}
 
-	canonicalPURL := packageurl.MakeString("swift", "apple/example", "")
+	canonicalPURL, _ := packageurl.MakeCacheStrings("swift", "apple/example", "1.2.3", upstream.URL)
 	canonical, err := db.GetPackageByPURL(canonicalPURL)
 	if err != nil {
 		t.Fatalf("getting canonical package: %v", err)
@@ -320,13 +328,9 @@ func TestSwiftSourceArchiveCanonicalizesPackageIdentity(t *testing.T) {
 		t.Fatalf("canonical package %q not found", canonicalPURL)
 	}
 
-	nonCanonicalPURL := packageurl.MakeString("swift", "APPLE/EXAMPLE", "")
-	nonCanonical, err := db.GetPackageByPURL(nonCanonicalPURL)
-	if err != nil {
-		t.Fatalf("getting non-canonical package: %v", err)
-	}
-	if nonCanonical != nil {
-		t.Errorf("non-canonical package %q was cached", nonCanonicalPURL)
+	nonCanonicalPURL, _ := packageurl.MakeCacheStrings("swift", "APPLE/EXAMPLE", "1.2.3", upstream.URL)
+	if nonCanonicalPURL != canonicalPURL {
+		t.Errorf("uppercase cache PURL = %q, want %q", nonCanonicalPURL, canonicalPURL)
 	}
 }
 
@@ -346,8 +350,10 @@ func TestSwiftSourceArchiveHeadRejectsCachedChecksumMismatch(t *testing.T) {
 		Size:        int64(len(archive)),
 		ContentType: "application/zip",
 	}
-	cached, err := proxy.GetOrFetchArtifactFromURL(
-		context.Background(), "swift", "apple/example", "1.2.3", "example-1.2.3.zip", upstream.URL+"/apple/example/1.2.3.zip",
+	packagePURL, versionPURL := packageurl.MakeCacheStrings("swift", "apple/example", "1.2.3", upstream.URL)
+	cached, err := proxy.getOrFetchArtifactFromURLWithCachePURLs(
+		context.Background(), "swift", "apple/example", "1.2.3", "example-1.2.3.zip",
+		packagePURL, versionPURL, upstream.URL+"/apple/example/1.2.3.zip", nil, "",
 	)
 	if err != nil {
 		t.Fatalf("seeding cache: %v", err)

--- a/internal/handler/swift_test.go
+++ b/internal/handler/swift_test.go
@@ -1,6 +1,7 @@
 package handler
 
 import (
+	"context"
 	"crypto/sha256"
 	"encoding/base64"
 	"encoding/hex"
@@ -226,6 +227,146 @@ func TestSwiftSourceArchiveCachesAndPreservesSecurityMetadata(t *testing.T) {
 	}
 	if fetcher.fetchCalled {
 		t.Error("cached archive contacted artifact upstream")
+	}
+}
+
+func TestSwiftSourceArchiveRejectsChecksumMismatch(t *testing.T) {
+	archive := []byte("unexpected archive")
+	expectedChecksum := sha256.Sum256([]byte("expected archive"))
+
+	upstream := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		_, _ = fmt.Fprintf(w, `{"id":"apple.example","version":"1.2.3","resources":[{"name":"source-archive","type":"application/zip","checksum":%q}]}`, hex.EncodeToString(expectedChecksum[:]))
+	}))
+	defer upstream.Close()
+
+	proxy, db, store, fetcher := setupTestProxy(t)
+	fetcher.artifact = &fetch.Artifact{
+		Body:        io.NopCloser(strings.NewReader(string(archive))),
+		Size:        int64(len(archive)),
+		ContentType: "application/zip",
+	}
+	handler := NewSwiftHandler(proxy, "https://proxy.example", upstream.URL).Routes()
+
+	w := httptest.NewRecorder()
+	handler.ServeHTTP(w, httptest.NewRequest(http.MethodGet, "/apple/example/1.2.3.zip", nil))
+
+	if w.Code != http.StatusBadGateway {
+		t.Fatalf("status = %d, want 502; body: %s", w.Code, w.Body.String())
+	}
+	if len(store.files) != 0 {
+		t.Errorf("mismatched archive remained in storage: %v", store.files)
+	}
+	versionPURL := packageurl.MakeString("swift", "apple/example", "1.2.3")
+	cached, err := db.GetCachedArtifact(packageurl.MakeString("swift", "apple/example", ""), versionPURL, "example-1.2.3.zip")
+	if err != nil {
+		t.Fatalf("checking cache: %v", err)
+	}
+	if cached != nil {
+		t.Error("mismatched archive gained a cache record")
+	}
+}
+
+func TestSwiftSourceArchiveHeadRejectsCachedChecksumMismatch(t *testing.T) {
+	archive := []byte("cached archive")
+	expectedChecksum := sha256.Sum256([]byte("expected archive"))
+
+	upstream := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		_, _ = fmt.Fprintf(w, `{"id":"apple.example","version":"1.2.3","resources":[{"name":"source-archive","type":"application/zip","checksum":%q}]}`, hex.EncodeToString(expectedChecksum[:]))
+	}))
+	defer upstream.Close()
+
+	proxy, _, store, fetcher := setupTestProxy(t)
+	fetcher.artifact = &fetch.Artifact{
+		Body:        io.NopCloser(strings.NewReader(string(archive))),
+		Size:        int64(len(archive)),
+		ContentType: "application/zip",
+	}
+	cached, err := proxy.GetOrFetchArtifactFromURL(
+		context.Background(), "swift", "apple/example", "1.2.3", "example-1.2.3.zip", upstream.URL+"/apple/example/1.2.3.zip",
+	)
+	if err != nil {
+		t.Fatalf("seeding cache: %v", err)
+	}
+	_ = cached.Reader.Close()
+
+	handler := NewSwiftHandler(proxy, "https://proxy.example", upstream.URL).Routes()
+	w := httptest.NewRecorder()
+	handler.ServeHTTP(w, httptest.NewRequest(http.MethodHead, "/apple/example/1.2.3.zip", nil))
+
+	if w.Code != http.StatusBadGateway {
+		t.Fatalf("status = %d, want 502; body: %s", w.Code, w.Body.String())
+	}
+	if len(store.files) != 0 {
+		t.Errorf("cached mismatched archive remained in storage: %v", store.files)
+	}
+}
+
+func TestSwiftSourceArchiveRequiresReleaseMetadata(t *testing.T) {
+	upstream := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		http.Error(w, "unavailable", http.StatusServiceUnavailable)
+	}))
+	defer upstream.Close()
+
+	proxy, _, store, fetcher := setupTestProxy(t)
+	fetcher.artifact = &fetch.Artifact{
+		Body:        io.NopCloser(strings.NewReader("signed archive")),
+		ContentType: "application/zip",
+	}
+	handler := NewSwiftHandler(proxy, "https://proxy.example", upstream.URL).Routes()
+
+	w := httptest.NewRecorder()
+	handler.ServeHTTP(w, httptest.NewRequest(http.MethodGet, "/apple/example/1.2.3.zip", nil))
+
+	if w.Code != http.StatusBadGateway {
+		t.Fatalf("status = %d, want 502; body: %s", w.Code, w.Body.String())
+	}
+	if fetcher.fetchCalled {
+		t.Error("archive was fetched without release security metadata")
+	}
+	if len(store.files) != 0 {
+		t.Errorf("archive was cached without release security metadata: %v", store.files)
+	}
+}
+
+func TestSwiftSourceArchiveColdHeadSendsArchiveAccept(t *testing.T) {
+	checksum := strings.Repeat("a", sha256.Size*2)
+	var archiveAccept string
+	var archiveMethod string
+	upstream := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		switch r.URL.Path {
+		case "/apple/example/1.2.3":
+			w.Header().Set("Content-Type", "application/json")
+			_, _ = fmt.Fprintf(w, `{"id":"apple.example","version":"1.2.3","resources":[{"name":"source-archive","type":"application/zip","checksum":%q}]}`, checksum)
+		case "/apple/example/1.2.3.zip":
+			archiveMethod = r.Method
+			archiveAccept = r.Header.Get("Accept")
+			w.Header().Set("Content-Length", "123")
+		default:
+			http.NotFound(w, r)
+		}
+	}))
+	defer upstream.Close()
+
+	proxy, _, _, _ := setupTestProxy(t)
+	proxy.HTTPClient = upstream.Client()
+	handler := NewSwiftHandler(proxy, "https://proxy.example", upstream.URL).Routes()
+
+	w := httptest.NewRecorder()
+	handler.ServeHTTP(w, httptest.NewRequest(http.MethodHead, "/apple/example/1.2.3.zip", nil))
+
+	if w.Code != http.StatusOK {
+		t.Fatalf("status = %d, want 200; body: %s", w.Code, w.Body.String())
+	}
+	if archiveMethod != http.MethodHead {
+		t.Errorf("upstream method = %q, want HEAD", archiveMethod)
+	}
+	if archiveAccept != swiftAcceptArchive {
+		t.Errorf("upstream Accept = %q, want %q", archiveAccept, swiftAcceptArchive)
+	}
+	if got := w.Header().Get("Content-Length"); got != "123" {
+		t.Errorf("Content-Length = %q, want 123", got)
 	}
 }
 

--- a/internal/handler/swift_test.go
+++ b/internal/handler/swift_test.go
@@ -33,7 +33,7 @@ func TestSwiftPackageReleasesRewritesRegistryURLs(t *testing.T) {
 
 	proxy, _, _, _ := setupTestProxy(t)
 	handler := NewSwiftHandler(proxy, "https://proxy.example", upstream.URL+"/registry").Routes()
-	req := httptest.NewRequest(http.MethodGet, "/apple/swift-argument-parser", nil)
+	req := httptest.NewRequest(http.MethodGet, "/APPLE/SWIFT-ARGUMENT-PARSER", nil)
 	req.Header.Set("Accept", swiftAcceptJSON)
 	w := httptest.NewRecorder()
 	handler.ServeHTTP(w, req)
@@ -83,7 +83,7 @@ func TestSwiftReleaseMetadataSupportsJSONExtensionAndHead(t *testing.T) {
 	handler := NewSwiftHandler(proxy, "https://proxy.example", upstream.URL+"/registry").Routes()
 
 	for _, method := range []string{http.MethodGet, http.MethodHead} {
-		req := httptest.NewRequest(method, "/apple/example/1.2.3.json", nil)
+		req := httptest.NewRequest(method, "/APPLE/EXAMPLE/1.2.3.json", nil)
 		w := httptest.NewRecorder()
 		handler.ServeHTTP(w, req)
 		if w.Code != http.StatusOK {
@@ -121,7 +121,7 @@ func TestSwiftManifestProxiesQueryAndRewritesLinks(t *testing.T) {
 
 	proxy, _, _, _ := setupTestProxy(t)
 	handler := NewSwiftHandler(proxy, "https://proxy.example", upstream.URL+"/registry").Routes()
-	req := httptest.NewRequest(http.MethodGet, "/apple/example/1.2.3/Package.swift?swift-version=5.9", nil)
+	req := httptest.NewRequest(http.MethodGet, "/APPLE/EXAMPLE/1.2.3/Package.swift?swift-version=5.9", nil)
 	req.Header.Set("Accept", swiftAcceptManifest)
 	w := httptest.NewRecorder()
 	handler.ServeHTTP(w, req)
@@ -268,6 +268,65 @@ func TestSwiftSourceArchiveRejectsChecksumMismatch(t *testing.T) {
 	}
 	if cached != nil {
 		t.Error("mismatched archive gained a cache record")
+	}
+}
+
+func TestSwiftSourceArchiveCanonicalizesPackageIdentity(t *testing.T) {
+	archive := []byte("swift source archive")
+	checksumBytes := sha256.Sum256(archive)
+	checksum := hex.EncodeToString(checksumBytes[:])
+	var metadataPaths []string
+
+	upstream := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		metadataPaths = append(metadataPaths, r.URL.Path)
+		w.Header().Set("Content-Type", "application/json")
+		_, _ = fmt.Fprintf(w, `{"id":"apple.example","version":"1.2.3","resources":[{"name":"source-archive","type":"application/zip","checksum":%q}]}`, checksum)
+	}))
+	defer upstream.Close()
+
+	proxy, db, store, fetcher := setupTestProxy(t)
+	handler := NewSwiftHandler(proxy, "https://proxy.example", upstream.URL).Routes()
+	requestArchive := func(path string) {
+		fetcher.artifact = &fetch.Artifact{
+			Body:        io.NopCloser(strings.NewReader(string(archive))),
+			Size:        int64(len(archive)),
+			ContentType: "application/zip",
+		}
+		w := httptest.NewRecorder()
+		handler.ServeHTTP(w, httptest.NewRequest(http.MethodGet, path, nil))
+		if w.Code != http.StatusOK {
+			t.Fatalf("GET %s status = %d, want 200; body: %s", path, w.Code, w.Body.String())
+		}
+	}
+
+	requestArchive("/apple/example/1.2.3.zip")
+	requestArchive("/APPLE/EXAMPLE/1.2.3.zip")
+
+	if len(store.files) != 1 {
+		t.Errorf("cached files = %d, want 1", len(store.files))
+	}
+	for _, path := range metadataPaths {
+		if path != "/apple/example/1.2.3" {
+			t.Errorf("metadata path = %q, want canonical lowercase path", path)
+		}
+	}
+
+	canonicalPURL := packageurl.MakeString("swift", "apple/example", "")
+	canonical, err := db.GetPackageByPURL(canonicalPURL)
+	if err != nil {
+		t.Fatalf("getting canonical package: %v", err)
+	}
+	if canonical == nil {
+		t.Fatalf("canonical package %q not found", canonicalPURL)
+	}
+
+	nonCanonicalPURL := packageurl.MakeString("swift", "APPLE/EXAMPLE", "")
+	nonCanonical, err := db.GetPackageByPURL(nonCanonicalPURL)
+	if err != nil {
+		t.Fatalf("getting non-canonical package: %v", err)
+	}
+	if nonCanonical != nil {
+		t.Errorf("non-canonical package %q was cached", nonCanonicalPURL)
 	}
 }
 

--- a/internal/packageurl/packageurl.go
+++ b/internal/packageurl/packageurl.go
@@ -7,19 +7,48 @@ import (
 	"github.com/git-pkgs/purl"
 )
 
-// Make constructs a package URL, including the namespace required by Swift
-// registry package identifiers such as apple/swift-argument-parser.
+// Make constructs a package URL from an ecosystem-native package name.
 func Make(ecosystem, name, version string) *purl.PURL {
-	if purl.NormalizeEcosystem(ecosystem) == "swift" {
-		if split := strings.LastIndexByte(name, '/'); split > 0 && split < len(name)-1 {
-			return purl.New("swift", name[:split], name[split+1:], version, nil)
-		}
-	}
-
 	return purl.MakePURL(ecosystem, name, version)
 }
 
-// MakeString constructs a package URL string.
+// MakeString constructs a package URL string. It returns an empty string when
+// the package identity cannot be represented as a PURL.
 func MakeString(ecosystem, name, version string) string {
-	return Make(ecosystem, name, version).String()
+	return purl.MakePURLString(ecosystem, name, version)
+}
+
+// MakeCacheStrings returns package and version PURLs suitable for artifact
+// cache records. Swift registry identities use an explicit generic PURL until
+// their source repository has been resolved.
+func MakeCacheStrings(ecosystem, name, version, registryURL string) (packagePURL, versionPURL string) {
+	if pkg := Make(ecosystem, name, ""); pkg != nil {
+		return pkg.String(), pkg.WithVersion(version).String()
+	}
+	if purl.NormalizeEcosystem(ecosystem) != "swift" {
+		return "", ""
+	}
+
+	identity, ok := swiftRegistryIdentity(name)
+	if !ok {
+		return "", ""
+	}
+
+	var qualifiers map[string]string
+	if registryURL != "" {
+		qualifiers = map[string]string{"repository_url": strings.TrimRight(registryURL, "/")}
+	}
+	pkg := purl.New("generic", "swift-registry", identity, "", qualifiers)
+	return pkg.String(), pkg.WithVersion(version).String()
+}
+
+func swiftRegistryIdentity(name string) (string, bool) {
+	scope, packageName, found := strings.Cut(name, "/")
+	if !found {
+		scope, packageName, found = strings.Cut(name, ".")
+	}
+	if !found || scope == "" || packageName == "" || strings.ContainsAny(packageName, "/.") {
+		return "", false
+	}
+	return strings.ToLower(scope) + "." + strings.ToLower(packageName), true
 }

--- a/internal/packageurl/packageurl.go
+++ b/internal/packageurl/packageurl.go
@@ -30,8 +30,10 @@ func WithVersionString(packagePURL, version string) string {
 
 // MakeCacheStrings returns package and version PURLs suitable for artifact
 // cache records. Swift registry identities use an explicit generic PURL until
-// their source repository has been resolved.
-func MakeCacheStrings(ecosystem, name, version, registryURL string) (packagePURL, versionPURL string) {
+// their source repository has been resolved. The result is independent of the
+// configured upstream so cache entries survive an upstream.swift change,
+// matching every other ecosystem.
+func MakeCacheStrings(ecosystem, name, version string) (packagePURL, versionPURL string) {
 	if pkg := Make(ecosystem, name, ""); pkg != nil {
 		return pkg.String(), pkg.WithVersion(version).String()
 	}
@@ -44,11 +46,7 @@ func MakeCacheStrings(ecosystem, name, version, registryURL string) (packagePURL
 		return "", ""
 	}
 
-	var qualifiers map[string]string
-	if registryURL != "" {
-		qualifiers = map[string]string{"repository_url": strings.TrimRight(registryURL, "/")}
-	}
-	pkg := purl.New("generic", "swift-registry", identity, "", qualifiers)
+	pkg := purl.New("generic", "swift-registry", identity, "", nil)
 	return pkg.String(), pkg.WithVersion(version).String()
 }
 

--- a/internal/packageurl/packageurl.go
+++ b/internal/packageurl/packageurl.go
@@ -18,6 +18,16 @@ func MakeString(ecosystem, name, version string) string {
 	return purl.MakePURLString(ecosystem, name, version)
 }
 
+// WithVersionString returns a package PURL with its version replaced. It
+// returns an empty string when packagePURL is invalid.
+func WithVersionString(packagePURL, version string) string {
+	pkg, err := purl.Parse(packagePURL)
+	if err != nil {
+		return ""
+	}
+	return pkg.WithVersion(version).String()
+}
+
 // MakeCacheStrings returns package and version PURLs suitable for artifact
 // cache records. Swift registry identities use an explicit generic PURL until
 // their source repository has been resolved.

--- a/internal/packageurl/packageurl.go
+++ b/internal/packageurl/packageurl.go
@@ -1,0 +1,25 @@
+// Package packageurl builds package URLs from ecosystem-native package names.
+package packageurl
+
+import (
+	"strings"
+
+	"github.com/git-pkgs/purl"
+)
+
+// Make constructs a package URL, including the namespace required by Swift
+// registry package identifiers such as apple/swift-argument-parser.
+func Make(ecosystem, name, version string) *purl.PURL {
+	if purl.NormalizeEcosystem(ecosystem) == "swift" {
+		if split := strings.LastIndexByte(name, '/'); split > 0 && split < len(name)-1 {
+			return purl.New("swift", name[:split], name[split+1:], version, nil)
+		}
+	}
+
+	return purl.MakePURL(ecosystem, name, version)
+}
+
+// MakeString constructs a package URL string.
+func MakeString(ecosystem, name, version string) string {
+	return Make(ecosystem, name, version).String()
+}

--- a/internal/packageurl/packageurl_test.go
+++ b/internal/packageurl/packageurl_test.go
@@ -38,31 +38,25 @@ func TestWithVersionStringPreservesQualifiers(t *testing.T) {
 }
 
 func TestMakeCacheStringsSwiftRegistryIdentity(t *testing.T) {
-	packagePURL, versionPURL := MakeCacheStrings(
-		"swift", "APPLE/EXAMPLE", "1.2.3", "https://tuist.dev/api/registry/swift/",
-	)
+	packagePURL, versionPURL := MakeCacheStrings("swift", "APPLE/EXAMPLE", "1.2.3")
 
-	wantPackage := "pkg:generic/swift-registry/apple.example?repository_url=https:%2F%2Ftuist.dev%2Fapi%2Fregistry%2Fswift"
+	wantPackage := "pkg:generic/swift-registry/apple.example"
 	if packagePURL != wantPackage {
 		t.Errorf("package PURL = %q, want %q", packagePURL, wantPackage)
 	}
-	wantVersion := "pkg:generic/swift-registry/apple.example@1.2.3?repository_url=https:%2F%2Ftuist.dev%2Fapi%2Fregistry%2Fswift"
+	wantVersion := "pkg:generic/swift-registry/apple.example@1.2.3"
 	if versionPURL != wantVersion {
 		t.Errorf("version PURL = %q, want %q", versionPURL, wantVersion)
 	}
 
-	dottedPackage, dottedVersion := MakeCacheStrings(
-		"swift", "apple.example", "1.2.3", "https://tuist.dev/api/registry/swift",
-	)
+	dottedPackage, dottedVersion := MakeCacheStrings("swift", "apple.example", "1.2.3")
 	if dottedPackage != packagePURL || dottedVersion != versionPURL {
 		t.Errorf("dotted identity cache PURLs = %q, %q; want %q, %q", dottedPackage, dottedVersion, packagePURL, versionPURL)
 	}
 }
 
 func TestMakeCacheStringsUsesSourcePURLWhenAvailable(t *testing.T) {
-	packagePURL, versionPURL := MakeCacheStrings(
-		"swift", "github.com/apple/swift-package-manager", "1.7.0", "https://tuist.dev/api/registry/swift",
-	)
+	packagePURL, versionPURL := MakeCacheStrings("swift", "github.com/apple/swift-package-manager", "1.7.0")
 
 	if packagePURL != "pkg:swift/github.com/apple/swift-package-manager" {
 		t.Errorf("package PURL = %q", packagePURL)

--- a/internal/packageurl/packageurl_test.go
+++ b/internal/packageurl/packageurl_test.go
@@ -2,19 +2,60 @@ package packageurl
 
 import "testing"
 
-func TestMakeStringSwiftNamespace(t *testing.T) {
-	got := MakeString("swift", "apple/swift-argument-parser", "1.8.2")
-	want := "pkg:swift/apple/swift-argument-parser@1.8.2"
+func TestMakeSwiftRegistryIdentityUnsupported(t *testing.T) {
+	identities := []string{"apple.swift-argument-parser", "apple/swift-argument-parser"}
+	for _, identity := range identities {
+		t.Run(identity, func(t *testing.T) {
+			if got := Make("swift", identity, "1.8.2"); got != nil {
+				t.Errorf("Make() = %q, want nil", got.String())
+			}
+			if got := MakeString("swift", identity, "1.8.2"); got != "" {
+				t.Errorf("MakeString() = %q, want empty string", got)
+			}
+		})
+	}
+}
+
+func TestMakeStringSwiftSourceCoordinate(t *testing.T) {
+	got := MakeString("swift", "github.com/apple/swift-package-manager", "1.7.0")
+	want := "pkg:swift/github.com/apple/swift-package-manager@1.7.0"
 	if got != want {
 		t.Errorf("MakeString() = %q, want %q", got, want)
 	}
 }
 
-func TestMakeStringSwiftNestedNamespace(t *testing.T) {
-	got := MakeString("swift", "github.com/apple/swift-package-manager", "1.7.0")
-	want := "pkg:swift/github.com/apple/swift-package-manager@1.7.0"
-	if got != want {
-		t.Errorf("MakeString() = %q, want %q", got, want)
+func TestMakeCacheStringsSwiftRegistryIdentity(t *testing.T) {
+	packagePURL, versionPURL := MakeCacheStrings(
+		"swift", "APPLE/EXAMPLE", "1.2.3", "https://tuist.dev/api/registry/swift/",
+	)
+
+	wantPackage := "pkg:generic/swift-registry/apple.example?repository_url=https:%2F%2Ftuist.dev%2Fapi%2Fregistry%2Fswift"
+	if packagePURL != wantPackage {
+		t.Errorf("package PURL = %q, want %q", packagePURL, wantPackage)
+	}
+	wantVersion := "pkg:generic/swift-registry/apple.example@1.2.3?repository_url=https:%2F%2Ftuist.dev%2Fapi%2Fregistry%2Fswift"
+	if versionPURL != wantVersion {
+		t.Errorf("version PURL = %q, want %q", versionPURL, wantVersion)
+	}
+
+	dottedPackage, dottedVersion := MakeCacheStrings(
+		"swift", "apple.example", "1.2.3", "https://tuist.dev/api/registry/swift",
+	)
+	if dottedPackage != packagePURL || dottedVersion != versionPURL {
+		t.Errorf("dotted identity cache PURLs = %q, %q; want %q, %q", dottedPackage, dottedVersion, packagePURL, versionPURL)
+	}
+}
+
+func TestMakeCacheStringsUsesSourcePURLWhenAvailable(t *testing.T) {
+	packagePURL, versionPURL := MakeCacheStrings(
+		"swift", "github.com/apple/swift-package-manager", "1.7.0", "https://tuist.dev/api/registry/swift",
+	)
+
+	if packagePURL != "pkg:swift/github.com/apple/swift-package-manager" {
+		t.Errorf("package PURL = %q", packagePURL)
+	}
+	if versionPURL != "pkg:swift/github.com/apple/swift-package-manager@1.7.0" {
+		t.Errorf("version PURL = %q", versionPURL)
 	}
 }
 

--- a/internal/packageurl/packageurl_test.go
+++ b/internal/packageurl/packageurl_test.go
@@ -24,6 +24,19 @@ func TestMakeStringSwiftSourceCoordinate(t *testing.T) {
 	}
 }
 
+func TestWithVersionStringPreservesQualifiers(t *testing.T) {
+	packagePURL := "pkg:generic/swift-registry/apple.example?repository_url=https:%2F%2Fold.example%2Fswift"
+	got := WithVersionString(packagePURL, "1.2.3")
+	want := "pkg:generic/swift-registry/apple.example@1.2.3?repository_url=https:%2F%2Fold.example%2Fswift"
+	if got != want {
+		t.Errorf("WithVersionString() = %q, want %q", got, want)
+	}
+
+	if got := WithVersionString("not a purl", "1.2.3"); got != "" {
+		t.Errorf("WithVersionString() = %q for invalid PURL, want empty string", got)
+	}
+}
+
 func TestMakeCacheStringsSwiftRegistryIdentity(t *testing.T) {
 	packagePURL, versionPURL := MakeCacheStrings(
 		"swift", "APPLE/EXAMPLE", "1.2.3", "https://tuist.dev/api/registry/swift/",

--- a/internal/packageurl/packageurl_test.go
+++ b/internal/packageurl/packageurl_test.go
@@ -1,0 +1,27 @@
+package packageurl
+
+import "testing"
+
+func TestMakeStringSwiftNamespace(t *testing.T) {
+	got := MakeString("swift", "apple/swift-argument-parser", "1.8.2")
+	want := "pkg:swift/apple/swift-argument-parser@1.8.2"
+	if got != want {
+		t.Errorf("MakeString() = %q, want %q", got, want)
+	}
+}
+
+func TestMakeStringSwiftNestedNamespace(t *testing.T) {
+	got := MakeString("swift", "github.com/apple/swift-package-manager", "1.7.0")
+	want := "pkg:swift/github.com/apple/swift-package-manager@1.7.0"
+	if got != want {
+		t.Errorf("MakeString() = %q, want %q", got, want)
+	}
+}
+
+func TestMakeStringDelegatesOtherEcosystems(t *testing.T) {
+	got := MakeString("npm", "@babel/core", "7.23.0")
+	want := "pkg:npm/%40babel/core@7.23.0"
+	if got != want {
+		t.Errorf("MakeString() = %q, want %q", got, want)
+	}
+}

--- a/internal/server/browse.go
+++ b/internal/server/browse.go
@@ -14,7 +14,6 @@ import (
 	"github.com/git-pkgs/magic"
 	"github.com/git-pkgs/proxy/internal/database"
 	"github.com/git-pkgs/proxy/internal/handler"
-	"github.com/git-pkgs/proxy/internal/packageurl"
 	"github.com/go-chi/chi/v5"
 )
 
@@ -226,7 +225,7 @@ func (s *Server) browseList(w http.ResponseWriter, r *http.Request, ecosystem, n
 	dirPath := r.URL.Query().Get("path")
 
 	// Get the artifact for this version
-	versionPURL := packageurl.MakeString(ecosystem, name, version)
+	versionPURL := s.cachePURLString(ecosystem, name, version)
 	artifacts, err := s.db.GetArtifactsByVersionPURL(versionPURL)
 	if err != nil {
 		notFound(w, "version not found")
@@ -313,7 +312,7 @@ func (s *Server) browseFile(w http.ResponseWriter, r *http.Request, ecosystem, n
 	}
 
 	// Get the artifact for this version
-	versionPURL := packageurl.MakeString(ecosystem, name, version)
+	versionPURL := s.cachePURLString(ecosystem, name, version)
 	artifacts, err := s.db.GetArtifactsByVersionPURL(versionPURL)
 	if err != nil {
 		notFound(w, "version not found")
@@ -534,8 +533,8 @@ type BrowseSourceData struct {
 // @Router /ui/api/compare/{ecosystem}/{name}/{fromVersion}/{toVersion} [get]
 func (s *Server) compareDiff(w http.ResponseWriter, r *http.Request, ecosystem, name, fromVersion, toVersion string) {
 	// Get artifacts for both versions
-	fromPURL := packageurl.MakeString(ecosystem, name, fromVersion)
-	toPURL := packageurl.MakeString(ecosystem, name, toVersion)
+	fromPURL := s.cachePURLString(ecosystem, name, fromVersion)
+	toPURL := s.cachePURLString(ecosystem, name, toVersion)
 
 	fromArtifacts, err := s.db.GetArtifactsByVersionPURL(fromPURL)
 	if err != nil || len(fromArtifacts) == 0 {

--- a/internal/server/browse.go
+++ b/internal/server/browse.go
@@ -14,7 +14,7 @@ import (
 	"github.com/git-pkgs/magic"
 	"github.com/git-pkgs/proxy/internal/database"
 	"github.com/git-pkgs/proxy/internal/handler"
-	"github.com/git-pkgs/purl"
+	"github.com/git-pkgs/proxy/internal/packageurl"
 	"github.com/go-chi/chi/v5"
 )
 
@@ -226,7 +226,7 @@ func (s *Server) browseList(w http.ResponseWriter, r *http.Request, ecosystem, n
 	dirPath := r.URL.Query().Get("path")
 
 	// Get the artifact for this version
-	versionPURL := purl.MakePURLString(ecosystem, name, version)
+	versionPURL := packageurl.MakeString(ecosystem, name, version)
 	artifacts, err := s.db.GetArtifactsByVersionPURL(versionPURL)
 	if err != nil {
 		notFound(w, "version not found")
@@ -313,7 +313,7 @@ func (s *Server) browseFile(w http.ResponseWriter, r *http.Request, ecosystem, n
 	}
 
 	// Get the artifact for this version
-	versionPURL := purl.MakePURLString(ecosystem, name, version)
+	versionPURL := packageurl.MakeString(ecosystem, name, version)
 	artifacts, err := s.db.GetArtifactsByVersionPURL(versionPURL)
 	if err != nil {
 		notFound(w, "version not found")
@@ -534,8 +534,8 @@ type BrowseSourceData struct {
 // @Router /ui/api/compare/{ecosystem}/{name}/{fromVersion}/{toVersion} [get]
 func (s *Server) compareDiff(w http.ResponseWriter, r *http.Request, ecosystem, name, fromVersion, toVersion string) {
 	// Get artifacts for both versions
-	fromPURL := purl.MakePURLString(ecosystem, name, fromVersion)
-	toPURL := purl.MakePURLString(ecosystem, name, toVersion)
+	fromPURL := packageurl.MakeString(ecosystem, name, fromVersion)
+	toPURL := packageurl.MakeString(ecosystem, name, toVersion)
 
 	fromArtifacts, err := s.db.GetArtifactsByVersionPURL(fromPURL)
 	if err != nil || len(fromArtifacts) == 0 {

--- a/internal/server/browse.go
+++ b/internal/server/browse.go
@@ -225,7 +225,7 @@ func (s *Server) browseList(w http.ResponseWriter, r *http.Request, ecosystem, n
 	dirPath := r.URL.Query().Get("path")
 
 	// Get the artifact for this version
-	versionPURL := s.cachePURLString(ecosystem, name, version)
+	versionPURL := s.cachedVersionPURL(ecosystem, name, version)
 	artifacts, err := s.db.GetArtifactsByVersionPURL(versionPURL)
 	if err != nil {
 		notFound(w, "version not found")
@@ -312,7 +312,7 @@ func (s *Server) browseFile(w http.ResponseWriter, r *http.Request, ecosystem, n
 	}
 
 	// Get the artifact for this version
-	versionPURL := s.cachePURLString(ecosystem, name, version)
+	versionPURL := s.cachedVersionPURL(ecosystem, name, version)
 	artifacts, err := s.db.GetArtifactsByVersionPURL(versionPURL)
 	if err != nil {
 		notFound(w, "version not found")
@@ -533,8 +533,8 @@ type BrowseSourceData struct {
 // @Router /ui/api/compare/{ecosystem}/{name}/{fromVersion}/{toVersion} [get]
 func (s *Server) compareDiff(w http.ResponseWriter, r *http.Request, ecosystem, name, fromVersion, toVersion string) {
 	// Get artifacts for both versions
-	fromPURL := s.cachePURLString(ecosystem, name, fromVersion)
-	toPURL := s.cachePURLString(ecosystem, name, toVersion)
+	fromPURL := s.cachedVersionPURL(ecosystem, name, fromVersion)
+	toPURL := s.cachedVersionPURL(ecosystem, name, toVersion)
 
 	fromArtifacts, err := s.db.GetArtifactsByVersionPURL(fromPURL)
 	if err != nil || len(fromArtifacts) == 0 {

--- a/internal/server/dashboard.go
+++ b/internal/server/dashboard.go
@@ -2,6 +2,7 @@ package server
 
 import (
 	"html/template"
+	"strings"
 
 	"github.com/git-pkgs/proxy/internal/database"
 )
@@ -141,6 +142,7 @@ func supportedEcosystems() []string {
 		"pub",
 		"pypi",
 		"rpm",
+		"swift",
 	}
 }
 
@@ -185,6 +187,8 @@ func ecosystemBadgeClasses(ecosystem string) string {
 		return base + " bg-slate-100 text-slate-700 dark:bg-slate-800 dark:text-slate-300"
 	case "julia":
 		return base + " bg-emerald-100 text-emerald-700 dark:bg-emerald-900/50 dark:text-emerald-300"
+	case "swift":
+		return base + " bg-orange-100 text-orange-700 dark:bg-orange-900/50 dark:text-orange-300"
 	case "oci":
 		return base + " bg-sky-100 text-sky-700 dark:bg-sky-900/50 dark:text-sky-300"
 	case "deb":
@@ -199,6 +203,11 @@ func ecosystemBadgeClasses(ecosystem string) string {
 }
 
 func getRegistryConfigs(baseURL string) []RegistryConfig {
+	swiftInsecureFlag := ""
+	if strings.HasPrefix(strings.ToLower(baseURL), "http://") {
+		swiftInsecureFlag = "--allow-insecure-http "
+	}
+
 	return []RegistryConfig{
 		{
 			ID:       "npm",
@@ -399,6 +408,15 @@ local({
 <p class="config-note">Or inside a running session:</p>
 <pre><code>ENV["JULIA_PKG_SERVER"] = "` + baseURL + `/julia"
 using Pkg; Pkg.update()</code></pre>`),
+		},
+		{
+			ID:       "swift",
+			Name:     "Swift Package Registry",
+			Language: "Swift",
+			Endpoint: "/swift/",
+			Instructions: template.HTML(`<p class="config-note">Configure SwiftPM to use the proxy for this project:</p>
+<pre><code>swift package-registry set ` + swiftInsecureFlag + baseURL + `/swift</code></pre>
+<p class="config-note">Use scoped package identifiers in Package.swift, for example <code>apple.swift-argument-parser</code>.</p>`),
 		},
 		{
 			ID:       "oci",

--- a/internal/server/server.go
+++ b/internal/server/server.go
@@ -885,7 +885,7 @@ func (s *Server) showVersion(w http.ResponseWriter, r *http.Request, ecosystem, 
 		return
 	}
 
-	versionPURL := s.cachePURLString(ecosystem, name, version)
+	versionPURL := packageurl.WithVersionString(pkg.PURL, version)
 	ver, err := s.db.GetVersionByPURL(versionPURL)
 	if err != nil || ver == nil {
 		s.logger.Error("failed to get version", "error", err)
@@ -927,19 +927,12 @@ func (s *Server) showVersion(w http.ResponseWriter, r *http.Request, ecosystem, 
 	}
 }
 
-func (s *Server) cachePURLString(ecosystem, name, version string) string {
-	registryURL := ""
-	if s.cfg != nil {
-		registryURL = s.cfg.Upstream.Swift
+func (s *Server) cachedVersionPURL(ecosystem, name, version string) string {
+	pkg, err := s.db.GetPackageByEcosystemName(ecosystem, name)
+	if err != nil || pkg == nil {
+		return ""
 	}
-	if registryURL == "" {
-		registryURL = config.DefaultSwiftUpstream
-	}
-	packagePURL, versionPURL := packageurl.MakeCacheStrings(ecosystem, name, version, registryURL)
-	if version == "" {
-		return packagePURL
-	}
-	return versionPURL
+	return packageurl.WithVersionString(pkg.PURL, version)
 }
 
 func (s *Server) showBrowseSource(w http.ResponseWriter, r *http.Request, ecosystem, name, version string) {

--- a/internal/server/server.go
+++ b/internal/server/server.go
@@ -885,7 +885,7 @@ func (s *Server) showVersion(w http.ResponseWriter, r *http.Request, ecosystem, 
 		return
 	}
 
-	versionPURL := packageurl.MakeString(ecosystem, name, version)
+	versionPURL := s.cachePURLString(ecosystem, name, version)
 	ver, err := s.db.GetVersionByPURL(versionPURL)
 	if err != nil || ver == nil {
 		s.logger.Error("failed to get version", "error", err)
@@ -925,6 +925,21 @@ func (s *Server) showVersion(w http.ResponseWriter, r *http.Request, ecosystem, 
 	if err := s.templates.Render(w, "version_show", data); err != nil {
 		s.logger.Error("failed to render version show", "error", err)
 	}
+}
+
+func (s *Server) cachePURLString(ecosystem, name, version string) string {
+	registryURL := ""
+	if s.cfg != nil {
+		registryURL = s.cfg.Upstream.Swift
+	}
+	if registryURL == "" {
+		registryURL = config.DefaultSwiftUpstream
+	}
+	packagePURL, versionPURL := packageurl.MakeCacheStrings(ecosystem, name, version, registryURL)
+	if version == "" {
+		return packagePURL
+	}
+	return versionPURL
 }
 
 func (s *Server) showBrowseSource(w http.ResponseWriter, r *http.Request, ecosystem, name, version string) {

--- a/internal/server/server.go
+++ b/internal/server/server.go
@@ -16,6 +16,7 @@
 //   - /conda/*    - Conda/Anaconda protocol
 //   - /cran/*     - CRAN (R) protocol
 //   - /julia/*    - Julia Pkg server protocol
+//   - /swift/*    - Swift Package Registry protocol
 //   - /v2/*       - OCI/Docker container registry protocol
 //   - /apk/*      - Alpine APK repository protocol
 //   - /debian/*   - Debian/APT repository protocol
@@ -71,8 +72,8 @@ import (
 	upstreamhttp "github.com/git-pkgs/proxy/internal/httpclient"
 	"github.com/git-pkgs/proxy/internal/metrics"
 	"github.com/git-pkgs/proxy/internal/mirror"
+	"github.com/git-pkgs/proxy/internal/packageurl"
 	"github.com/git-pkgs/proxy/internal/storage"
-	"github.com/git-pkgs/purl"
 	"github.com/git-pkgs/registries/fetch"
 	"github.com/git-pkgs/registries/safehttp"
 	"github.com/git-pkgs/spdx"
@@ -302,6 +303,7 @@ func (s *Server) serve(listener net.Listener) error {
 	condaHandler := handler.NewCondaHandlerWithUpstream(proxy, s.cfg.BaseURL, s.cfg.Upstream.Conda)
 	cranHandler := handler.NewCRANHandlerWithUpstream(proxy, s.cfg.BaseURL, s.cfg.Upstream.CRAN)
 	juliaHandler := handler.NewJuliaHandlerWithUpstream(proxy, s.cfg.Upstream.Julia)
+	swiftHandler := handler.NewSwiftHandler(proxy, s.cfg.BaseURL, s.cfg.Upstream.Swift)
 	containerHandler := handler.NewContainerHandlerWithRegistry(
 		proxy,
 		s.cfg.BaseURL,
@@ -328,6 +330,7 @@ func (s *Server) serve(listener net.Listener) error {
 	r.Mount("/conda", http.StripPrefix("/conda", condaHandler.Routes()))
 	r.Mount("/cran", http.StripPrefix("/cran", cranHandler.Routes()))
 	r.Mount("/julia", http.StripPrefix("/julia", juliaHandler.Routes()))
+	r.Mount("/swift", http.StripPrefix("/swift", swiftHandler.Routes()))
 	r.Mount("/v2", http.StripPrefix("/v2", containerHandler.Routes()))
 	r.Mount("/helm", http.StripPrefix("/helm", helmHandler.Routes()))
 	r.Mount("/apk", http.StripPrefix("/apk", apkHandler.Routes()))
@@ -882,7 +885,7 @@ func (s *Server) showVersion(w http.ResponseWriter, r *http.Request, ecosystem, 
 		return
 	}
 
-	versionPURL := purl.MakePURLString(ecosystem, name, version)
+	versionPURL := packageurl.MakeString(ecosystem, name, version)
 	ver, err := s.db.GetVersionByPURL(versionPURL)
 	if err != nil || ver == nil {
 		s.logger.Error("failed to get version", "error", err)

--- a/internal/server/server_test.go
+++ b/internal/server/server_test.go
@@ -89,6 +89,7 @@ func newTestServer(t *testing.T) *testServer {
 	goHandler := handler.NewGoHandler(proxy, cfg.BaseURL)
 	pypiHandler := handler.NewPyPIHandler(proxy, cfg.BaseURL)
 	gradleHandler := handler.NewGradleBuildCacheHandler(proxy)
+	swiftHandler := handler.NewSwiftHandler(proxy, cfg.BaseURL, cfg.Upstream.Swift)
 
 	r.Mount("/npm", http.StripPrefix("/npm", npmHandler.Routes()))
 	r.Mount("/cargo", http.StripPrefix("/cargo", cargoHandler.Routes()))
@@ -96,6 +97,7 @@ func newTestServer(t *testing.T) *testServer {
 	r.Mount("/go", http.StripPrefix("/go", goHandler.Routes()))
 	r.Mount("/pypi", http.StripPrefix("/pypi", pypiHandler.Routes()))
 	r.Mount("/gradle", http.StripPrefix("/gradle", gradleHandler.Routes()))
+	r.Mount("/swift", http.StripPrefix("/swift", swiftHandler.Routes()))
 
 	hc, err := newHealthCache(store, "30s", logger)
 	if err != nil {
@@ -475,8 +477,24 @@ func TestDashboard(t *testing.T) {
 	if !strings.Contains(body, ">debian<") {
 		t.Error("dashboard should show debian in supported ecosystems")
 	}
+	if !strings.Contains(body, ">swift<") {
+		t.Error("dashboard should show swift in supported ecosystems")
+	}
 	if !strings.Contains(body, "/openapi.json") {
 		t.Error("page should link to the OpenAPI JSON spec")
+	}
+}
+
+func TestSwiftHandlerMounted(t *testing.T) {
+	ts := newTestServer(t)
+	defer ts.close()
+
+	req := httptest.NewRequest(http.MethodPut, "/swift/apple/example/1.2.3", strings.NewReader("ignored"))
+	w := httptest.NewRecorder()
+	ts.handler.ServeHTTP(w, req)
+
+	if w.Code != http.StatusMethodNotAllowed {
+		t.Fatalf("status = %d, want 405; body: %s", w.Code, w.Body.String())
 	}
 }
 

--- a/internal/server/server_test.go
+++ b/internal/server/server_test.go
@@ -498,6 +498,16 @@ func TestSwiftHandlerMounted(t *testing.T) {
 	}
 }
 
+func TestSwiftCachePURLString(t *testing.T) {
+	s := &Server{}
+
+	got := s.cachePURLString("swift", "apple/example", "1.2.3")
+	want := "pkg:generic/swift-registry/apple.example@1.2.3?repository_url=https:%2F%2Ftuist.dev%2Fapi%2Fregistry%2Fswift"
+	if got != want {
+		t.Errorf("cachePURLString() = %q, want %q", got, want)
+	}
+}
+
 func min(a, b int) int {
 	if a < b {
 		return a

--- a/internal/server/server_test.go
+++ b/internal/server/server_test.go
@@ -498,13 +498,29 @@ func TestSwiftHandlerMounted(t *testing.T) {
 	}
 }
 
-func TestSwiftCachePURLString(t *testing.T) {
-	s := &Server{}
+func TestSwiftCachedVersionPURLUsesStoredPackagePURL(t *testing.T) {
+	ts := newTestServer(t)
+	defer ts.close()
 
-	got := s.cachePURLString("swift", "apple/example", "1.2.3")
-	want := "pkg:generic/swift-registry/apple.example@1.2.3?repository_url=https:%2F%2Ftuist.dev%2Fapi%2Fregistry%2Fswift"
+	packagePURL := "pkg:generic/swift-registry/apple.example?repository_url=https:%2F%2Fold.example%2Fswift"
+	if err := ts.db.UpsertPackage(&database.Package{
+		PURL:      packagePURL,
+		Ecosystem: "swift",
+		Name:      "apple/example",
+	}); err != nil {
+		t.Fatalf("failed to upsert package: %v", err)
+	}
+
+	s := &Server{
+		cfg: &config.Config{
+			Upstream: config.UpstreamConfig{Swift: "https://new.example/swift"},
+		},
+		db: ts.db,
+	}
+	got := s.cachedVersionPURL("swift", "apple/example", "1.2.3")
+	want := "pkg:generic/swift-registry/apple.example@1.2.3?repository_url=https:%2F%2Fold.example%2Fswift"
 	if got != want {
-		t.Errorf("cachePURLString() = %q, want %q", got, want)
+		t.Errorf("cachedVersionPURL() = %q, want %q", got, want)
 	}
 }
 

--- a/internal/server/templates_test.go
+++ b/internal/server/templates_test.go
@@ -519,6 +519,20 @@ func TestEcosystemBadgeLabel(t *testing.T) {
 	}
 }
 
+func TestSwiftRegistryInstructionsAllowLocalHTTP(t *testing.T) {
+	registries := getRegistryConfigs("http://localhost:8080")
+	for _, registry := range registries {
+		if registry.ID != "swift" {
+			continue
+		}
+		if !strings.Contains(string(registry.Instructions), "--allow-insecure-http") {
+			t.Error("Swift HTTP instructions do not allow the insecure local registry")
+		}
+		return
+	}
+	t.Fatal("Swift registry instructions not found")
+}
+
 func TestEcosystemBadgeClasses(t *testing.T) {
 	// Every supported ecosystem should return a non-empty class string
 	ecosystems := supportedEcosystems()


### PR DESCRIPTION
Add read-only Swift Package Registry v1 proxying for release lists, release metadata, manifests, identifier lookup, and source archives.

Registry URLs are rewritten through the proxy, and source archives are cached while checksum and signing headers are preserved. The Swift upstream is configurable, with the Tuist registry as the default.

Publishing remains unsupported and returns 405 Method Not Allowed.