### PR TITLE
Bump github.com/git-pkgs/purl to v0.1.17

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -11,7 +11,7 @@ require (
 	github.com/git-pkgs/cooldown v0.1.1
 	github.com/git-pkgs/enrichment v0.6.5
 	github.com/git-pkgs/magic v0.2.0
-	github.com/git-pkgs/purl v0.1.16
+	github.com/git-pkgs/purl v0.1.17
 	github.com/git-pkgs/registries v0.7.0
 	github.com/git-pkgs/spdx v0.3.1
 	github.com/git-pkgs/vers v0.3.1

--- a/go.sum
+++ b/go.sum
@@ -256,8 +256,8 @@ github.com/git-pkgs/packageurl-go v0.3.1 h1:WM3RBABQZLaRBxgKyYughc3cVBE8KyQxbSC6
 github.com/git-pkgs/packageurl-go v0.3.1/go.mod h1:rcIxiG37BlQLB6FZfgdj9Fm7yjhRQd3l+5o7J0QPAk4=
 github.com/git-pkgs/pom v0.1.5 h1:TGT8Az2OMxGWsXnSagtUMGzZm7Oax8HrSCteA+mi0qY=
 github.com/git-pkgs/pom v0.1.5/go.mod h1:ufdMBe1lKzqOeP9IUb9NPZ458xKV8E8NvuyBMxOfwIk=
-github.com/git-pkgs/purl v0.1.16 h1:VAX6tv0hhdTENbkrGMoPZbOAl1Y8U1/ZnzoCsYuNBYM=
-github.com/git-pkgs/purl v0.1.16/go.mod h1:7u7ora8tQdrkS7Auclr5v8dCJdjN4ej6AbrvYZi2b7k=
+github.com/git-pkgs/purl v0.1.17 h1:oRSd8tqllTLl74Wa4WnuqU500hXd9OdUnImOEswQUVE=
+github.com/git-pkgs/purl v0.1.17/go.mod h1:7u7ora8tQdrkS7Auclr5v8dCJdjN4ej6AbrvYZi2b7k=
 github.com/git-pkgs/registries v0.7.0 h1:+LbOOMHbvjmXGfsi88hcGH+SfTXYsXA3UY5KYI5mB7s=
 github.com/git-pkgs/registries v0.7.0/go.mod h1:VCD4q+ZW0fInopzseg9rAmBEL553R2JQe60UHXtv26w=
 github.com/git-pkgs/spdx v0.3.1 h1:58JPY5X9pYpXvnzzZIgehItlBykeOOw52pNc4OBcS+c=

--- a/internal/handler/handler.go
+++ b/internal/handler/handler.go
@@ -61,9 +61,7 @@ var artifactCopyBufferPool = sync.Pool{ //nolint:gochecknoglobals // shared acro
 // canonicalPackagePURL returns a versionless PURL in canonical form so cooldown
 // lookups match keys produced by config.CooldownConfig.NormalizedPackages.
 func canonicalPackagePURL(ecosystem, name string) string {
-	p := purl.MakePURL(ecosystem, name, "")
-	_ = p.Normalize()
-	return p.String()
+	return purl.MakePURLString(ecosystem, name, "")
 }
 
 const contentTypeJSON = "application/json"


### PR DESCRIPTION
`MakePURL`/`MakePURLString`/`New` now apply the same per-type normalization as `Parse` (git-pkgs/purl#30), so `canonicalPackagePURL` no longer needs its own `Normalize` call and DB writes/lookups produce canonical keys.

Existing rows written under a non-canonical purl (mixed-case pypi, composer, etc) become cache misses on lookup and re-populate under the canonical key on the next fetch; the old rows are left in place rather than migrated.

Closes #207