### PR TITLE
Bump Dockerfile builder to golang:1.26.7-alpine

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM --platform=$BUILDPLATFORM golang:1.26.6-alpine AS builder
+FROM --platform=$BUILDPLATFORM golang:1.26.7-alpine AS builder
 
 WORKDIR /src
 


### PR DESCRIPTION
go.mod requires `go 1.26.7`; the 1.26.6 builder image with `GOTOOLCHAIN=local` refuses `go mod download`, which broke the v0.8.0 Docker publish.