### PR TITLE
Mark Helm as completed in registry table

### DIFF
--- a/README.md
+++ b/README.md
@@ -68,7 +68,7 @@ The proxy never uploads artifact bytes to a scanner. Each scanner is notified wi
 | Arch | Arch Linux | | ✗ |
 | Chef | Chef | | ✗ |
 | Generic | Any | | ✓ |
-| Helm | Kubernetes | | ✗ |
+| Helm | Kubernetes | | ✓ |
 | Vagrant | Vagrant | | ✗ |
 
 Cooldown requires publish timestamps in metadata. Registries without a "Yes" in the cooldown column either don't expose timestamps or haven't been wired up yet.


### PR DESCRIPTION
The Helm handler landed in #268 and is mounted at `/helm` in `server.go`.