### PR TITLE
feat: add Helm repository proxy support

### DIFF
--- a/README.md
+++ b/README.md
@@ -392,7 +392,7 @@ upstream:
 ```
 
 ```bash
-helm pull oci://localhost:8080/upstream/ghcr/owner/charts/mychart --version 1.0.0
+helm pull oci://localhost:8080/upstream/ghcr/owner/charts/mychart --version 1.0.0 --plain-http
 ```
 
 ### Debian / APT

--- a/README.md
+++ b/README.md
@@ -362,6 +362,39 @@ Or pull images directly:
 docker pull localhost:8080/library/nginx:latest
 ```
 
+### Helm
+
+Configure each HTTP chart repository with a name, then add the matching proxy
+URL to Helm:
+
+```yaml
+upstream:
+  helm:
+    bitnami: "https://charts.bitnami.com/bitnami"
+```
+
+```bash
+helm repo add bitnami http://localhost:8080/helm/bitnami
+helm repo update
+helm pull bitnami/nginx
+```
+
+The proxy caches `index.yaml` using the normal metadata-cache settings and
+caches chart archives after verifying their SHA-256 digest from the index.
+
+For charts stored in an OCI registry, configure a named OCI upstream and add
+the reserved `upstream/{name}` prefix to the chart reference:
+
+```yaml
+upstream:
+  oci:
+    ghcr: "https://ghcr.io"
+```
+
+```bash
+helm pull oci://localhost:8080/upstream/ghcr/owner/charts/mychart --version 1.0.0
+```
+
 ### Debian / APT
 
 Configure APT to use the proxy in `/etc/apt/sources.list.d/proxy.list`:
@@ -631,6 +664,7 @@ Recently cached:
 | `GET /conda/*` | Conda/Anaconda protocol |
 | `GET /cran/*` | CRAN (R) protocol |
 | `GET /julia/*` | Julia Pkg server protocol |
+| `GET /helm/{repository}/*` | HTTP Helm chart repository protocol |
 | `GET /v2/*` | OCI/Docker registry protocol |
 | `GET /debian/*` | Debian/APT repository protocol |
 | `GET /rpm/*` | RPM/Yum repository protocol |

--- a/config.example.yaml
+++ b/config.example.yaml
@@ -98,6 +98,15 @@ upstream:
   # Debian/APT repository URL (used by /debian endpoint)
   debian: "http://deb.debian.org/debian"
 
+  # Named HTTP Helm chart repositories (used by /helm/{name}/)
+  # helm:
+  #   bitnami: "https://charts.bitnami.com/bitnami"
+
+  # Named OCI registries. Use the upstream/{name}/ repository prefix, e.g.
+  # oci://proxy.example.com/upstream/ghcr/owner/chart.
+  # oci:
+  #   ghcr: "https://ghcr.io"
+
   # Authentication for upstream registries
   # Keys are absolute URL scopes. Scheme, host, effective port, and path
   # segment boundaries must match; the longest matching scope wins.

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -119,7 +119,25 @@ upstream:
   gradle_plugin_portal: "https://plugins.gradle.org/m2"
   cargo: "https://index.crates.io"
   cargo_download: "https://static.crates.io/crates"
+
+  # Named HTTP Helm chart repositories, served at /helm/{name}/.
+  helm:
+    bitnami: "https://charts.bitnami.com/bitnami"
+
+  # Named OCI registries. Select one with the repository prefix
+  # upstream/{name}/, e.g. oci://proxy.example.com/upstream/ghcr/owner/chart.
+  oci:
+    ghcr: "https://ghcr.io"
 ```
+
+Helm HTTP repositories are read-only. The proxy fetches and rewrites each
+repository's `index.yaml` so chart archives are downloaded through the proxy.
+Chart archives are retained only when their SHA-256 digest matches the digest
+listed in the index. Relative and absolute chart URLs are both supported.
+
+Named OCI registries preserve the existing unprefixed Docker Hub mirror. A
+reference such as `oci://proxy.example.com/upstream/ghcr/owner/chart` is sent
+to the registry configured as `ghcr` with `owner/chart` as its repository.
 
 ## Authentication
 

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -138,6 +138,8 @@ listed in the index. Relative and absolute chart URLs are both supported.
 Named OCI registries preserve the existing unprefixed Docker Hub mirror. A
 reference such as `oci://proxy.example.com/upstream/ghcr/owner/chart` is sent
 to the registry configured as `ghcr` with `owner/chart` as its repository.
+When the proxy uses plain HTTP (for example `localhost:8080`), pass
+`--plain-http` to Helm OCI commands.
 
 ## Authentication
 

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -309,6 +309,16 @@ type UpstreamConfig struct {
 	// Default: http://deb.debian.org/debian
 	Debian string `json:"debian" yaml:"debian"`
 
+	// Helm maps repository names to HTTP Helm chart repository URLs.
+	// Requests use /helm/{name}/index.yaml and chart URLs in the index are
+	// rewritten to the same named proxy endpoint.
+	Helm map[string]string `json:"helm" yaml:"helm"`
+
+	// OCI maps names to OCI registry URLs. Requests to a named registry use
+	// the repository prefix upstream/{name}/, for example
+	// oci://proxy.example.com/upstream/ghcr/owner/chart.
+	OCI map[string]string `json:"oci" yaml:"oci"`
+
 	// Auth configures authentication for upstream registries.
 	// Keys are absolute URL scopes matched by scheme, host, effective port,
 	// and path-segment prefix.
@@ -347,6 +357,24 @@ func (u *UpstreamConfig) Validate() error {
 	for pattern := range u.Auth {
 		if _, err := parseAuthURL(pattern); err != nil {
 			return fmt.Errorf("invalid upstream.auth URL %q: %w", pattern, err)
+		}
+	}
+	if err := validateNamedUpstreams("upstream.helm", u.Helm); err != nil {
+		return err
+	}
+	if err := validateNamedUpstreams("upstream.oci", u.OCI); err != nil {
+		return err
+	}
+	return nil
+}
+
+func validateNamedUpstreams(field string, upstreams map[string]string) error {
+	for name, upstreamURL := range upstreams {
+		if name == "" || name == "." || name == ".." || strings.ContainsAny(name, `/\\`) {
+			return fmt.Errorf("invalid %s name %q", field, name)
+		}
+		if err := validateAbsoluteURL(field+"."+name, upstreamURL); err != nil {
+			return err
 		}
 	}
 	return nil

--- a/internal/config/config_test.go
+++ b/internal/config/config_test.go
@@ -866,3 +866,44 @@ func TestValidateUpstreamAuthURLs(t *testing.T) {
 		}
 	})
 }
+
+func TestValidateNamedUpstreams(t *testing.T) {
+	tests := []struct {
+		name    string
+		modify  func(*Config)
+		wantErr bool
+	}{
+		{
+			name: "valid Helm and OCI upstreams",
+			modify: func(cfg *Config) {
+				cfg.Upstream.Helm = map[string]string{"bitnami": "https://charts.bitnami.com/bitnami"}
+				cfg.Upstream.OCI = map[string]string{"ghcr": "https://ghcr.io"}
+			},
+		},
+		{
+			name: "Helm upstream name contains path separator",
+			modify: func(cfg *Config) {
+				cfg.Upstream.Helm = map[string]string{"team/charts": "https://charts.example.com"}
+			},
+			wantErr: true,
+		},
+		{
+			name: "OCI upstream URL is not absolute",
+			modify: func(cfg *Config) {
+				cfg.Upstream.OCI = map[string]string{"private": "registry.example.com"}
+			},
+			wantErr: true,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			cfg := Default()
+			tt.modify(cfg)
+			err := cfg.Validate()
+			if (err != nil) != tt.wantErr {
+				t.Errorf("Validate() error = %v, wantErr %t", err, tt.wantErr)
+			}
+		})
+	}
+}

--- a/internal/handler/container.go
+++ b/internal/handler/container.go
@@ -11,28 +11,40 @@ import (
 )
 
 const (
-	dockerHubRegistry  = "https://registry-1.docker.io"
-	blobMatchCount     = 3 // full match + name + digest
-	manifestMatchCount = 3 // full match + name + reference
-	tagsListMatchCount = 2 // full match + name
+	dockerHubRegistry     = "https://registry-1.docker.io"
+	blobMatchCount        = 3 // full match + name + digest
+	manifestMatchCount    = 3 // full match + name + reference
+	tagsListMatchCount    = 2 // full match + name
+	registrySelectorParts = 3 // upstream + name + repository
 )
 
 // ContainerHandler handles OCI/Docker container registry protocol requests.
 // It implements the OCI Distribution Spec for pulling images.
 // Reference: https://github.com/opencontainers/distribution-spec/blob/main/spec.md
 type ContainerHandler struct {
-	proxy       *Proxy
-	registryURL string
-	proxyURL    string
+	proxy           *Proxy
+	registryURL     string
+	proxyURL        string
+	namedRegistries map[string]string
 }
 
 // NewContainerHandler creates a new container registry protocol handler.
-func NewContainerHandler(proxy *Proxy, proxyURL string) *ContainerHandler {
-	return &ContainerHandler{
+// Named registries are selected with the repository prefix
+// upstream/{name}/, leaving unprefixed requests compatible with the Docker Hub
+// mirror behavior.
+func NewContainerHandler(proxy *Proxy, proxyURL string, namedRegistries ...map[string]string) *ContainerHandler {
+	h := &ContainerHandler{
 		proxy:       proxy,
 		registryURL: dockerHubRegistry,
 		proxyURL:    strings.TrimSuffix(proxyURL, "/"),
 	}
+	if len(namedRegistries) > 0 {
+		h.namedRegistries = make(map[string]string, len(namedRegistries[0]))
+		for name, registryURL := range namedRegistries[0] {
+			h.namedRegistries[name] = strings.TrimSuffix(registryURL, "/")
+		}
+	}
+	return h
 }
 
 // Routes returns the HTTP handler for container registry requests.
@@ -85,10 +97,16 @@ func (h *ContainerHandler) handleBlobDownload(w http.ResponseWriter, r *http.Req
 		return
 	}
 
-	h.proxy.Logger.Info("container blob request", "name", name, "digest", digest)
+	registryURL, upstreamName, cacheName, ok := h.registryForName(name)
+	if !ok {
+		h.containerError(w, http.StatusNotFound, "NAME_UNKNOWN", "unknown upstream registry")
+		return
+	}
+
+	h.proxy.Logger.Info("container blob request", "name", upstreamName, "digest", digest)
 
 	filename := digest
-	cached, err := h.proxy.GetCachedArtifact(r.Context(), "oci", name, digest, filename)
+	cached, err := h.proxy.GetCachedArtifact(r.Context(), "oci", cacheName, digest, filename)
 	if err != nil {
 		h.proxy.Logger.Error("failed to check blob cache", "error", err)
 		h.containerError(w, http.StatusInternalServerError, "INTERNAL_ERROR", "failed to check blob cache")
@@ -96,14 +114,18 @@ func (h *ContainerHandler) handleBlobDownload(w http.ResponseWriter, r *http.Req
 	}
 	if cached != nil {
 		w.Header().Set("Docker-Content-Digest", digest)
-		w.Header().Set("Content-Type", "application/octet-stream")
+		if cached.ContentType != "" {
+			w.Header().Set("Content-Type", cached.ContentType)
+		} else {
+			w.Header().Set("Content-Type", "application/octet-stream")
+		}
 		serveArtifact(w, r.Method, cached)
 		return
 	}
 
 	// For HEAD requests, just proxy to upstream
 	if r.Method == http.MethodHead {
-		h.proxyBlobHead(w, r, name, digest)
+		h.proxyBlobHead(w, r, registryURL, upstreamName, digest)
 		return
 	}
 
@@ -111,10 +133,10 @@ func (h *ContainerHandler) handleBlobDownload(w http.ResponseWriter, r *http.Req
 	result, err := h.proxy.GetOrFetchArtifactFromURL(
 		r.Context(),
 		"oci",
-		name,
+		cacheName,
 		digest, // use digest as version
 		filename,
-		fmt.Sprintf("%s/v2/%s/blobs/%s", h.registryURL, name, digest),
+		fmt.Sprintf("%s/v2/%s/blobs/%s", registryURL, upstreamName, digest),
 	)
 
 	if err != nil {
@@ -128,7 +150,11 @@ func (h *ContainerHandler) handleBlobDownload(w http.ResponseWriter, r *http.Req
 	}
 
 	w.Header().Set("Docker-Content-Digest", digest)
-	w.Header().Set("Content-Type", "application/octet-stream")
+	if result.ContentType != "" {
+		w.Header().Set("Content-Type", result.ContentType)
+	} else {
+		w.Header().Set("Content-Type", "application/octet-stream")
+	}
 	ServeArtifact(w, result)
 }
 
@@ -146,8 +172,14 @@ func (h *ContainerHandler) handleManifest(w http.ResponseWriter, r *http.Request
 		return
 	}
 
-	h.proxy.Logger.Info("container manifest request", "name", name, "reference", reference)
-	h.serveManifest(w, r, name, reference)
+	registryURL, upstreamName, _, ok := h.registryForName(name)
+	if !ok {
+		h.containerError(w, http.StatusNotFound, "NAME_UNKNOWN", "unknown upstream registry")
+		return
+	}
+
+	h.proxy.Logger.Info("container manifest request", "name", upstreamName, "reference", reference)
+	h.serveManifest(w, r, registryURL, upstreamName, reference)
 }
 
 // handleTagsList proxies tag list requests to upstream.
@@ -163,7 +195,13 @@ func (h *ContainerHandler) handleTagsList(w http.ResponseWriter, r *http.Request
 		return
 	}
 
-	upstreamURL := fmt.Sprintf("%s/v2/%s/tags/list", h.registryURL, name)
+	registryURL, upstreamName, _, ok := h.registryForName(name)
+	if !ok {
+		h.containerError(w, http.StatusNotFound, "NAME_UNKNOWN", "unknown upstream registry")
+		return
+	}
+
+	upstreamURL := fmt.Sprintf("%s/v2/%s/tags/list", registryURL, upstreamName)
 	if r.URL.RawQuery != "" {
 		upstreamURL += "?" + r.URL.RawQuery
 	}
@@ -187,8 +225,8 @@ func (h *ContainerHandler) handleTagsList(w http.ResponseWriter, r *http.Request
 }
 
 // proxyBlobHead handles HEAD requests for blobs.
-func (h *ContainerHandler) proxyBlobHead(w http.ResponseWriter, r *http.Request, name, digest string) {
-	upstreamURL := fmt.Sprintf("%s/v2/%s/blobs/%s", h.registryURL, name, digest)
+func (h *ContainerHandler) proxyBlobHead(w http.ResponseWriter, r *http.Request, registryURL, name, digest string) {
+	upstreamURL := fmt.Sprintf("%s/v2/%s/blobs/%s", registryURL, name, digest)
 
 	req, err := http.NewRequestWithContext(r.Context(), http.MethodHead, upstreamURL, nil)
 	if err != nil {
@@ -210,6 +248,24 @@ func (h *ContainerHandler) proxyBlobHead(w http.ResponseWriter, r *http.Request,
 	}
 
 	w.WriteHeader(resp.StatusCode)
+}
+
+// registryForName resolves a client-visible OCI repository name to an upstream
+// registry and its repository name. Named upstreams use upstream/{name}/ as a
+// reserved prefix; all other names continue to target Docker Hub.
+func (h *ContainerHandler) registryForName(name string) (registryURL, upstreamName, cacheName string, ok bool) {
+	parts := strings.SplitN(name, "/", registrySelectorParts)
+	if len(parts) >= 2 && parts[0] == "upstream" {
+		if len(parts) != registrySelectorParts || parts[2] == "" {
+			return "", "", "", false
+		}
+		registryURL, ok = h.namedRegistries[parts[1]]
+		if !ok || registryURL == "" {
+			return "", "", "", false
+		}
+		return registryURL, parts[2], name, true
+	}
+	return h.registryURL, name, name, true
 }
 
 // containerError writes an OCI-compliant error response.

--- a/internal/handler/container_manifest.go
+++ b/internal/handler/container_manifest.go
@@ -33,9 +33,9 @@ type cachedContainerManifest struct {
 	fetchedAt     time.Time
 }
 
-func (h *ContainerHandler) serveManifest(w http.ResponseWriter, r *http.Request, name, reference string) {
+func (h *ContainerHandler) serveManifest(w http.ResponseWriter, r *http.Request, registryURL, name, reference string) {
 	accept := containerManifestAccept(r)
-	cacheKey := h.containerManifestCacheKey(name, reference, accept)
+	cacheKey := h.containerManifestCacheKey(registryURL, name, reference, accept)
 	cached, err := h.loadContainerManifest(r.Context(), cacheKey)
 	if err != nil {
 		h.proxy.Logger.Warn("failed to read cached container manifest", "error", err)
@@ -48,7 +48,7 @@ func (h *ContainerHandler) serveManifest(w http.ResponseWriter, r *http.Request,
 		return
 	}
 
-	upstreamURL := fmt.Sprintf("%s/v2/%s/manifests/%s", h.registryURL, name, reference)
+	upstreamURL := fmt.Sprintf("%s/v2/%s/manifests/%s", registryURL, name, reference)
 	req, err := http.NewRequestWithContext(r.Context(), r.Method, upstreamURL, nil)
 	if err != nil {
 		h.containerError(w, http.StatusInternalServerError, "INTERNAL_ERROR", "failed to create request")
@@ -111,7 +111,7 @@ func (h *ContainerHandler) serveManifest(w http.ResponseWriter, r *http.Request,
 		h.proxy.Logger.Warn("failed to cache container manifest", "error", err)
 	}
 	if manifest.contentDigest != reference && manifestDigestReferencePattern.MatchString(manifest.contentDigest) {
-		digestKey := h.containerManifestCacheKey(name, manifest.contentDigest, accept)
+		digestKey := h.containerManifestCacheKey(registryURL, name, manifest.contentDigest, accept)
 		if err := h.storeContainerManifest(r.Context(), digestKey, manifest); err != nil {
 			h.proxy.Logger.Warn("failed to cache container manifest by digest", "error", err)
 		}
@@ -133,8 +133,8 @@ func (h *ContainerHandler) containerManifestFresh(manifest *cachedContainerManif
 	return h.proxy.MetadataTTL > 0 && !manifest.fetchedAt.IsZero() && time.Since(manifest.fetchedAt) < h.proxy.MetadataTTL
 }
 
-func (h *ContainerHandler) containerManifestCacheKey(name, reference, accept string) string {
-	identity := strings.Join([]string{h.registryURL, name, reference, accept}, "\x00")
+func (h *ContainerHandler) containerManifestCacheKey(registryURL, name, reference, accept string) string {
+	identity := strings.Join([]string{registryURL, name, reference, accept}, "\x00")
 	sum := sha256.Sum256([]byte(identity))
 	return hex.EncodeToString(sum[:])
 }

--- a/internal/handler/container_test.go
+++ b/internal/handler/container_test.go
@@ -134,6 +134,52 @@ func TestContainerHandler_parseTagsListPath(t *testing.T) {
 	}
 }
 
+func TestContainerHandler_NamedOCIRegistryServesHelmArtifacts(t *testing.T) {
+	digest := "sha256:abc123def456abc123def456abc123def456abc123def456abc123def456abcd"
+	manifest := `{"schemaVersion":2,"config":{"mediaType":"application/vnd.cncf.helm.config.v1+json"},"layers":[{"mediaType":"application/vnd.cncf.helm.chart.content.v1.tar+gzip","digest":"` + digest + `"}]}`
+	upstream := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		switch r.URL.Path {
+		case "/v2/owner/demo/manifests/1.0.0":
+			w.Header().Set("Content-Type", "application/vnd.oci.image.manifest.v1+json")
+			w.Header().Set("Docker-Content-Digest", digest)
+			_, _ = io.WriteString(w, manifest)
+		case "/v2/owner/demo/blobs/" + digest:
+			w.Header().Set("Content-Type", "application/vnd.cncf.helm.chart.content.v1.tar+gzip")
+			_, _ = io.WriteString(w, "chart archive")
+		default:
+			http.NotFound(w, r)
+		}
+	}))
+	defer upstream.Close()
+
+	proxy, _, _, _ := setupTestProxy(t)
+	proxy.HTTPClient = upstream.Client()
+	fetcher := fetch.NewFetcher(fetch.WithHTTPClient(upstream.Client()), fetch.WithMaxRetries(0))
+	proxy.Fetcher = fetcher
+	t.Cleanup(func() { _ = fetcher.Close() })
+	h := NewContainerHandler(proxy, "http://proxy.example", map[string]string{"ghcr": upstream.URL})
+
+	manifestResponse := httptest.NewRecorder()
+	h.Routes().ServeHTTP(manifestResponse,
+		httptest.NewRequest(http.MethodGet, "/upstream/ghcr/owner/demo/manifests/1.0.0", nil))
+	if manifestResponse.Code != http.StatusOK {
+		t.Fatalf("manifest status = %d, want 200: %s", manifestResponse.Code, manifestResponse.Body.String())
+	}
+	if got := manifestResponse.Header().Get("Content-Type"); got != "application/vnd.oci.image.manifest.v1+json" {
+		t.Errorf("manifest Content-Type = %q", got)
+	}
+
+	blobResponse := httptest.NewRecorder()
+	h.Routes().ServeHTTP(blobResponse,
+		httptest.NewRequest(http.MethodGet, "/upstream/ghcr/owner/demo/blobs/"+digest, nil))
+	if blobResponse.Code != http.StatusOK {
+		t.Fatalf("blob status = %d, want 200: %s", blobResponse.Code, blobResponse.Body.String())
+	}
+	if got := blobResponse.Header().Get("Content-Type"); got != "application/vnd.cncf.helm.chart.content.v1.tar+gzip" {
+		t.Errorf("blob Content-Type = %q", got)
+	}
+}
+
 func TestContainerHandler_BlobDownload_DiscoversBearerChallenge(t *testing.T) {
 	digest := "sha256:abc123def456abc123def456abc123def456abc123def456abc123def456abcd"
 	registryRequests := 0

--- a/internal/handler/handler.go
+++ b/internal/handler/handler.go
@@ -165,14 +165,24 @@ func (p *Proxy) GetCachedArtifact(ctx context.Context, ecosystem, name, version,
 	return p.checkCache(ctx, pkgPURL, versionPURL, filename)
 }
 
-// ClearCachedArtifact removes an artifact cache record after an external
-// integrity check fails. The unreferenced storage object is left for normal
-// storage cleanup, but it can no longer be served.
-func (p *Proxy) ClearCachedArtifact(ecosystem, name, version, filename string) error {
-	if p.DB == nil {
+// ClearCachedArtifact removes both an artifact cache record and its stored
+// bytes after an external integrity check fails.
+func (p *Proxy) ClearCachedArtifact(ctx context.Context, ecosystem, name, version, filename string) error {
+	if p.DB == nil || p.Storage == nil {
 		return nil
 	}
+	pkgPURL := purl.MakePURLString(ecosystem, name, "")
 	versionPURL := purl.MakePURLString(ecosystem, name, version)
+	cached, err := p.DB.GetCachedArtifact(pkgPURL, versionPURL, filename)
+	if err != nil {
+		return fmt.Errorf("looking up cached artifact: %w", err)
+	}
+	if cached == nil {
+		return nil
+	}
+	if err := p.Storage.Delete(ctx, cached.StoragePath); err != nil {
+		return fmt.Errorf("deleting cached artifact: %w", err)
+	}
 	return p.DB.ClearArtifactCache(versionPURL, filename)
 }
 

--- a/internal/handler/handler.go
+++ b/internal/handler/handler.go
@@ -165,6 +165,17 @@ func (p *Proxy) GetCachedArtifact(ctx context.Context, ecosystem, name, version,
 	return p.checkCache(ctx, pkgPURL, versionPURL, filename)
 }
 
+// ClearCachedArtifact removes an artifact cache record after an external
+// integrity check fails. The unreferenced storage object is left for normal
+// storage cleanup, but it can no longer be served.
+func (p *Proxy) ClearCachedArtifact(ecosystem, name, version, filename string) error {
+	if p.DB == nil {
+		return nil
+	}
+	versionPURL := purl.MakePURLString(ecosystem, name, version)
+	return p.DB.ClearArtifactCache(versionPURL, filename)
+}
+
 // checkCache looks up an artifact in the cache. Returns nil if not cached.
 func (p *Proxy) checkCache(ctx context.Context, pkgPURL, versionPURL, filename string) (*CacheResult, error) {
 	artifact, err := p.DB.GetCachedArtifact(pkgPURL, versionPURL, filename)

--- a/internal/handler/handler_test.go
+++ b/internal/handler/handler_test.go
@@ -3,7 +3,9 @@ package handler
 import (
 	"bytes"
 	"context"
+	"crypto/sha256"
 	"database/sql"
+	"encoding/hex"
 	"errors"
 	"io"
 	"log/slog"
@@ -42,7 +44,8 @@ func (s *mockStorage) Store(_ context.Context, path string, r io.Reader) (int64,
 		return 0, "", err
 	}
 	s.files[path] = data
-	return int64(len(data)), "fakehash123", nil
+	digest := sha256.Sum256(data)
+	return int64(len(data)), hex.EncodeToString(digest[:]), nil
 }
 
 func (s *mockStorage) Open(_ context.Context, path string) (io.ReadCloser, error) {

--- a/internal/handler/helm.go
+++ b/internal/handler/helm.go
@@ -1,0 +1,331 @@
+package handler
+
+import (
+	"errors"
+	"fmt"
+	"net/http"
+	"net/url"
+	"path"
+	"strings"
+	"time"
+
+	"gopkg.in/yaml.v3"
+)
+
+const (
+	helmMetadataEcosystem = "helm"
+	helmIndexFilename     = "index.yaml"
+	sha256HexLength       = 64
+)
+
+// HelmHandler serves read-only HTTP Helm chart repositories. Each configured
+// repository is mounted at /helm/{repository}/.
+type HelmHandler struct {
+	proxy        *Proxy
+	proxyURL     string
+	repositories map[string]string
+}
+
+// NewHelmHandler creates a Helm chart repository protocol handler.
+func NewHelmHandler(proxy *Proxy, proxyURL string, repositories map[string]string) *HelmHandler {
+	h := &HelmHandler{
+		proxyURL:     strings.TrimSuffix(proxyURL, "/"),
+		repositories: make(map[string]string, len(repositories)),
+		proxy:        proxy,
+	}
+	for name, repositoryURL := range repositories {
+		h.repositories[name] = strings.TrimSuffix(repositoryURL, "/")
+	}
+	return h
+}
+
+// Routes returns the HTTP handler for Helm chart repository requests.
+func (h *HelmHandler) Routes() http.Handler {
+	mux := http.NewServeMux()
+	mux.HandleFunc("GET /{repository}/index.yaml", h.handleIndex)
+	mux.HandleFunc("GET /{repository}/charts/{digest}/{filename}", h.handleChart)
+	return mux
+}
+
+func (h *HelmHandler) handleIndex(w http.ResponseWriter, r *http.Request) {
+	repository, upstreamURL, ok := h.repositoryForRequest(r)
+	if !ok {
+		http.NotFound(w, r)
+		return
+	}
+
+	body, contentType, err := h.fetchIndex(r, repository, upstreamURL)
+	if err != nil {
+		h.serveIndexError(w, err)
+		return
+	}
+
+	rewritten, err := h.rewriteIndex(repository, upstreamURL, body)
+	if err != nil {
+		h.proxy.Logger.Warn("failed to rewrite Helm index", "repository", repository, "error", err)
+		http.Error(w, "invalid Helm repository index", http.StatusBadGateway)
+		return
+	}
+
+	h.proxy.writeMetadataCachedResponse(w, r, helmMetadataEcosystem, h.indexCacheKey(repository), rewritten, contentType)
+}
+
+func (h *HelmHandler) handleChart(w http.ResponseWriter, r *http.Request) {
+	repository, upstreamURL, ok := h.repositoryForRequest(r)
+	if !ok {
+		http.NotFound(w, r)
+		return
+	}
+
+	digest, ok := normalizeHelmDigest(r.PathValue("digest"))
+	filename := r.PathValue("filename")
+	if !ok || filename == "" || strings.Contains(filename, "/") || containsPathTraversal(filename) {
+		http.Error(w, "invalid chart request", http.StatusBadRequest)
+		return
+	}
+
+	body, _, err := h.fetchIndex(r, repository, upstreamURL)
+	if err != nil {
+		h.serveIndexError(w, err)
+		return
+	}
+
+	downloadURL, err := h.findChartDownload(upstreamURL, body, digest, filename)
+	if err != nil {
+		if errors.Is(err, errHelmChartNotFound) {
+			http.NotFound(w, r)
+			return
+		}
+		h.proxy.Logger.Warn("failed to read Helm index", "repository", repository, "error", err)
+		http.Error(w, "invalid Helm repository index", http.StatusBadGateway)
+		return
+	}
+
+	result, err := h.proxy.GetOrFetchArtifactFromURL(
+		r.Context(), helmMetadataEcosystem, repository, digest, filename, downloadURL)
+	if err != nil {
+		h.proxy.serveArtifactError(w, err, "failed to fetch chart")
+		return
+	}
+	if !strings.EqualFold(result.Hash, digest) {
+		if result.Reader != nil {
+			_ = result.Reader.Close()
+		}
+		if clearErr := h.proxy.ClearCachedArtifact(helmMetadataEcosystem, repository, digest, filename); clearErr != nil {
+			h.proxy.Logger.Warn("failed to clear Helm chart with invalid digest", "error", clearErr)
+		}
+		http.Error(w, "chart digest verification failed", http.StatusBadGateway)
+		return
+	}
+
+	if result.ContentType == "" {
+		w.Header().Set("Content-Type", "application/gzip")
+	}
+	ServeArtifact(w, result)
+}
+
+func (h *HelmHandler) repositoryForRequest(r *http.Request) (name, upstreamURL string, ok bool) {
+	name = r.PathValue("repository")
+	upstreamURL, ok = h.repositories[name]
+	return name, upstreamURL, ok
+}
+
+func (h *HelmHandler) fetchIndex(r *http.Request, repository, upstreamURL string) ([]byte, string, error) {
+	return h.proxy.FetchOrCacheMetadata(
+		r.Context(),
+		helmMetadataEcosystem,
+		h.indexCacheKey(repository),
+		upstreamURL+"/"+helmIndexFilename,
+		"application/x-yaml, text/yaml;q=0.9, */*;q=0.1",
+	)
+}
+
+func (h *HelmHandler) indexCacheKey(repository string) string {
+	return repository + "/" + helmIndexFilename
+}
+
+func (h *HelmHandler) serveIndexError(w http.ResponseWriter, err error) {
+	if errors.Is(err, ErrUpstreamNotFound) {
+		http.Error(w, "Helm repository not found", http.StatusNotFound)
+		return
+	}
+	h.proxy.Logger.Error("failed to fetch Helm index", "error", err)
+	http.Error(w, "failed to fetch Helm repository index", http.StatusBadGateway)
+}
+
+func (h *HelmHandler) rewriteIndex(repository, upstreamURL string, body []byte) ([]byte, error) {
+	document, entries, err := parseHelmIndex(body)
+	if err != nil {
+		return nil, err
+	}
+
+	for i := 0; i < len(entries.Content); i += 2 {
+		chartName := entries.Content[i].Value
+		releases := entries.Content[i+1]
+		if releases.Kind != yaml.SequenceNode {
+			return nil, fmt.Errorf("chart %q releases must be a sequence", chartName)
+		}
+
+		filtered := make([]*yaml.Node, 0, len(releases.Content))
+		for _, release := range releases.Content {
+			chart, err := h.parseChartRelease(chartName, upstreamURL, release)
+			if err != nil {
+				return nil, err
+			}
+			if h.chartOnCooldown(chartName, chart.created) {
+				continue
+			}
+			for _, download := range chart.downloads {
+				download.node.Value = h.chartProxyURL(repository, chart.digest, download.filename)
+			}
+			filtered = append(filtered, release)
+		}
+		releases.Content = filtered
+	}
+
+	return yaml.Marshal(document)
+}
+
+func (h *HelmHandler) findChartDownload(upstreamURL string, body []byte, digest, filename string) (string, error) {
+	_, entries, err := parseHelmIndex(body)
+	if err != nil {
+		return "", err
+	}
+
+	for i := 0; i < len(entries.Content); i += 2 {
+		chartName := entries.Content[i].Value
+		releases := entries.Content[i+1]
+		if releases.Kind != yaml.SequenceNode {
+			return "", fmt.Errorf("chart %q releases must be a sequence", chartName)
+		}
+		for _, release := range releases.Content {
+			chart, err := h.parseChartRelease(chartName, upstreamURL, release)
+			if err != nil {
+				return "", err
+			}
+			if chart.digest != digest || h.chartOnCooldown(chartName, chart.created) {
+				continue
+			}
+			for _, download := range chart.downloads {
+				if download.filename == filename {
+					return download.url, nil
+				}
+			}
+		}
+	}
+
+	return "", errHelmChartNotFound
+}
+
+func (h *HelmHandler) chartOnCooldown(chartName string, created time.Time) bool {
+	return !created.IsZero() && h.proxy.Cooldown != nil && h.proxy.Cooldown.Enabled() &&
+		!h.proxy.Cooldown.IsAllowed(helmMetadataEcosystem, canonicalPackagePURL(helmMetadataEcosystem, chartName), created)
+}
+
+type helmChartDownload struct {
+	node     *yaml.Node
+	url      string
+	filename string
+}
+
+type helmChartRelease struct {
+	created   time.Time
+	digest    string
+	downloads []helmChartDownload
+}
+
+var errHelmChartNotFound = errors.New("chart not found in Helm index")
+
+func (h *HelmHandler) parseChartRelease(chartName, upstreamURL string, release *yaml.Node) (helmChartRelease, error) {
+	digestNode := helmMappingValue(release, "digest")
+	urlsNode := helmMappingValue(release, "urls")
+	if digestNode == nil || urlsNode == nil || urlsNode.Kind != yaml.SequenceNode || len(urlsNode.Content) == 0 {
+		return helmChartRelease{}, fmt.Errorf("chart %q has no digest or URLs", chartName)
+	}
+	digest, ok := normalizeHelmDigest(digestNode.Value)
+	if !ok {
+		return helmChartRelease{}, fmt.Errorf("chart %q has invalid digest", chartName)
+	}
+
+	baseURL, err := url.Parse(upstreamURL + "/" + helmIndexFilename)
+	if err != nil {
+		return helmChartRelease{}, fmt.Errorf("parsing Helm repository URL: %w", err)
+	}
+
+	chart := helmChartRelease{digest: digest}
+	if createdNode := helmMappingValue(release, "created"); createdNode != nil && createdNode.Value != "" {
+		chart.created, err = time.Parse(time.RFC3339Nano, createdNode.Value)
+		if err != nil {
+			return helmChartRelease{}, fmt.Errorf("chart %q has invalid creation time: %w", chartName, err)
+		}
+	}
+
+	for _, urlNode := range urlsNode.Content {
+		if urlNode.Kind != yaml.ScalarNode {
+			return helmChartRelease{}, fmt.Errorf("chart %q has invalid URL", chartName)
+		}
+		reference, err := url.Parse(urlNode.Value)
+		if err != nil {
+			return helmChartRelease{}, fmt.Errorf("parsing chart %q URL: %w", chartName, err)
+		}
+		downloadURL := baseURL.ResolveReference(reference)
+		if (downloadURL.Scheme != "http" && downloadURL.Scheme != "https") || downloadURL.Host == "" {
+			return helmChartRelease{}, fmt.Errorf("chart %q URL must be HTTP(S)", chartName)
+		}
+		filename := path.Base(downloadURL.Path)
+		if filename == "." || filename == "/" || filename == "" || !strings.HasSuffix(filename, ".tgz") {
+			return helmChartRelease{}, fmt.Errorf("chart %q URL must point to a .tgz file", chartName)
+		}
+		chart.downloads = append(chart.downloads, helmChartDownload{
+			node:     urlNode,
+			url:      downloadURL.String(),
+			filename: filename,
+		})
+	}
+	return chart, nil
+}
+
+func (h *HelmHandler) chartProxyURL(repository, digest, filename string) string {
+	return fmt.Sprintf("%s/helm/%s/charts/%s/%s", h.proxyURL,
+		url.PathEscape(repository), digest, url.PathEscape(filename))
+}
+
+func parseHelmIndex(body []byte) (*yaml.Node, *yaml.Node, error) {
+	var document yaml.Node
+	if err := yaml.Unmarshal(body, &document); err != nil {
+		return nil, nil, fmt.Errorf("parsing Helm index: %w", err)
+	}
+	if len(document.Content) != 1 || document.Content[0].Kind != yaml.MappingNode {
+		return nil, nil, errors.New("helm index must be a mapping")
+	}
+	entries := helmMappingValue(document.Content[0], "entries")
+	if entries == nil || entries.Kind != yaml.MappingNode {
+		return nil, nil, errors.New("helm index has no entries mapping")
+	}
+	return &document, entries, nil
+}
+
+func helmMappingValue(mapping *yaml.Node, key string) *yaml.Node {
+	if mapping == nil || mapping.Kind != yaml.MappingNode {
+		return nil
+	}
+	for i := 0; i+1 < len(mapping.Content); i += 2 {
+		if mapping.Content[i].Value == key {
+			return mapping.Content[i+1]
+		}
+	}
+	return nil
+}
+
+func normalizeHelmDigest(value string) (string, bool) {
+	digest := strings.TrimPrefix(strings.ToLower(value), "sha256:")
+	if len(digest) != sha256HexLength {
+		return "", false
+	}
+	for _, char := range digest {
+		if (char < '0' || char > '9') && (char < 'a' || char > 'f') {
+			return "", false
+		}
+	}
+	return digest, true
+}

--- a/internal/handler/helm.go
+++ b/internal/handler/helm.go
@@ -86,6 +86,17 @@ func (h *HelmHandler) handleChart(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
+	cached, err := h.proxy.GetCachedArtifact(r.Context(), helmMetadataEcosystem, repository, digest, filename)
+	if err != nil {
+		h.proxy.Logger.Error("failed to check Helm chart cache", "error", err)
+		http.Error(w, "failed to check chart cache", http.StatusInternalServerError)
+		return
+	}
+	if cached != nil {
+		h.serveChart(w, r, repository, digest, filename, cached)
+		return
+	}
+
 	body, _, err := h.fetchIndex(r, repository, upstreamURL)
 	if err != nil {
 		h.serveIndexError(w, err)
@@ -109,6 +120,10 @@ func (h *HelmHandler) handleChart(w http.ResponseWriter, r *http.Request) {
 		h.proxy.serveArtifactError(w, err, "failed to fetch chart")
 		return
 	}
+	h.serveChart(w, r, repository, digest, filename, result)
+}
+
+func (h *HelmHandler) serveChart(w http.ResponseWriter, r *http.Request, repository, digest, filename string, result *CacheResult) {
 	if !strings.EqualFold(result.Hash, digest) {
 		if result.Reader != nil {
 			_ = result.Reader.Close()
@@ -299,14 +314,28 @@ func parseHelmIndex(body []byte) (*yaml.Node, *yaml.Node, error) {
 	if err := yaml.Unmarshal(body, &document); err != nil {
 		return nil, nil, fmt.Errorf("parsing Helm index: %w", err)
 	}
+	entries, err := helmIndexEntries(&document)
+	if err != nil {
+		return nil, nil, err
+	}
+	return &document, entries, nil
+}
+
+func helmIndexEntries(document *yaml.Node) (*yaml.Node, error) {
+	if document == nil {
+		return nil, errors.New("helm index is empty")
+	}
 	if len(document.Content) != 1 || document.Content[0].Kind != yaml.MappingNode {
-		return nil, nil, errors.New("helm index must be a mapping")
+		return nil, errors.New("helm index must be a mapping")
 	}
 	entries := helmMappingValue(document.Content[0], "entries")
 	if entries == nil || entries.Kind != yaml.MappingNode {
-		return nil, nil, errors.New("helm index has no entries mapping")
+		return nil, errors.New("helm index has no entries mapping")
 	}
-	return &document, entries, nil
+	if len(entries.Content)%2 != 0 {
+		return nil, errors.New("helm index entries mapping has an incomplete key-value pair")
+	}
+	return entries, nil
 }
 
 func helmMappingValue(mapping *yaml.Node, key string) *yaml.Node {

--- a/internal/handler/helm.go
+++ b/internal/handler/helm.go
@@ -1,6 +1,8 @@
 package handler
 
 import (
+	"crypto/sha256"
+	"encoding/hex"
 	"errors"
 	"fmt"
 	"net/http"
@@ -67,7 +69,7 @@ func (h *HelmHandler) handleIndex(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
-	h.proxy.writeMetadataCachedResponse(w, r, helmMetadataEcosystem, h.indexCacheKey(repository), rewritten, contentType)
+	h.proxy.writeMetadataCachedResponse(w, r, helmMetadataEcosystem, h.indexCacheKey(repository, upstreamURL), rewritten, contentType)
 }
 
 func (h *HelmHandler) handleChart(w http.ResponseWriter, r *http.Request) {
@@ -111,7 +113,7 @@ func (h *HelmHandler) handleChart(w http.ResponseWriter, r *http.Request) {
 		if result.Reader != nil {
 			_ = result.Reader.Close()
 		}
-		if clearErr := h.proxy.ClearCachedArtifact(helmMetadataEcosystem, repository, digest, filename); clearErr != nil {
+		if clearErr := h.proxy.ClearCachedArtifact(r.Context(), helmMetadataEcosystem, repository, digest, filename); clearErr != nil {
 			h.proxy.Logger.Warn("failed to clear Helm chart with invalid digest", "error", clearErr)
 		}
 		http.Error(w, "chart digest verification failed", http.StatusBadGateway)
@@ -134,14 +136,16 @@ func (h *HelmHandler) fetchIndex(r *http.Request, repository, upstreamURL string
 	return h.proxy.FetchOrCacheMetadata(
 		r.Context(),
 		helmMetadataEcosystem,
-		h.indexCacheKey(repository),
+		h.indexCacheKey(repository, upstreamURL),
 		upstreamURL+"/"+helmIndexFilename,
 		"application/x-yaml, text/yaml;q=0.9, */*;q=0.1",
 	)
 }
 
-func (h *HelmHandler) indexCacheKey(repository string) string {
-	return repository + "/" + helmIndexFilename
+func (h *HelmHandler) indexCacheKey(repository, upstreamURL string) string {
+	identity := repository + "\x00" + upstreamURL
+	digest := sha256.Sum256([]byte(identity))
+	return hex.EncodeToString(digest[:])
 }
 
 func (h *HelmHandler) serveIndexError(w http.ResponseWriter, err error) {

--- a/internal/handler/helm_test.go
+++ b/internal/handler/helm_test.go
@@ -1,0 +1,257 @@
+package handler
+
+import (
+	"crypto/sha256"
+	"encoding/hex"
+	"fmt"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"sync/atomic"
+	"testing"
+	"time"
+
+	"github.com/git-pkgs/cooldown"
+	upstreamhttp "github.com/git-pkgs/proxy/internal/httpclient"
+	"github.com/git-pkgs/registries/fetch"
+	"gopkg.in/yaml.v3"
+)
+
+func TestHelmHandler_RewritesIndexAndCachesChart(t *testing.T) {
+	chart := []byte("a Helm chart")
+	digest := helmSHA256Hex(chart)
+	var available atomic.Bool
+	available.Store(true)
+	var indexRequests atomic.Int32
+	var chartRequests atomic.Int32
+
+	var upstream *httptest.Server
+	upstream = httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if !available.Load() {
+			http.Error(w, "unavailable", http.StatusServiceUnavailable)
+			return
+		}
+		switch r.URL.Path {
+		case "/charts/index.yaml":
+			indexRequests.Add(1)
+			w.Header().Set("Content-Type", "application/x-yaml")
+			_, _ = fmt.Fprintf(w, `apiVersion: v1
+entries:
+  demo:
+    - annotations:
+        example.com/retained: "true"
+      created: 2020-01-02T03:04:05Z
+      digest: %s
+      name: demo
+      urls:
+        - demo-1.0.0.tgz
+        - %s/charts/mirror/demo-1.0.0.tgz
+      version: 1.0.0
+generated: 2020-01-02T03:04:05Z
+`, digest, upstream.URL)
+		case "/charts/demo-1.0.0.tgz", "/charts/mirror/demo-1.0.0.tgz":
+			chartRequests.Add(1)
+			w.Header().Set("Content-Type", "application/gzip")
+			_, _ = w.Write(chart)
+		default:
+			http.NotFound(w, r)
+		}
+	}))
+	defer upstream.Close()
+
+	proxy, _, _, _ := setupTestProxy(t)
+	proxy.CacheMetadata = true
+	proxy.MetadataTTL = time.Hour
+	proxy.HTTPClient = upstream.Client()
+	fetcher := fetch.NewFetcher(fetch.WithHTTPClient(upstream.Client()), fetch.WithMaxRetries(0))
+	proxy.Fetcher = fetcher
+	t.Cleanup(func() { _ = fetcher.Close() })
+
+	h := NewHelmHandler(proxy, "http://proxy.example", map[string]string{"stable": upstream.URL + "/charts"})
+
+	indexResponse := serveHelmRequest(h, "/stable/index.yaml")
+	if indexResponse.Code != http.StatusOK {
+		t.Fatalf("index status = %d, want 200: %s", indexResponse.Code, indexResponse.Body.String())
+	}
+	if got := indexResponse.Header().Get("Content-Type"); got != "application/x-yaml" {
+		t.Errorf("index Content-Type = %q, want application/x-yaml", got)
+	}
+	if strings.Contains(indexResponse.Body.String(), upstream.URL) {
+		t.Errorf("rewritten index contains upstream URL: %s", indexResponse.Body.String())
+	}
+	if !strings.Contains(indexResponse.Body.String(), "example.com/retained") {
+		t.Errorf("rewritten index lost an unrelated field: %s", indexResponse.Body.String())
+	}
+
+	var index map[string]any
+	if err := yaml.Unmarshal(indexResponse.Body.Bytes(), &index); err != nil {
+		t.Fatalf("parse rewritten index: %v", err)
+	}
+	entries := index["entries"].(map[string]any)
+	release := entries["demo"].([]any)[0].(map[string]any)
+	urls := release["urls"].([]any)
+	wantURL := "http://proxy.example/helm/stable/charts/" + digest + "/demo-1.0.0.tgz"
+	for _, rawURL := range urls {
+		if rawURL != wantURL {
+			t.Errorf("rewritten URL = %q, want %q", rawURL, wantURL)
+		}
+	}
+
+	firstChart := serveHelmRequest(h, "/stable/charts/"+digest+"/demo-1.0.0.tgz")
+	if firstChart.Code != http.StatusOK {
+		t.Fatalf("chart status = %d, want 200: %s", firstChart.Code, firstChart.Body.String())
+	}
+	if got := firstChart.Body.String(); got != string(chart) {
+		t.Errorf("chart body = %q, want %q", got, chart)
+	}
+	if got := firstChart.Header().Get("Content-Type"); got != "application/gzip" {
+		t.Errorf("chart Content-Type = %q, want application/gzip", got)
+	}
+
+	available.Store(false)
+	cachedChart := serveHelmRequest(h, "/stable/charts/"+digest+"/demo-1.0.0.tgz")
+	if cachedChart.Code != http.StatusOK {
+		t.Fatalf("cached chart status = %d, want 200: %s", cachedChart.Code, cachedChart.Body.String())
+	}
+	if got := cachedChart.Body.String(); got != string(chart) {
+		t.Errorf("cached chart body = %q, want %q", got, chart)
+	}
+	if got := indexRequests.Load(); got != 1 {
+		t.Errorf("index requests = %d, want 1", got)
+	}
+	if got := chartRequests.Load(); got != 1 {
+		t.Errorf("chart requests = %d, want 1", got)
+	}
+}
+
+func TestHelmHandler_RejectsChartDigestMismatch(t *testing.T) {
+	chart := []byte("tampered chart")
+	digest := helmSHA256Hex([]byte("expected chart"))
+	requests := 0
+
+	upstream := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		switch r.URL.Path {
+		case "/index.yaml":
+			_, _ = fmt.Fprintf(w, "apiVersion: v1\nentries:\n  demo:\n    - digest: %s\n      urls: [demo.tgz]\n", digest)
+		case "/demo.tgz":
+			requests++
+			_, _ = w.Write(chart)
+		default:
+			http.NotFound(w, r)
+		}
+	}))
+	defer upstream.Close()
+
+	proxy, _, _, _ := setupTestProxy(t)
+	proxy.CacheMetadata = true
+	proxy.MetadataTTL = time.Hour
+	proxy.HTTPClient = upstream.Client()
+	fetcher := fetch.NewFetcher(fetch.WithHTTPClient(upstream.Client()), fetch.WithMaxRetries(0))
+	proxy.Fetcher = fetcher
+	t.Cleanup(func() { _ = fetcher.Close() })
+	h := NewHelmHandler(proxy, "http://proxy.example", map[string]string{"test": upstream.URL})
+
+	for range 2 {
+		response := serveHelmRequest(h, "/test/charts/"+digest+"/demo.tgz")
+		if response.Code != http.StatusBadGateway {
+			t.Errorf("status = %d, want 502: %s", response.Code, response.Body.String())
+		}
+	}
+	if requests != 2 {
+		t.Errorf("chart requests = %d, want 2 after invalid cache entry is cleared", requests)
+	}
+}
+
+func TestHelmHandler_UsesConfiguredUpstreamAuthentication(t *testing.T) {
+	chart := []byte("private Helm chart")
+	digest := helmSHA256Hex(chart)
+	upstream := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.Header.Get("Authorization") != "Bearer private-token" {
+			http.Error(w, "unauthorized", http.StatusUnauthorized)
+			return
+		}
+		switch r.URL.Path {
+		case "/index.yaml":
+			_, _ = fmt.Fprintf(w, "apiVersion: v1\nentries:\n  demo:\n    - digest: %s\n      urls: [demo.tgz]\n", digest)
+		case "/demo.tgz":
+			_, _ = w.Write(chart)
+		default:
+			http.NotFound(w, r)
+		}
+	}))
+	defer upstream.Close()
+
+	proxy, _, _, _ := setupTestProxy(t)
+	proxy.CacheMetadata = true
+	proxy.MetadataTTL = time.Hour
+	authClient := &http.Client{Transport: upstreamhttp.NewTransport(http.DefaultTransport,
+		upstreamhttp.AuthFunc(func(string) (string, string) {
+			return "Authorization", "Bearer private-token"
+		}))}
+	proxy.HTTPClient = authClient
+	fetcher := fetch.NewFetcher(fetch.WithHTTPClient(authClient), fetch.WithMaxRetries(0))
+	proxy.Fetcher = fetcher
+	t.Cleanup(func() { _ = fetcher.Close() })
+	h := NewHelmHandler(proxy, "http://proxy.example", map[string]string{"private": upstream.URL})
+
+	response := serveHelmRequest(h, "/private/charts/"+digest+"/demo.tgz")
+	if response.Code != http.StatusOK {
+		t.Fatalf("status = %d, want 200: %s", response.Code, response.Body.String())
+	}
+	if got := response.Body.String(); got != string(chart) {
+		t.Errorf("body = %q, want %q", got, chart)
+	}
+}
+
+func TestHelmHandler_FiltersNewChartsFromIndex(t *testing.T) {
+	oldDigest := strings.Repeat("a", 64)
+	newDigest := strings.Repeat("b", 64)
+	proxy := &Proxy{Cooldown: &cooldown.Config{Default: "3d"}}
+	h := NewHelmHandler(proxy, "http://proxy.example", map[string]string{"test": "https://charts.example"})
+
+	body := fmt.Sprintf(`apiVersion: v1
+entries:
+  demo:
+    - created: %s
+      digest: %s
+      urls: [demo-old.tgz]
+    - created: %s
+      digest: %s
+      urls: [demo-new.tgz]
+`, time.Now().Add(-10*24*time.Hour).Format(time.RFC3339), oldDigest,
+		time.Now().Add(-time.Hour).Format(time.RFC3339), newDigest)
+
+	rewritten, err := h.rewriteIndex("test", "https://charts.example", []byte(body))
+	if err != nil {
+		t.Fatalf("rewriteIndex() error = %v", err)
+	}
+	if strings.Contains(string(rewritten), newDigest) {
+		t.Errorf("rewritten index includes a chart still in cooldown: %s", rewritten)
+	}
+	if !strings.Contains(string(rewritten), oldDigest) {
+		t.Errorf("rewritten index omitted an old chart: %s", rewritten)
+	}
+}
+
+func TestNormalizeHelmDigest(t *testing.T) {
+	digest := strings.Repeat("a", 64)
+	for _, input := range []string{digest, "sha256:" + digest, "SHA256:" + strings.ToUpper(digest)} {
+		if got, ok := normalizeHelmDigest(input); !ok || got != digest {
+			t.Errorf("normalizeHelmDigest(%q) = %q, %t; want %q, true", input, got, ok, digest)
+		}
+	}
+	if _, ok := normalizeHelmDigest("bad"); ok {
+		t.Error("normalizeHelmDigest accepted an invalid digest")
+	}
+}
+
+func serveHelmRequest(h *HelmHandler, target string) *httptest.ResponseRecorder {
+	w := httptest.NewRecorder()
+	h.Routes().ServeHTTP(w, httptest.NewRequest(http.MethodGet, target, nil))
+	return w
+}
+
+func helmSHA256Hex(data []byte) string {
+	digest := sha256.Sum256(data)
+	return hex.EncodeToString(digest[:])
+}

--- a/internal/handler/helm_test.go
+++ b/internal/handler/helm_test.go
@@ -13,6 +13,7 @@ import (
 
 	"github.com/git-pkgs/cooldown"
 	upstreamhttp "github.com/git-pkgs/proxy/internal/httpclient"
+	"github.com/git-pkgs/proxy/internal/storage"
 	"github.com/git-pkgs/registries/fetch"
 	"gopkg.in/yaml.v3"
 )
@@ -142,7 +143,7 @@ func TestHelmHandler_RejectsChartDigestMismatch(t *testing.T) {
 	}))
 	defer upstream.Close()
 
-	proxy, _, _, _ := setupTestProxy(t)
+	proxy, _, store, _ := setupTestProxy(t)
 	proxy.CacheMetadata = true
 	proxy.MetadataTTL = time.Hour
 	proxy.HTTPClient = upstream.Client()
@@ -159,6 +160,59 @@ func TestHelmHandler_RejectsChartDigestMismatch(t *testing.T) {
 	}
 	if requests != 2 {
 		t.Errorf("chart requests = %d, want 2 after invalid cache entry is cleared", requests)
+	}
+	storagePath := storage.ArtifactPath(helmMetadataEcosystem, "", "test", digest, "demo.tgz")
+	if exists, err := store.Exists(t.Context(), storagePath); err != nil {
+		t.Fatalf("checking rejected chart storage: %v", err)
+	} else if exists {
+		t.Errorf("rejected chart remains in storage at %q", storagePath)
+	}
+}
+
+func TestHelmHandler_IndexCacheChangesWithUpstreamURL(t *testing.T) {
+	firstDigest := strings.Repeat("a", sha256HexLength)
+	secondDigest := strings.Repeat("b", sha256HexLength)
+	firstRequests := 0
+	secondRequests := 0
+	first := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		firstRequests++
+		_, _ = fmt.Fprintf(w, "apiVersion: v1\nentries:\n  demo:\n    - digest: %s\n      urls: [demo.tgz]\n", firstDigest)
+	}))
+	defer first.Close()
+	second := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		secondRequests++
+		_, _ = fmt.Fprintf(w, "apiVersion: v1\nentries:\n  demo:\n    - digest: %s\n      urls: [demo.tgz]\n", secondDigest)
+	}))
+	defer second.Close()
+
+	proxy, db, store, _ := setupTestProxy(t)
+	proxy.CacheMetadata = true
+	proxy.MetadataTTL = time.Hour
+	proxy.HTTPClient = first.Client()
+	firstHandler := NewHelmHandler(proxy, "http://proxy.example", map[string]string{"stable": first.URL})
+	if response := serveHelmRequest(firstHandler, "/stable/index.yaml"); response.Code != http.StatusOK {
+		t.Fatalf("first index status = %d, want 200: %s", response.Code, response.Body.String())
+	}
+
+	// Model a restarted server with the same database and storage but a changed
+	// repository URL. Its cache key must not reuse the previous index or ETag.
+	restartedProxy := NewProxy(db, store, &mockFetcher{}, fetch.NewResolver(), nil)
+	restartedProxy.CacheMetadata = true
+	restartedProxy.MetadataTTL = time.Hour
+	restartedProxy.HTTPClient = second.Client()
+	secondHandler := NewHelmHandler(restartedProxy, "http://proxy.example", map[string]string{"stable": second.URL})
+	response := serveHelmRequest(secondHandler, "/stable/index.yaml")
+	if response.Code != http.StatusOK {
+		t.Fatalf("second index status = %d, want 200: %s", response.Code, response.Body.String())
+	}
+	if !strings.Contains(response.Body.String(), secondDigest) {
+		t.Errorf("second index did not use the new upstream: %s", response.Body.String())
+	}
+	if firstRequests != 1 {
+		t.Errorf("first upstream requests = %d, want 1", firstRequests)
+	}
+	if secondRequests != 1 {
+		t.Errorf("second upstream requests = %d, want 1", secondRequests)
 	}
 }
 

--- a/internal/handler/helm_test.go
+++ b/internal/handler/helm_test.go
@@ -109,6 +109,9 @@ generated: 2020-01-02T03:04:05Z
 		t.Errorf("chart Content-Type = %q, want application/gzip", got)
 	}
 
+	// Artifact cache availability must not depend on metadata caching or a
+	// reachable index upstream.
+	proxy.CacheMetadata = false
 	available.Store(false)
 	cachedChart := serveHelmRequest(h, "/stable/charts/"+digest+"/demo-1.0.0.tgz")
 	if cachedChart.Code != http.StatusOK {
@@ -296,6 +299,29 @@ func TestNormalizeHelmDigest(t *testing.T) {
 	}
 	if _, ok := normalizeHelmDigest("bad"); ok {
 		t.Error("normalizeHelmDigest accepted an invalid digest")
+	}
+}
+
+func TestHelmIndexEntriesRejectsIncompleteMapping(t *testing.T) {
+	entries := &yaml.Node{
+		Kind: yaml.MappingNode,
+		Content: []*yaml.Node{
+			{Kind: yaml.ScalarNode, Value: "demo"},
+		},
+	}
+	document := &yaml.Node{
+		Kind: yaml.DocumentNode,
+		Content: []*yaml.Node{{
+			Kind: yaml.MappingNode,
+			Content: []*yaml.Node{
+				{Kind: yaml.ScalarNode, Value: "entries"},
+				entries,
+			},
+		}},
+	}
+
+	if _, err := helmIndexEntries(document); err == nil {
+		t.Fatal("helmIndexEntries() error = nil, want incomplete mapping error")
 	}
 }
 

--- a/internal/server/server.go
+++ b/internal/server/server.go
@@ -235,7 +235,8 @@ func (s *Server) Start() error {
 	condaHandler := handler.NewCondaHandler(proxy, s.cfg.BaseURL)
 	cranHandler := handler.NewCRANHandler(proxy, s.cfg.BaseURL)
 	juliaHandler := handler.NewJuliaHandler(proxy, s.cfg.BaseURL)
-	containerHandler := handler.NewContainerHandler(proxy, s.cfg.BaseURL)
+	containerHandler := handler.NewContainerHandler(proxy, s.cfg.BaseURL, s.cfg.Upstream.OCI)
+	helmHandler := handler.NewHelmHandler(proxy, s.cfg.BaseURL, s.cfg.Upstream.Helm)
 	debianHandler := handler.NewDebianHandler(proxy, s.cfg.BaseURL, s.cfg.Upstream.Debian)
 	rpmHandler := handler.NewRPMHandler(proxy, s.cfg.BaseURL)
 
@@ -255,6 +256,7 @@ func (s *Server) Start() error {
 	r.Mount("/cran", http.StripPrefix("/cran", cranHandler.Routes()))
 	r.Mount("/julia", http.StripPrefix("/julia", juliaHandler.Routes()))
 	r.Mount("/v2", http.StripPrefix("/v2", containerHandler.Routes()))
+	r.Mount("/helm", http.StripPrefix("/helm", helmHandler.Routes()))
 	r.Mount("/debian", http.StripPrefix("/debian", debianHandler.Routes()))
 	r.Mount("/rpm", http.StripPrefix("/rpm", rpmHandler.Routes()))
 


### PR DESCRIPTION
Closes #261
## Summary

Adds read-only caching proxy support for Helm chart repositories and Helm charts distributed through OCI registries.

### HTTP chart repositories

- Adds named `upstream.helm` repository configuration.
- Serves and caches `index.yaml` through `/helm/{repository}/index.yaml`.
- Rewrites both relative and absolute chart URLs to the proxy.
- Caches chart archives and verifies their SHA-256 digest against `index.yaml`.
- Applies existing metadata TTL, stale-cache fallback and configured upstream authentication.
- Filters recently created chart releases when Helm cooldown is enabled.

### OCI registries

- Adds named `upstream.oci` registry configuration.
- Routes named registries via the `upstream/{name}/` repository prefix while preserving existing Docker Hub mirror behavior.
- Supports Helm OCI manifests and chart layer media types.
- Keeps OCI manifests and blobs isolated by upstream registry in cache routing.

### Documentation and tests

- Documents HTTP and OCI Helm client configuration.
- Adds configuration validation for named Helm and OCI upstreams.
- Adds coverage for URL rewriting, cache reuse during upstream outage, digest mismatch rejection, cooldown filtering, private authentication and Helm OCI artifact requests.

## Validation

- `go tool golangci-lint run ./...`
- `go vet ./...`
- `go test -race ./...`
- `git diff --check`

