### PR TITLE
fix(oci): retry transient token requests

### DIFF
--- a/internal/httpclient/transport.go
+++ b/internal/httpclient/transport.go
@@ -31,6 +31,7 @@ type AuthFunc func(url string) (headerName, headerValue string)
 type Transport struct {
 	base       http.RoundTripper
 	authForURL AuthFunc
+	retryWait  func(context.Context, time.Duration) error
 
 	mu         sync.Mutex
 	tokens     map[string]cachedToken
@@ -63,6 +64,7 @@ func NewTransport(base http.RoundTripper, authForURL AuthFunc) *Transport {
 	return &Transport{
 		base:       base,
 		authForURL: authForURL,
+		retryWait:  waitForRetry,
 		tokens:     make(map[string]cachedToken),
 		challenges: make(map[string]bearerChallenge),
 	}
@@ -183,7 +185,7 @@ func (t *Transport) fetchToken(ctx context.Context, challenge bearerChallenge) (
 			if !shouldRetryTokenRequest(ctx, err) || attempt == tokenMaxRetries {
 				return "", time.Time{}, requestErr
 			}
-			if err := waitForTokenRetry(ctx, attempt); err != nil {
+			if err := t.waitForTokenRetry(ctx, attempt); err != nil {
 				return "", time.Time{}, err
 			}
 			continue
@@ -197,7 +199,7 @@ func (t *Transport) fetchToken(ctx context.Context, challenge bearerChallenge) (
 		if !shouldRetryTokenStatus(resp.StatusCode) || attempt == tokenMaxRetries {
 			return "", time.Time{}, responseErr
 		}
-		if err := waitForTokenRetry(ctx, attempt); err != nil {
+		if err := t.waitForTokenRetry(ctx, attempt); err != nil {
 			return "", time.Time{}, err
 		}
 	}
@@ -246,15 +248,30 @@ func shouldRetryTokenRequest(ctx context.Context, err error) bool {
 	}
 
 	var networkErr net.Error
-	return errors.As(err, &networkErr)
+	if !errors.As(err, &networkErr) {
+		return false
+	}
+
+	var dnsErr *net.DNSError
+	if errors.As(err, &dnsErr) {
+		return dnsErr.IsTemporary || dnsErr.IsTimeout
+	}
+	return networkErr.Timeout()
 }
 
 func shouldRetryTokenStatus(status int) bool {
 	return status == http.StatusTooManyRequests || status >= http.StatusInternalServerError
 }
 
-func waitForTokenRetry(ctx context.Context, attempt int) error {
+func (t *Transport) waitForTokenRetry(ctx context.Context, attempt int) error {
 	delay := tokenRetryBaseDelay << attempt
+	if t.retryWait != nil {
+		return t.retryWait(ctx, delay)
+	}
+	return waitForRetry(ctx, delay)
+}
+
+func waitForRetry(ctx context.Context, delay time.Duration) error {
 	timer := time.NewTimer(delay)
 	defer timer.Stop()
 

--- a/internal/httpclient/transport.go
+++ b/internal/httpclient/transport.go
@@ -4,8 +4,10 @@ package httpclient
 import (
 	"context"
 	"encoding/json"
+	"errors"
 	"fmt"
 	"io"
+	"net"
 	"net/http"
 	"net/url"
 	"strings"
@@ -18,6 +20,8 @@ const (
 	tokenExpirySkew       = 5 * time.Second
 	maxTokenResponseSize  = 1 << 20
 	shortTokenSkewDivisor = 10
+	tokenMaxRetries       = 3
+	tokenRetryBaseDelay   = 500 * time.Millisecond
 )
 
 // AuthFunc returns a configured authentication header for a URL.
@@ -172,16 +176,37 @@ func (t *Transport) fetchToken(ctx context.Context, challenge bearerChallenge) (
 	}
 
 	client := &http.Client{Transport: configuredTransport{parent: t}}
-	resp, err := client.Do(req)
-	if err != nil {
-		return "", time.Time{}, fmt.Errorf("requesting token: %w", err)
-	}
-	defer func() { _ = resp.Body.Close() }()
+	for attempt := 0; attempt <= tokenMaxRetries; attempt++ {
+		resp, err := client.Do(req.Clone(ctx))
+		if err != nil {
+			requestErr := fmt.Errorf("requesting token: %w", err)
+			if !shouldRetryTokenRequest(ctx, err) || attempt == tokenMaxRetries {
+				return "", time.Time{}, requestErr
+			}
+			if err := waitForTokenRetry(ctx, attempt); err != nil {
+				return "", time.Time{}, err
+			}
+			continue
+		}
 
-	if resp.StatusCode < http.StatusOK || resp.StatusCode >= http.StatusMultipleChoices {
-		body, _ := io.ReadAll(io.LimitReader(resp.Body, maxTokenResponseSize))
-		return "", time.Time{}, fmt.Errorf("token service returned %d: %s", resp.StatusCode, strings.TrimSpace(string(body)))
+		if resp.StatusCode >= http.StatusOK && resp.StatusCode < http.StatusMultipleChoices {
+			return decodeTokenResponse(resp)
+		}
+
+		responseErr := tokenResponseError(resp)
+		if !shouldRetryTokenStatus(resp.StatusCode) || attempt == tokenMaxRetries {
+			return "", time.Time{}, responseErr
+		}
+		if err := waitForTokenRetry(ctx, attempt); err != nil {
+			return "", time.Time{}, err
+		}
 	}
+
+	return "", time.Time{}, errors.New("token request retries exhausted")
+}
+
+func decodeTokenResponse(resp *http.Response) (string, time.Time, error) {
+	defer func() { _ = resp.Body.Close() }()
 
 	var payload tokenResponse
 	if err := json.NewDecoder(io.LimitReader(resp.Body, maxTokenResponseSize)).Decode(&payload); err != nil {
@@ -207,6 +232,38 @@ func (t *Transport) fetchToken(ctx context.Context, challenge bearerChallenge) (
 	}
 	expiresAt := issuedAt.Add(lifetime).Add(-expirySkew(lifetime))
 	return token, expiresAt, nil
+}
+
+func tokenResponseError(resp *http.Response) error {
+	defer func() { _ = resp.Body.Close() }()
+	body, _ := io.ReadAll(io.LimitReader(resp.Body, maxTokenResponseSize))
+	return fmt.Errorf("token service returned %d: %s", resp.StatusCode, strings.TrimSpace(string(body)))
+}
+
+func shouldRetryTokenRequest(ctx context.Context, err error) bool {
+	if ctx.Err() != nil || errors.Is(err, context.Canceled) || errors.Is(err, context.DeadlineExceeded) {
+		return false
+	}
+
+	var networkErr net.Error
+	return errors.As(err, &networkErr)
+}
+
+func shouldRetryTokenStatus(status int) bool {
+	return status == http.StatusTooManyRequests || status >= http.StatusInternalServerError
+}
+
+func waitForTokenRetry(ctx context.Context, attempt int) error {
+	delay := tokenRetryBaseDelay << attempt
+	timer := time.NewTimer(delay)
+	defer timer.Stop()
+
+	select {
+	case <-ctx.Done():
+		return ctx.Err()
+	case <-timer.C:
+		return nil
+	}
 }
 
 type configuredTransport struct {

--- a/internal/httpclient/transport_test.go
+++ b/internal/httpclient/transport_test.go
@@ -2,6 +2,7 @@ package httpclient
 
 import (
 	"context"
+	"errors"
 	"io"
 	"net"
 	"net/http"
@@ -161,6 +162,69 @@ func TestTransportDoesNotRetryPermanentTokenFailures(t *testing.T) {
 	_, _, err := transport.fetchToken(context.Background(), bearerChallenge{realm: server.URL + "/token"})
 	if err == nil {
 		t.Fatal("fetchToken succeeded, want error")
+	}
+	if tokenRequests != 1 {
+		t.Errorf("token requests = %d, want 1", tokenRequests)
+	}
+}
+
+func TestTransportRetriesTokenServiceFailures(t *testing.T) {
+	for _, status := range []int{http.StatusTooManyRequests, http.StatusServiceUnavailable} {
+		t.Run(http.StatusText(status), func(t *testing.T) {
+			var tokenRequests int
+			server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+				tokenRequests++
+				http.Error(w, "temporary token service failure", status)
+			}))
+			defer server.Close()
+
+			var delays []time.Duration
+			transport := NewTransport(http.DefaultTransport, nil)
+			transport.retryWait = func(_ context.Context, delay time.Duration) error {
+				delays = append(delays, delay)
+				return nil
+			}
+
+			_, _, err := transport.fetchToken(context.Background(), bearerChallenge{realm: server.URL + "/token"})
+			if err == nil {
+				t.Fatal("fetchToken succeeded, want error")
+			}
+			if tokenRequests != tokenMaxRetries+1 {
+				t.Errorf("token requests = %d, want %d", tokenRequests, tokenMaxRetries+1)
+			}
+			wantDelays := []time.Duration{500 * time.Millisecond, time.Second, 2 * time.Second}
+			if len(delays) != len(wantDelays) {
+				t.Fatalf("retry delays = %v, want %v", delays, wantDelays)
+			}
+			for index, want := range wantDelays {
+				if delays[index] != want {
+					t.Errorf("retry delay %d = %s, want %s", index, delays[index], want)
+				}
+			}
+		})
+	}
+}
+
+func TestTransportStopsTokenRetriesWhenWaitingIsCancelled(t *testing.T) {
+	var tokenRequests int
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		tokenRequests++
+		http.Error(w, "temporary token service failure", http.StatusServiceUnavailable)
+	}))
+	defer server.Close()
+
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+	transport := NewTransport(http.DefaultTransport, nil)
+	transport.retryWait = func(ctx context.Context, _ time.Duration) error {
+		cancel()
+		<-ctx.Done()
+		return ctx.Err()
+	}
+
+	_, _, err := transport.fetchToken(ctx, bearerChallenge{realm: server.URL + "/token"})
+	if !errors.Is(err, context.Canceled) {
+		t.Errorf("fetchToken error = %v, want context canceled", err)
 	}
 	if tokenRequests != 1 {
 		t.Errorf("token requests = %d, want 1", tokenRequests)

--- a/internal/httpclient/transport_test.go
+++ b/internal/httpclient/transport_test.go
@@ -3,12 +3,19 @@ package httpclient
 import (
 	"context"
 	"io"
+	"net"
 	"net/http"
 	"net/http/httptest"
 	"strings"
 	"testing"
 	"time"
 )
+
+type roundTripperFunc func(*http.Request) (*http.Response, error)
+
+func (fn roundTripperFunc) RoundTrip(req *http.Request) (*http.Response, error) {
+	return fn(req)
+}
 
 func TestTransportFollowsBearerChallengeAndCachesToken(t *testing.T) {
 	var registryRequests int
@@ -65,6 +72,78 @@ func TestTransportFollowsBearerChallengeAndCachesToken(t *testing.T) {
 	}
 	if registryRequests != 3 {
 		t.Errorf("registry requests = %d, want 3", registryRequests)
+	}
+}
+
+func TestTransportRetriesTemporaryTokenLookupFailures(t *testing.T) {
+	var registryRequests int
+	var tokenRequests int
+	var tokenLookupFailures int
+	var server *httptest.Server
+
+	server = httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		switch r.URL.Path {
+		case "/token":
+			tokenRequests++
+			_, _ = io.WriteString(w, `{"token":"registry-token"}`)
+		case "/v2/library/test/blobs/sha256:test":
+			registryRequests++
+			if r.Header.Get("Authorization") != "Bearer registry-token" {
+				w.Header().Set("WWW-Authenticate", `Bearer realm="`+server.URL+`/token",service="registry.test",scope="repository:library/test:pull"`)
+				http.Error(w, "authentication required", http.StatusUnauthorized)
+				return
+			}
+			_, _ = io.WriteString(w, "blob")
+		default:
+			http.NotFound(w, r)
+		}
+	}))
+	defer server.Close()
+
+	base := roundTripperFunc(func(req *http.Request) (*http.Response, error) {
+		if req.URL.Path == "/token" && tokenLookupFailures < 2 {
+			tokenLookupFailures++
+			return nil, &net.DNSError{Err: "server misbehaving", IsTemporary: true}
+		}
+		return http.DefaultTransport.RoundTrip(req)
+	})
+	client := &http.Client{Transport: NewTransport(base, nil)}
+
+	resp, err := client.Get(server.URL + "/v2/library/test/blobs/sha256:test")
+	if err != nil {
+		t.Fatalf("GET blob: %v", err)
+	}
+	defer func() { _ = resp.Body.Close() }()
+
+	if resp.StatusCode != http.StatusOK {
+		t.Errorf("status = %d, want %d", resp.StatusCode, http.StatusOK)
+	}
+	if tokenLookupFailures != 2 {
+		t.Errorf("token lookup failures = %d, want 2", tokenLookupFailures)
+	}
+	if tokenRequests != 1 {
+		t.Errorf("token requests = %d, want 1", tokenRequests)
+	}
+	if registryRequests != 2 {
+		t.Errorf("registry requests = %d, want 2", registryRequests)
+	}
+}
+
+func TestTransportDoesNotRetryPermanentTokenFailures(t *testing.T) {
+	var tokenRequests int
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		tokenRequests++
+		http.Error(w, "invalid credentials", http.StatusUnauthorized)
+	}))
+	defer server.Close()
+
+	transport := NewTransport(http.DefaultTransport, nil)
+	_, _, err := transport.fetchToken(context.Background(), bearerChallenge{realm: server.URL + "/token"})
+	if err == nil {
+		t.Fatal("fetchToken succeeded, want error")
+	}
+	if tokenRequests != 1 {
+		t.Errorf("token requests = %d, want 1", tokenRequests)
 	}
 }
 

--- a/internal/httpclient/transport_test.go
+++ b/internal/httpclient/transport_test.go
@@ -107,7 +107,9 @@ func TestTransportRetriesTemporaryTokenLookupFailures(t *testing.T) {
 		}
 		return http.DefaultTransport.RoundTrip(req)
 	})
-	client := &http.Client{Transport: NewTransport(base, nil)}
+	transport := NewTransport(base, nil)
+	transport.retryWait = func(context.Context, time.Duration) error { return nil }
+	client := &http.Client{Transport: transport}
 
 	resp, err := client.Get(server.URL + "/v2/library/test/blobs/sha256:test")
 	if err != nil {
@@ -126,6 +128,24 @@ func TestTransportRetriesTemporaryTokenLookupFailures(t *testing.T) {
 	}
 	if registryRequests != 2 {
 		t.Errorf("registry requests = %d, want 2", registryRequests)
+	}
+}
+
+func TestTransportDoesNotRetryPermanentTokenLookupFailures(t *testing.T) {
+	var tokenRequests int
+	base := roundTripperFunc(func(*http.Request) (*http.Response, error) {
+		tokenRequests++
+		return nil, &net.DNSError{Err: "no such host"}
+	})
+	transport := NewTransport(base, nil)
+	transport.retryWait = func(context.Context, time.Duration) error { return nil }
+
+	_, _, err := transport.fetchToken(context.Background(), bearerChallenge{realm: "https://auth.example.test/token"})
+	if err == nil {
+		t.Fatal("fetchToken succeeded, want error")
+	}
+	if tokenRequests != 1 {
+		t.Errorf("token requests = %d, want 1", tokenRequests)
 	}
 }
 


### PR DESCRIPTION
## Summary

Fixes #266.

- Retry OCI Bearer-token requests after transient network and DNS failures.
- Retry rate-limited (`429`) and server-error (`5xx`) token responses.
- Use bounded exponential backoff: 500ms, 1s and 2s.
- Respect request cancellation and deadlines while waiting to retry.
- Avoid retrying permanent token failures such as invalid credentials (`401`).
- Add regression coverage for temporary DNS failures and permanent authentication failures.

## Validation

- `gofmt`
- `go tool golangci-lint run ./...`
- `go vet ./...`
- `go test -race ./...`
- `git diff --check`