### PR TITLE
docker host is trimmed too much in the docs

### DIFF
--- a/internal/server/dashboard.go
+++ b/internal/server/dashboard.go
@@ -207,6 +207,7 @@ func getRegistryConfigs(baseURL string) []RegistryConfig {
 	if strings.HasPrefix(strings.ToLower(baseURL), "http://") {
 		swiftInsecureFlag = "--allow-insecure-http "
 	}
+	dockerHost := strings.TrimPrefix(strings.TrimPrefix(baseURL, "https://"), "http://")
 
 	return []RegistryConfig{
 		{
@@ -433,7 +434,7 @@ using Pkg; Pkg.update()</code></pre>`),
 sudo systemctl restart docker
 
 # Or pull directly
-docker pull ` + baseURL[8:] + `/library/nginx:latest</code></pre>`),
+docker pull ` + dockerHost + `/library/nginx:latest</code></pre>`),
 		},
 		{
 			ID:       "deb",

--- a/internal/server/templates_test.go
+++ b/internal/server/templates_test.go
@@ -519,6 +519,21 @@ func TestEcosystemBadgeLabel(t *testing.T) {
 	}
 }
 
+func TestOCIRegistryInstructionsDockerPull(t *testing.T) {
+	registries := getRegistryConfigs("http://package-proxy:8080")
+	for _, registry := range registries {
+		if registry.ID != "oci" {
+			continue
+		}
+		want := "docker pull package-proxy:8080/library/nginx:latest"
+		if !strings.Contains(string(registry.Instructions), want) {
+			t.Errorf("OCI instructions = %q, want substring %q", registry.Instructions, want)
+		}
+		return
+	}
+	t.Fatal("OCI registry instructions not found")
+}
+
 func TestSwiftRegistryInstructionsAllowLocalHTTP(t *testing.T) {
 	registries := getRegistryConfigs("http://localhost:8080")
 	for _, registry := range registries {


### PR DESCRIPTION
When browsing the installation docs in the proxy UI, I noticed the Docker/OCI instructions had a weird trimming issue - "docker pull ackage-proxy..."

<img width="578" height="337" alt="image" src="https://github.com/user-attachments/assets/a342ecea-8b14-4963-a2e9-dc9520407a72" />

Turns out there was a rather rudimentary string slice that assumed https - but when hosted on http, this trims too much.

(I originally planned to parse via net/url, but that seems like overkill since there are only two schemes to consider here.)

(Also the test is a bit meh - feel free to drop it.)