### PR TITLE
fix(handler): preserve upstream content-encoding for cached metadata

### DIFF
--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -169,6 +169,7 @@ metadata_cache (
     storage_path  TEXT NOT NULL,
     etag          TEXT,
     content_type  TEXT,
+    content_encoding TEXT,           -- replayed on serve so signed bytes stay verbatim
     size          INTEGER,           -- BIGINT on Postgres
     fetched_at    DATETIME,
     created_at    DATETIME,

--- a/internal/database/metadata_cache_test.go
+++ b/internal/database/metadata_cache_test.go
@@ -280,3 +280,77 @@ func TestMetadataCacheLinkMigrationPreservesExistingRows(t *testing.T) {
 		t.Errorf("legacy link = %q, want NULL", entry.Link.String)
 	}
 }
+
+func TestMetadataCacheContentEncodingMigrationPreservesExistingRows(t *testing.T) {
+	dbPath := filepath.Join(t.TempDir(), "test.db")
+	db, err := Create(dbPath)
+	if err != nil {
+		t.Fatalf("Create failed: %v", err)
+	}
+	defer func() { _ = db.Close() }()
+
+	if _, err := db.Exec("ALTER TABLE metadata_cache DROP COLUMN content_encoding"); err != nil {
+		t.Fatalf("dropping content_encoding: %v", err)
+	}
+	if _, err := db.Exec("DELETE FROM migrations WHERE name = ?", "008_add_metadata_content_encoding"); err != nil {
+		t.Fatalf("resetting content_encoding migration: %v", err)
+	}
+	if _, err := db.Exec(`
+		INSERT INTO metadata_cache (ecosystem, name, storage_path, content_type, size, fetched_at, created_at, updated_at)
+		VALUES (?, ?, ?, ?, ?, ?, ?, ?)
+	`, "apk", "cache-key", "_metadata/apk/cache-key/metadata", "application/octet-stream", 2, time.Now(), time.Now(), time.Now()); err != nil {
+		t.Fatalf("inserting legacy cache row: %v", err)
+	}
+
+	if err := db.MigrateSchema(); err != nil {
+		t.Fatalf("MigrateSchema() error = %v", err)
+	}
+	hasEncoding, err := db.HasColumn("metadata_cache", "content_encoding")
+	if err != nil {
+		t.Fatalf("HasColumn() error = %v", err)
+	}
+	if !hasEncoding {
+		t.Fatal("metadata_cache.content_encoding was not added")
+	}
+
+	entry, err := db.GetMetadataCache("apk", "cache-key")
+	if err != nil {
+		t.Fatalf("GetMetadataCache() error = %v", err)
+	}
+	if entry == nil || entry.StoragePath != "_metadata/apk/cache-key/metadata" {
+		t.Fatalf("existing metadata cache row was not preserved: %#v", entry)
+	}
+	if entry.ContentEncoding.Valid {
+		t.Errorf("legacy content encoding = %q, want NULL", entry.ContentEncoding.String)
+	}
+}
+
+func TestMetadataCacheRoundTripsContentEncoding(t *testing.T) {
+	dbPath := filepath.Join(t.TempDir(), "test.db")
+	db, err := Create(dbPath)
+	if err != nil {
+		t.Fatalf("Create failed: %v", err)
+	}
+	defer func() { _ = db.Close() }()
+
+	entry := &MetadataCacheEntry{
+		Ecosystem:       "apk",
+		Name:            "index-key",
+		StoragePath:     "_metadata/apk/index-key/metadata",
+		ContentType:     sql.NullString{String: "application/octet-stream", Valid: true},
+		ContentEncoding: sql.NullString{String: "gzip", Valid: true},
+		Size:            sql.NullInt64{Int64: 10, Valid: true},
+		FetchedAt:       sql.NullTime{Time: time.Now(), Valid: true},
+	}
+	if err := db.UpsertMetadataCache(entry); err != nil {
+		t.Fatalf("UpsertMetadataCache() error = %v", err)
+	}
+
+	got, err := db.GetMetadataCache("apk", "index-key")
+	if err != nil {
+		t.Fatalf("GetMetadataCache() error = %v", err)
+	}
+	if got == nil || !got.ContentEncoding.Valid || got.ContentEncoding.String != "gzip" {
+		t.Fatalf("content encoding round-trip failed: %#v", got)
+	}
+}

--- a/internal/database/metadata_cache_test.go
+++ b/internal/database/metadata_cache_test.go
@@ -296,9 +296,9 @@ func TestMetadataCacheContentEncodingMigrationPreservesExistingRows(t *testing.T
 		t.Fatalf("resetting content_encoding migration: %v", err)
 	}
 	if _, err := db.Exec(`
-		INSERT INTO metadata_cache (ecosystem, name, storage_path, content_type, size, fetched_at, created_at, updated_at)
-		VALUES (?, ?, ?, ?, ?, ?, ?, ?)
-	`, "apk", "cache-key", "_metadata/apk/cache-key/metadata", "application/octet-stream", 2, time.Now(), time.Now(), time.Now()); err != nil {
+		INSERT INTO metadata_cache (ecosystem, name, storage_path, etag, content_type, size, fetched_at, created_at, updated_at)
+		VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?)
+	`, "apk", "cache-key", "_metadata/apk/cache-key/metadata", "\"legacy-etag\"", "application/octet-stream", 2, time.Now(), time.Now(), time.Now()); err != nil {
 		t.Fatalf("inserting legacy cache row: %v", err)
 	}
 
@@ -322,6 +322,14 @@ func TestMetadataCacheContentEncodingMigrationPreservesExistingRows(t *testing.T
 	}
 	if entry.ContentEncoding.Valid {
 		t.Errorf("legacy content encoding = %q, want NULL", entry.ContentEncoding.String)
+	}
+	// The migration must clear the pre-fix validators so the row is refetched
+	// once with identity instead of a 304 re-serving the decompressed copy.
+	if entry.ETag.Valid {
+		t.Errorf("legacy etag = %q, want cleared", entry.ETag.String)
+	}
+	if entry.FetchedAt.Valid {
+		t.Errorf("legacy fetched_at = %v, want cleared", entry.FetchedAt.Time)
 	}
 }
 

--- a/internal/database/queries.go
+++ b/internal/database/queries.go
@@ -938,7 +938,7 @@ func (db *DB) CountCachedPackages(ecosystem string) (int64, error) {
 func (db *DB) GetMetadataCache(ecosystem, name string) (*MetadataCacheEntry, error) {
 	var entry MetadataCacheEntry
 	query := db.Rebind(`
-		SELECT id, ecosystem, name, storage_path, etag, link, content_type,
+		SELECT id, ecosystem, name, storage_path, etag, link, content_type, content_encoding,
 		       content_digest, size, last_modified, fetched_at, created_at, updated_at
 		FROM metadata_cache WHERE ecosystem = ? AND name = ?
 	`)
@@ -958,14 +958,15 @@ func (db *DB) UpsertMetadataCache(entry *MetadataCacheEntry) error {
 
 	if db.dialect == DialectPostgres {
 		query = `
-			INSERT INTO metadata_cache (ecosystem, name, storage_path, etag, link, content_type,
+			INSERT INTO metadata_cache (ecosystem, name, storage_path, etag, link, content_type, content_encoding,
 			                            content_digest, size, last_modified, fetched_at, created_at, updated_at)
-			VALUES ($1, $2, $3, $4, $5, $6, $7, $8, $9, $10, $11, $12)
+			VALUES ($1, $2, $3, $4, $5, $6, $7, $8, $9, $10, $11, $12, $13)
 			ON CONFLICT(ecosystem, name) DO UPDATE SET
 				storage_path = EXCLUDED.storage_path,
 				etag = EXCLUDED.etag,
 				link = EXCLUDED.link,
 				content_type = EXCLUDED.content_type,
+				content_encoding = EXCLUDED.content_encoding,
 				content_digest = EXCLUDED.content_digest,
 				size = EXCLUDED.size,
 				last_modified = EXCLUDED.last_modified,
@@ -974,14 +975,15 @@ func (db *DB) UpsertMetadataCache(entry *MetadataCacheEntry) error {
 		`
 	} else {
 		query = `
-			INSERT INTO metadata_cache (ecosystem, name, storage_path, etag, link, content_type,
+			INSERT INTO metadata_cache (ecosystem, name, storage_path, etag, link, content_type, content_encoding,
 			                            content_digest, size, last_modified, fetched_at, created_at, updated_at)
-			VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
+			VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
 			ON CONFLICT(ecosystem, name) DO UPDATE SET
 				storage_path = excluded.storage_path,
 				etag = excluded.etag,
 				link = excluded.link,
 				content_type = excluded.content_type,
+				content_encoding = excluded.content_encoding,
 				content_digest = excluded.content_digest,
 				size = excluded.size,
 				last_modified = excluded.last_modified,
@@ -992,7 +994,7 @@ func (db *DB) UpsertMetadataCache(entry *MetadataCacheEntry) error {
 
 	_, err := db.Exec(query,
 		entry.Ecosystem, entry.Name, entry.StoragePath, entry.ETag, entry.Link,
-		entry.ContentType, entry.ContentDigest, entry.Size, entry.LastModified, entry.FetchedAt, now, now,
+		entry.ContentType, entry.ContentEncoding, entry.ContentDigest, entry.Size, entry.LastModified, entry.FetchedAt, now, now,
 	)
 	if err != nil {
 		return fmt.Errorf("upserting metadata cache: %w", err)

--- a/internal/database/schema.go
+++ b/internal/database/schema.go
@@ -103,6 +103,7 @@ CREATE TABLE IF NOT EXISTS metadata_cache (
 	etag TEXT,
 	link TEXT,
 	content_type TEXT,
+	content_encoding TEXT,
 	content_digest TEXT,
 	size INTEGER,
 	last_modified DATETIME,
@@ -205,6 +206,7 @@ CREATE TABLE IF NOT EXISTS metadata_cache (
 	etag TEXT,
 	link TEXT,
 	content_type TEXT,
+	content_encoding TEXT,
 	content_digest TEXT,
 	size BIGINT,
 	last_modified TIMESTAMP,
@@ -365,6 +367,7 @@ var migrations = []migration{
 	{"005_ensure_metadata_cache_table", migrateEnsureMetadataCacheTable},
 	{"006_add_metadata_content_digest", migrateAddMetadataContentDigest},
 	{"007_add_metadata_link", migrateAddMetadataLink},
+	{"008_add_metadata_content_encoding", migrateAddMetadataContentEncoding},
 }
 
 // isTableNotFound returns true if the error indicates a missing table.
@@ -615,6 +618,20 @@ func migrateAddMetadataLink(db *DB) error {
 	return nil
 }
 
+func migrateAddMetadataContentEncoding(db *DB) error {
+	hasColumn, err := db.HasColumn("metadata_cache", "content_encoding")
+	if err != nil {
+		return fmt.Errorf("checking metadata_cache content_encoding column: %w", err)
+	}
+	if hasColumn {
+		return nil
+	}
+	if _, err := db.Exec("ALTER TABLE metadata_cache ADD COLUMN content_encoding TEXT"); err != nil {
+		return fmt.Errorf("adding metadata_cache content_encoding column: %w", err)
+	}
+	return nil
+}
+
 // EnsureMetadataCacheTable creates the metadata_cache table if it doesn't exist.
 func (db *DB) EnsureMetadataCacheTable() error {
 	has, err := db.HasTable("metadata_cache")
@@ -636,6 +653,7 @@ func (db *DB) EnsureMetadataCacheTable() error {
 			etag TEXT,
 			link TEXT,
 			content_type TEXT,
+			content_encoding TEXT,
 				content_digest TEXT,
 				size BIGINT,
 				last_modified TIMESTAMP,
@@ -655,6 +673,7 @@ func (db *DB) EnsureMetadataCacheTable() error {
 			etag TEXT,
 			link TEXT,
 			content_type TEXT,
+			content_encoding TEXT,
 				content_digest TEXT,
 				size INTEGER,
 				last_modified DATETIME,

--- a/internal/database/schema.go
+++ b/internal/database/schema.go
@@ -629,6 +629,14 @@ func migrateAddMetadataContentEncoding(db *DB) error {
 	if _, err := db.Exec("ALTER TABLE metadata_cache ADD COLUMN content_encoding TEXT"); err != nil {
 		return fmt.Errorf("adding metadata_cache content_encoding column: %w", err)
 	}
+	// Rows cached before this column existed hold transport-decompressed bytes
+	// with no recorded encoding and the upstream ETag captured under Go's
+	// auto-added Accept-Encoding: gzip. Clearing the validators forces one fresh
+	// fetch per key so the encoding is recorded and verbatim bytes are restored,
+	// instead of an If-None-Match 304 re-serving the stale decompressed copy.
+	if _, err := db.Exec("UPDATE metadata_cache SET etag = NULL, fetched_at = NULL"); err != nil {
+		return fmt.Errorf("invalidating metadata_cache validators: %w", err)
+	}
 	return nil
 }
 

--- a/internal/database/types.go
+++ b/internal/database/types.go
@@ -158,19 +158,20 @@ type CachedArtifact struct {
 
 // MetadataCacheEntry represents a cached metadata blob for offline serving.
 type MetadataCacheEntry struct {
-	ID            int64          `db:"id" json:"id"`
-	Ecosystem     string         `db:"ecosystem" json:"ecosystem"`
-	Name          string         `db:"name" json:"name"`
-	StoragePath   string         `db:"storage_path" json:"storage_path"`
-	ETag          sql.NullString `db:"etag" json:"etag,omitempty"`
-	Link          sql.NullString `db:"link" json:"link,omitempty"`
-	ContentType   sql.NullString `db:"content_type" json:"content_type,omitempty"`
-	ContentDigest sql.NullString `db:"content_digest" json:"content_digest,omitempty"`
-	Size          sql.NullInt64  `db:"size" json:"size,omitempty"`
-	LastModified  sql.NullTime   `db:"last_modified" json:"last_modified,omitempty"`
-	FetchedAt     sql.NullTime   `db:"fetched_at" json:"fetched_at,omitempty"`
-	CreatedAt     time.Time      `db:"created_at" json:"created_at"`
-	UpdatedAt     time.Time      `db:"updated_at" json:"updated_at"`
+	ID              int64          `db:"id" json:"id"`
+	Ecosystem       string         `db:"ecosystem" json:"ecosystem"`
+	Name            string         `db:"name" json:"name"`
+	StoragePath     string         `db:"storage_path" json:"storage_path"`
+	ETag            sql.NullString `db:"etag" json:"etag,omitempty"`
+	Link            sql.NullString `db:"link" json:"link,omitempty"`
+	ContentType     sql.NullString `db:"content_type" json:"content_type,omitempty"`
+	ContentEncoding sql.NullString `db:"content_encoding" json:"content_encoding,omitempty"`
+	ContentDigest   sql.NullString `db:"content_digest" json:"content_digest,omitempty"`
+	Size            sql.NullInt64  `db:"size" json:"size,omitempty"`
+	LastModified    sql.NullTime   `db:"last_modified" json:"last_modified,omitempty"`
+	FetchedAt       sql.NullTime   `db:"fetched_at" json:"fetched_at,omitempty"`
+	CreatedAt       time.Time      `db:"created_at" json:"created_at"`
+	UpdatedAt       time.Time      `db:"updated_at" json:"updated_at"`
 }
 
 // Vulnerability represents a cached vulnerability record.

--- a/internal/handler/handler.go
+++ b/internal/handler/handler.go
@@ -575,6 +575,15 @@ func metadataStoragePath(ecosystem, cacheKey string) string {
 // cacheKey is typically the package name but can include subpath components.
 // Optional acceptHeaders specify the Accept header(s) to send; defaults to application/json.
 func (p *Proxy) FetchOrCacheMetadata(ctx context.Context, ecosystem, cacheKey, upstreamURL string, acceptHeaders ...string) ([]byte, string, error) {
+	return p.fetchOrCacheMetadata(ctx, ecosystem, cacheKey, upstreamURL, false, acceptHeaders...)
+}
+
+// fetchOrCacheMetadata implements FetchOrCacheMetadata. When verbatim is true
+// (the ProxyCached path, which serves upstream bytes through unchanged) the
+// upstream is fetched with Accept-Encoding: identity so signed and hash-pinned
+// index files are cached exactly as sent. Direct callers that parse or rewrite
+// the body pass verbatim=false and keep transparent transfer compression.
+func (p *Proxy) fetchOrCacheMetadata(ctx context.Context, ecosystem, cacheKey, upstreamURL string, verbatim bool, acceptHeaders ...string) ([]byte, string, error) {
 	if containsPathTraversal(cacheKey) {
 		return nil, "", fmt.Errorf("invalid cache key: %q", cacheKey)
 	}
@@ -614,10 +623,10 @@ func (p *Proxy) FetchOrCacheMetadata(ctx context.Context, ecosystem, cacheKey, u
 	}
 
 	// Try upstream
-	meta, err := p.fetchUpstreamMetadata(ctx, upstreamURL, entry, accept)
+	meta, err := p.fetchUpstreamMetadata(ctx, upstreamURL, entry, accept, verbatim)
 	if errors.Is(err, errStale304) {
 		// 304 but cached file is gone; retry without ETag
-		meta, err = p.fetchUpstreamMetadata(ctx, upstreamURL, nil, accept)
+		meta, err = p.fetchUpstreamMetadata(ctx, upstreamURL, nil, accept, verbatim)
 	}
 	if err == nil {
 		if p.CacheMetadata {
@@ -673,16 +682,18 @@ type upstreamMetadata struct {
 // It requests the identity encoding and never transparently decompresses, so the returned
 // bytes are exactly what the upstream sent; any Content-Encoding the upstream applied
 // anyway is reported alongside so callers can store and replay it.
-func (p *Proxy) fetchUpstreamMetadata(ctx context.Context, upstreamURL string, entry *database.MetadataCacheEntry, accept string) (*upstreamMetadata, error) {
+func (p *Proxy) fetchUpstreamMetadata(ctx context.Context, upstreamURL string, entry *database.MetadataCacheEntry, accept string, verbatim bool) (*upstreamMetadata, error) {
 	req, err := http.NewRequestWithContext(ctx, http.MethodGet, upstreamURL, nil)
 	if err != nil {
 		return nil, fmt.Errorf("creating request: %w", err)
 	}
 	req.Header.Set("Accept", accept)
-	// Setting Accept-Encoding explicitly disables Go's transparent gzip
-	// decompression (it only applies when the transport adds the header
-	// itself), so signed index files are cached byte-for-byte as sent.
-	req.Header.Set(headerAcceptEncoding, "identity")
+	if verbatim {
+		// Setting Accept-Encoding explicitly disables Go's transparent gzip
+		// decompression (it only applies when the transport adds the header
+		// itself), so signed index files are cached byte-for-byte as sent.
+		req.Header.Set(headerAcceptEncoding, "identity")
+	}
 	p.applyUpstreamAuth(req)
 
 	if entry != nil && entry.ETag.Valid {
@@ -817,7 +828,7 @@ func (p *Proxy) ProxyCached(w http.ResponseWriter, r *http.Request, upstreamURL,
 		return
 	}
 
-	body, contentType, err := p.FetchOrCacheMetadata(r.Context(), ecosystem, cacheKey, upstreamURL, acceptHeaders...)
+	body, contentType, err := p.fetchOrCacheMetadata(r.Context(), ecosystem, cacheKey, upstreamURL, true, acceptHeaders...)
 	if err != nil {
 		if errors.Is(err, ErrUpstreamNotFound) {
 			http.Error(w, "not found", http.StatusNotFound)
@@ -883,9 +894,13 @@ func (p *Proxy) proxyMetadataStream(w http.ResponseWriter, r *http.Request, upst
 		accept = acceptHeaders[0]
 	}
 	req.Header.Set("Accept", accept)
+	// ProxyCached serves bytes through verbatim, so request identity to keep
+	// Go from transparently decompressing (and stripping the Content-Encoding
+	// of) signed index files, regardless of what the client negotiated.
+	req.Header.Set(headerAcceptEncoding, "identity")
 	p.applyUpstreamAuth(req)
 
-	for _, header := range []string{headerAcceptEncoding, "If-Modified-Since", "If-None-Match"} {
+	for _, header := range []string{"If-Modified-Since", "If-None-Match"} {
 		if v := r.Header.Get(header); v != "" {
 			req.Header.Set(header, v)
 		}

--- a/internal/handler/handler.go
+++ b/internal/handler/handler.go
@@ -92,9 +92,10 @@ func packagePURLStrings(ecosystem, name, version string) (string, string, error)
 const contentTypeJSON = "application/json"
 
 const (
-	headerAcceptEncoding = "Accept-Encoding"
-	headerContentType    = "Content-Type"
-	headerContentLength  = "Content-Length"
+	headerAcceptEncoding  = "Accept-Encoding"
+	headerContentType     = "Content-Type"
+	headerContentLength   = "Content-Length"
+	headerContentEncoding = "Content-Encoding"
 )
 
 // defaultMetadataMaxSize is used when Proxy.MetadataMaxSize is unset.
@@ -613,16 +614,16 @@ func (p *Proxy) FetchOrCacheMetadata(ctx context.Context, ecosystem, cacheKey, u
 	}
 
 	// Try upstream
-	body, contentType, etag, lastModified, err := p.fetchUpstreamMetadata(ctx, upstreamURL, entry, accept)
+	meta, err := p.fetchUpstreamMetadata(ctx, upstreamURL, entry, accept)
 	if errors.Is(err, errStale304) {
 		// 304 but cached file is gone; retry without ETag
-		body, contentType, etag, lastModified, err = p.fetchUpstreamMetadata(ctx, upstreamURL, nil, accept)
+		meta, err = p.fetchUpstreamMetadata(ctx, upstreamURL, nil, accept)
 	}
 	if err == nil {
 		if p.CacheMetadata {
-			p.cacheMetadataBlob(ctx, ecosystem, cacheKey, storagePath, body, contentType, etag, lastModified)
+			p.cacheMetadataBlob(ctx, ecosystem, cacheKey, storagePath, meta)
 		}
-		return body, contentType, nil
+		return meta.body, meta.contentType, nil
 	}
 
 	// Upstream failed -- fall back to cache if available
@@ -659,16 +660,29 @@ func (p *Proxy) recordMetadataCacheMiss(ecosystem string) {
 	}
 }
 
-// fetchUpstreamMetadata fetches metadata from upstream, using ETag for conditional revalidation.
-// Returns the body, content type, ETag, upstream Last-Modified time, and any error.
-func (p *Proxy) fetchUpstreamMetadata(ctx context.Context, upstreamURL string, entry *database.MetadataCacheEntry, accept string) ([]byte, string, string, time.Time, error) {
-	var zeroTime time.Time
+// upstreamMetadata holds a fetched metadata response in upstream byte form.
+type upstreamMetadata struct {
+	body            []byte
+	contentType     string
+	contentEncoding string
+	etag            string
+	lastModified    time.Time
+}
 
+// fetchUpstreamMetadata fetches metadata from upstream, using ETag for conditional revalidation.
+// It requests the identity encoding and never transparently decompresses, so the returned
+// bytes are exactly what the upstream sent; any Content-Encoding the upstream applied
+// anyway is reported alongside so callers can store and replay it.
+func (p *Proxy) fetchUpstreamMetadata(ctx context.Context, upstreamURL string, entry *database.MetadataCacheEntry, accept string) (*upstreamMetadata, error) {
 	req, err := http.NewRequestWithContext(ctx, http.MethodGet, upstreamURL, nil)
 	if err != nil {
-		return nil, "", "", zeroTime, fmt.Errorf("creating request: %w", err)
+		return nil, fmt.Errorf("creating request: %w", err)
 	}
 	req.Header.Set("Accept", accept)
+	// Setting Accept-Encoding explicitly disables Go's transparent gzip
+	// decompression (it only applies when the transport adds the header
+	// itself), so signed index files are cached byte-for-byte as sent.
+	req.Header.Set(headerAcceptEncoding, "identity")
 	p.applyUpstreamAuth(req)
 
 	if entry != nil && entry.ETag.Valid {
@@ -677,7 +691,7 @@ func (p *Proxy) fetchUpstreamMetadata(ctx context.Context, upstreamURL string, e
 
 	resp, err := p.HTTPClient.Do(req)
 	if err != nil {
-		return nil, "", "", zeroTime, fmt.Errorf("fetching metadata: %w", err)
+		return nil, fmt.Errorf("fetching metadata: %w", err)
 	}
 	defer func() { _ = resp.Body.Close() }()
 
@@ -685,80 +699,84 @@ func (p *Proxy) fetchUpstreamMetadata(ctx context.Context, upstreamURL string, e
 	if resp.StatusCode == http.StatusNotModified && entry != nil {
 		cached, readErr := p.Storage.Open(ctx, entry.StoragePath)
 		if readErr != nil {
-			return nil, "", "", zeroTime, errStale304
+			return nil, errStale304
 		}
 		defer func() { _ = cached.Close() }()
 		data, readErr := p.ReadMetadata(cached)
 		if readErr != nil {
-			return nil, "", "", zeroTime, errStale304
+			return nil, errStale304
 		}
-		ct := contentTypeJSON
+		meta := &upstreamMetadata{body: data, contentType: contentTypeJSON, etag: entry.ETag.String}
 		if entry.ContentType.Valid {
-			ct = entry.ContentType.String
+			meta.contentType = entry.ContentType.String
 		}
-		lm := zeroTime
+		if entry.ContentEncoding.Valid {
+			meta.contentEncoding = entry.ContentEncoding.String
+		}
 		if entry.LastModified.Valid {
-			lm = entry.LastModified.Time
+			meta.lastModified = entry.LastModified.Time
 		}
-		return data, ct, entry.ETag.String, lm, nil
+		return meta, nil
 	}
 
 	if resp.StatusCode == http.StatusNotFound {
-		return nil, "", "", zeroTime, ErrUpstreamNotFound
+		return nil, ErrUpstreamNotFound
 	}
 	if resp.StatusCode != http.StatusOK {
-		return nil, "", "", zeroTime, fmt.Errorf("upstream returned %d", resp.StatusCode)
+		return nil, fmt.Errorf("upstream returned %d", resp.StatusCode)
 	}
 
 	body, err := p.ReadMetadata(resp.Body)
 	if err != nil {
-		return nil, "", "", zeroTime, fmt.Errorf("reading response: %w", err)
+		return nil, fmt.Errorf("reading response: %w", err)
 	}
 
-	contentType := resp.Header.Get(headerContentType)
-	if contentType == "" {
-		contentType = contentTypeJSON
+	meta := &upstreamMetadata{
+		body:            body,
+		contentType:     resp.Header.Get(headerContentType),
+		contentEncoding: resp.Header.Get(headerContentEncoding),
+		etag:            resp.Header.Get("ETag"),
 	}
-
-	etag := resp.Header.Get("ETag")
-
-	var lastModified time.Time
+	if meta.contentType == "" {
+		meta.contentType = contentTypeJSON
+	}
 	if lm := resp.Header.Get("Last-Modified"); lm != "" {
-		lastModified, _ = http.ParseTime(lm)
+		meta.lastModified, _ = http.ParseTime(lm)
 	}
-
-	return body, contentType, etag, lastModified, nil
+	return meta, nil
 }
 
 // cacheMetadataBlob stores metadata bytes in storage and updates the database.
-func (p *Proxy) cacheMetadataBlob(ctx context.Context, ecosystem, cacheKey, storagePath string, data []byte, contentType, etag string, lastModified time.Time) {
+func (p *Proxy) cacheMetadataBlob(ctx context.Context, ecosystem, cacheKey, storagePath string, meta *upstreamMetadata) {
 	if p.DB == nil || p.Storage == nil {
 		return
 	}
 
-	size, _, err := p.Storage.Store(ctx, storagePath, bytes.NewReader(data))
+	size, _, err := p.Storage.Store(ctx, storagePath, bytes.NewReader(meta.body))
 	if err != nil {
 		p.Logger.Warn("failed to cache metadata", "ecosystem", ecosystem, "key", cacheKey, "error", err)
 		return
 	}
 
 	_ = p.DB.UpsertMetadataCache(&database.MetadataCacheEntry{
-		Ecosystem:    ecosystem,
-		Name:         cacheKey,
-		StoragePath:  storagePath,
-		ETag:         sql.NullString{String: etag, Valid: etag != ""},
-		ContentType:  sql.NullString{String: contentType, Valid: contentType != ""},
-		Size:         sql.NullInt64{Int64: size, Valid: true},
-		LastModified: sql.NullTime{Time: lastModified, Valid: !lastModified.IsZero()},
-		FetchedAt:    sql.NullTime{Time: time.Now(), Valid: true},
+		Ecosystem:       ecosystem,
+		Name:            cacheKey,
+		StoragePath:     storagePath,
+		ETag:            sql.NullString{String: meta.etag, Valid: meta.etag != ""},
+		ContentType:     sql.NullString{String: meta.contentType, Valid: meta.contentType != ""},
+		ContentEncoding: sql.NullString{String: meta.contentEncoding, Valid: meta.contentEncoding != ""},
+		Size:            sql.NullInt64{Int64: size, Valid: true},
+		LastModified:    sql.NullTime{Time: meta.lastModified, Valid: !meta.lastModified.IsZero()},
+		FetchedAt:       sql.NullTime{Time: time.Now(), Valid: true},
 	})
 }
 
 // cachedMeta holds cache validators and freshness state from a metadata cache entry.
 type cachedMeta struct {
-	etag         string
-	lastModified time.Time
-	stale        bool
+	etag            string
+	lastModified    time.Time
+	contentEncoding string
+	stale           bool
 }
 
 // lookupCachedMeta retrieves cache validators for a metadata entry.
@@ -776,6 +794,9 @@ func (p *Proxy) lookupCachedMeta(ecosystem, cacheKey string) cachedMeta {
 	}
 	if entry.LastModified.Valid {
 		cm.lastModified = entry.LastModified.Time
+	}
+	if entry.ContentEncoding.Valid {
+		cm.contentEncoding = entry.ContentEncoding.String
 	}
 	// If FetchedAt is older than TTL, upstream must have failed and
 	// we served from stale cache (successful fetches update FetchedAt).
@@ -832,6 +853,9 @@ func (p *Proxy) writeMetadataCachedResponse(w http.ResponseWriter, r *http.Reque
 
 	w.Header().Set(headerContentType, contentType)
 	w.Header().Set(headerContentLength, strconv.Itoa(len(body)))
+	if cm.contentEncoding != "" {
+		w.Header().Set(headerContentEncoding, cm.contentEncoding)
+	}
 	if cm.etag != "" {
 		w.Header().Set("ETag", cm.etag)
 	}
@@ -874,7 +898,7 @@ func (p *Proxy) proxyMetadataStream(w http.ResponseWriter, r *http.Request, upst
 	}
 	defer func() { _ = resp.Body.Close() }()
 
-	for _, header := range []string{headerContentType, headerContentLength, "Last-Modified", "ETag"} {
+	for _, header := range []string{headerContentType, headerContentLength, headerContentEncoding, "Last-Modified", "ETag"} {
 		if v := resp.Header.Get(header); v != "" {
 			w.Header().Set(header, v)
 		}

--- a/internal/handler/metadata_encoding_test.go
+++ b/internal/handler/metadata_encoding_test.go
@@ -1,0 +1,151 @@
+package handler
+
+import (
+	"bytes"
+	"compress/gzip"
+	"net/http"
+	"net/http/httptest"
+	"sync/atomic"
+	"testing"
+	"time"
+)
+
+// gzipPayload returns a gzip-compressed copy of data, simulating an origin
+// that stores pre-compressed index files.
+func gzipPayload(t *testing.T, data []byte) []byte {
+	t.Helper()
+	var buf bytes.Buffer
+	zw := gzip.NewWriter(&buf)
+	if _, err := zw.Write(data); err != nil {
+		t.Fatalf("compressing payload: %v", err)
+	}
+	if err := zw.Close(); err != nil {
+		t.Fatalf("closing gzip writer: %v", err)
+	}
+	return buf.Bytes()
+}
+
+// TestProxyCached_PreservesContentEncodedBytes covers issue #300: an upstream
+// that serves a signed index with Content-Encoding: gzip must have its bytes
+// cached and re-served verbatim, with the encoding header replayed, instead of
+// being transparently decompressed by the HTTP client.
+func TestProxyCached_PreservesContentEncodedBytes(t *testing.T) {
+	raw := gzipPayload(t, []byte("signed index payload"))
+
+	var available atomic.Bool
+	available.Store(true)
+	var sawAcceptEncoding atomic.Value
+	var upstreamRequests atomic.Int32
+	upstream := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if !available.Load() {
+			http.Error(w, "unavailable", http.StatusServiceUnavailable)
+			return
+		}
+		upstreamRequests.Add(1)
+		sawAcceptEncoding.Store(r.Header.Get(headerAcceptEncoding))
+		w.Header().Set(headerContentType, "application/octet-stream")
+		w.Header().Set(headerContentEncoding, "gzip")
+		_, _ = w.Write(raw)
+	}))
+	defer upstream.Close()
+
+	proxy, _, _, _ := setupTestProxy(t)
+	proxy.CacheMetadata = true
+	proxy.MetadataTTL = time.Hour
+	proxy.HTTPClient = upstream.Client()
+
+	serve := func() *httptest.ResponseRecorder {
+		w := httptest.NewRecorder()
+		r := httptest.NewRequest(http.MethodGet, "/index", nil)
+		proxy.ProxyCached(w, r, upstream.URL+"/index", "apk", "index-key", "*/*")
+		return w
+	}
+
+	first := serve()
+	if first.Code != http.StatusOK {
+		t.Fatalf("first response status = %d, want 200: %s", first.Code, first.Body.String())
+	}
+	if got, _ := sawAcceptEncoding.Load().(string); got != "identity" {
+		t.Errorf("upstream saw Accept-Encoding %q, want %q", got, "identity")
+	}
+	if !bytes.Equal(first.Body.Bytes(), raw) {
+		t.Errorf("first response altered the upstream bytes: got %d bytes, want %d", first.Body.Len(), len(raw))
+	}
+	if got := first.Header().Get(headerContentEncoding); got != "gzip" {
+		t.Errorf("first response Content-Encoding = %q, want %q", got, "gzip")
+	}
+
+	// Within the TTL and with the upstream down, the cached copy must be
+	// served with the same bytes and encoding.
+	available.Store(false)
+	second := serve()
+	if second.Code != http.StatusOK {
+		t.Fatalf("cached response status = %d, want 200: %s", second.Code, second.Body.String())
+	}
+	if !bytes.Equal(second.Body.Bytes(), raw) {
+		t.Errorf("cached response altered the stored bytes")
+	}
+	if got := second.Header().Get(headerContentEncoding); got != "gzip" {
+		t.Errorf("cached response Content-Encoding = %q, want %q", got, "gzip")
+	}
+	if got := upstreamRequests.Load(); got != 1 {
+		t.Errorf("upstream requests = %d, want 1", got)
+	}
+}
+
+// TestProxyCached_NoEncodingHeaderForIdentityResponses pins that ordinary
+// responses do not grow a spurious Content-Encoding header.
+func TestProxyCached_NoEncodingHeaderForIdentityResponses(t *testing.T) {
+	upstream := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		w.Header().Set(headerContentType, contentTypeJSON)
+		_, _ = w.Write([]byte(`{"ok":true}`))
+	}))
+	defer upstream.Close()
+
+	proxy, _, _, _ := setupTestProxy(t)
+	proxy.CacheMetadata = true
+	proxy.MetadataTTL = time.Hour
+	proxy.HTTPClient = upstream.Client()
+
+	w := httptest.NewRecorder()
+	r := httptest.NewRequest(http.MethodGet, "/meta", nil)
+	proxy.ProxyCached(w, r, upstream.URL+"/meta", "npm", "meta-key", contentTypeJSON)
+	if w.Code != http.StatusOK {
+		t.Fatalf("status = %d, want 200: %s", w.Code, w.Body.String())
+	}
+	if got := w.Header().Get(headerContentEncoding); got != "" {
+		t.Errorf("Content-Encoding = %q, want empty", got)
+	}
+}
+
+// TestProxyMetadataStream_ForwardsContentEncoding pins the uncached streaming
+// path: a Content-Encoding header from upstream must reach the client along
+// with the raw bytes.
+func TestProxyMetadataStream_ForwardsContentEncoding(t *testing.T) {
+	raw := gzipPayload(t, []byte("streamed index payload"))
+	upstream := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		w.Header().Set(headerContentType, "application/octet-stream")
+		w.Header().Set(headerContentEncoding, "gzip")
+		_, _ = w.Write(raw)
+	}))
+	defer upstream.Close()
+
+	proxy, _, _, _ := setupTestProxy(t)
+	proxy.CacheMetadata = false
+	proxy.HTTPClient = upstream.Client()
+
+	w := httptest.NewRecorder()
+	r := httptest.NewRequest(http.MethodGet, "/index", nil)
+	r.Header.Set(headerAcceptEncoding, "gzip")
+	proxy.ProxyCached(w, r, upstream.URL+"/index", "apk", "stream-key", "*/*")
+
+	if w.Code != http.StatusOK {
+		t.Fatalf("status = %d, want 200: %s", w.Code, w.Body.String())
+	}
+	if !bytes.Equal(w.Body.Bytes(), raw) {
+		t.Errorf("streamed response altered the upstream bytes")
+	}
+	if got := w.Header().Get(headerContentEncoding); got != "gzip" {
+		t.Errorf("Content-Encoding = %q, want %q", got, "gzip")
+	}
+}

--- a/internal/handler/metadata_encoding_test.go
+++ b/internal/handler/metadata_encoding_test.go
@@ -5,6 +5,7 @@ import (
 	"compress/gzip"
 	"net/http"
 	"net/http/httptest"
+	"strings"
 	"sync/atomic"
 	"testing"
 	"time"
@@ -118,12 +119,16 @@ func TestProxyCached_NoEncodingHeaderForIdentityResponses(t *testing.T) {
 	}
 }
 
-// TestProxyMetadataStream_ForwardsContentEncoding pins the uncached streaming
-// path: a Content-Encoding header from upstream must reach the client along
-// with the raw bytes.
-func TestProxyMetadataStream_ForwardsContentEncoding(t *testing.T) {
+// TestProxyMetadataStream_PreservesSignedBytesWithoutClientEncoding pins the
+// uncached streaming path (the default, since cache_metadata is off) for the
+// realistic client that sends no Accept-Encoding: the proxy must request
+// identity upstream so Go does not transparently decompress a signed index,
+// and the raw bytes plus the Content-Encoding header must reach the client.
+func TestProxyMetadataStream_PreservesSignedBytesWithoutClientEncoding(t *testing.T) {
 	raw := gzipPayload(t, []byte("streamed index payload"))
-	upstream := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+	var sawAcceptEncoding string
+	upstream := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		sawAcceptEncoding = r.Header.Get(headerAcceptEncoding)
 		w.Header().Set(headerContentType, "application/octet-stream")
 		w.Header().Set(headerContentEncoding, "gzip")
 		_, _ = w.Write(raw)
@@ -135,17 +140,61 @@ func TestProxyMetadataStream_ForwardsContentEncoding(t *testing.T) {
 	proxy.HTTPClient = upstream.Client()
 
 	w := httptest.NewRecorder()
+	// No Accept-Encoding on the client request -- the apk/apt/dnf case.
 	r := httptest.NewRequest(http.MethodGet, "/index", nil)
-	r.Header.Set(headerAcceptEncoding, "gzip")
 	proxy.ProxyCached(w, r, upstream.URL+"/index", "apk", "stream-key", "*/*")
 
 	if w.Code != http.StatusOK {
 		t.Fatalf("status = %d, want 200: %s", w.Code, w.Body.String())
 	}
+	if sawAcceptEncoding != "identity" {
+		t.Errorf("upstream saw Accept-Encoding %q, want %q", sawAcceptEncoding, "identity")
+	}
 	if !bytes.Equal(w.Body.Bytes(), raw) {
-		t.Errorf("streamed response altered the upstream bytes")
+		t.Errorf("streamed response altered the upstream bytes: got %d bytes, want %d", w.Body.Len(), len(raw))
 	}
 	if got := w.Header().Get(headerContentEncoding); got != "gzip" {
 		t.Errorf("Content-Encoding = %q, want %q", got, "gzip")
+	}
+}
+
+// TestFetchOrCacheMetadata_DirectCallersKeepTransparentCompression pins that
+// the parsing/rewriting ecosystems (npm, pypi, cargo, helm, ...) that call
+// FetchOrCacheMetadata directly are NOT forced to identity: they keep Go's
+// transparent transfer compression and receive decoded bytes, so a gzip-only
+// upstream does not regress them (no wire-size blowup, no parse failures).
+func TestFetchOrCacheMetadata_DirectCallersKeepTransparentCompression(t *testing.T) {
+	plaintext := []byte(`{"name":"demo","versions":{"1.0.0":{}}}`)
+	var sawAcceptEncoding string
+	upstream := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		sawAcceptEncoding = r.Header.Get(headerAcceptEncoding)
+		// Serve gzip only when the client accepts it, like a real CDN.
+		if strings.Contains(r.Header.Get(headerAcceptEncoding), "gzip") {
+			w.Header().Set(headerContentType, contentTypeJSON)
+			w.Header().Set(headerContentEncoding, "gzip")
+			_, _ = w.Write(gzipPayload(t, plaintext))
+			return
+		}
+		w.Header().Set(headerContentType, contentTypeJSON)
+		_, _ = w.Write(plaintext)
+	}))
+	defer upstream.Close()
+
+	proxy, _, _, _ := setupTestProxy(t)
+	proxy.CacheMetadata = true
+	proxy.MetadataTTL = time.Hour
+	proxy.HTTPClient = upstream.Client()
+
+	body, _, err := proxy.FetchOrCacheMetadata(t.Context(), "npm", "demo", upstream.URL+"/demo", contentTypeJSON)
+	if err != nil {
+		t.Fatalf("FetchOrCacheMetadata() error = %v", err)
+	}
+	// The default transport adds Accept-Encoding: gzip and transparently
+	// decompresses, so the caller sees decoded JSON regardless of the wire form.
+	if sawAcceptEncoding == "identity" {
+		t.Errorf("direct caller forced identity; want transparent compression")
+	}
+	if !bytes.Equal(body, plaintext) {
+		t.Errorf("direct caller got %q, want decoded %q", body, plaintext)
 	}
 }


### PR DESCRIPTION
## Summary

`fetchUpstreamMetadata` in `internal/handler/handler.go` relied on Go's default transport, which sends `Accept-Encoding: gzip` and transparently decompresses any response carrying `Content-Encoding: gzip`. The metadata cache stored the decoded body and a content type, but not the content encoding.

For ecosystems that cache signed or hash-pinned index files through this path (`debian` `Release`/`Packages.gz`, `rpm` `repomd.xml`, `helm` `index.yaml`, `conda` `repodata.json`, `apk` `APKINDEX.tar.gz`/`Packages.adb`), an upstream that serves the file with `Content-Encoding: gzip` caused the proxy to cache and re-serve different bytes from what the upstream signed, breaking client-side verification.

## Changes

- Request `Accept-Encoding: identity` on the shared metadata fetch so Go no longer auto-decompresses the response; the body is stored exactly as the upstream sent it.
- Persist the upstream `Content-Encoding` in a new `metadata_cache.content_encoding` column (migration `008`, SQLite + Postgres) and replay it on serve, for both fresh and offline (stale-cache) responses.
- Forward `Content-Encoding` on the uncached streaming path as well.
- Refactor `fetchUpstreamMetadata` to return an `upstreamMetadata` struct instead of five positional values.

## Tests

- `internal/handler/metadata_encoding_test.go`: byte-for-byte fidelity of a `Content-Encoding: gzip` index, header replay from cache while the upstream is down, no spurious encoding header on identity responses, and the uncached streaming path.
- `internal/database/metadata_cache_test.go`: the `008` migration preserves existing rows (new column NULL), and the column round-trips through upsert/get.
- Verified the fidelity test fails without the `identity` header, confirming the fix is load-bearing.

`go test ./internal/handler/ ./internal/database/ -race` passes; `go vet` and `gofmt` clean.

Fixes #300